### PR TITLE
hide form back button if javascript disabled

### DIFF
--- a/app/views/registrations/_form.html.erb
+++ b/app/views/registrations/_form.html.erb
@@ -1,5 +1,7 @@
-<%= link_to 'Back', 'javascript:history.go(-1);', class: "govuk-back-link" %>
+<%= link_to 'Back', 'javascript:history.go(-1);', class: "govuk-back-link hidden", id: "backlink" %>
 <%= form_for @registration, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: registrations_path do |f| %>
   <%= f.govuk_error_summary %>
   <%= render @registration, f: f %>
 <% end %> 
+
+<%= javascript_pack_tag 'back_link'%>

--- a/app/webpacker/packs/back_link.js
+++ b/app/webpacker/packs/back_link.js
@@ -1,0 +1,4 @@
+document.addEventListener("turbolinks:load", function () {
+  var x = document.getElementById("backlink");
+  x.style.display = "inline-block";
+});

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -14,3 +14,7 @@ $govuk-image-url-function: frontend-image-url;
 .auto-width {
   width: auto;
 }
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
### JIRA ticket number
https://dfedigital.atlassian.net/browse/GITPB-122
### Context

### Changes proposed in this pull request
Hide the back button if javascript is disabled in browser
### Guidance to review
Disable javascript in browser, complete form, on next screen 'back' button hidden. Enable javascript ,complete form, on next screen button is visible
