### PR TITLE
Output of coverage is full directory, we cannout use that

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,12 @@ jobs:
           name: Code_Coverage
           path: ${{ github.workspace }}/coverage/*
 
+      - name:  Keep Unit Tests Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: unit_tests 
+          path: ${{ github.workspace }}/out/*
+
       - name: Lint Ruby
         run: |-
           docker run -t --rm -e RAILS_ENV=test $DOCKER_IMAGE bundle exec rubocop app config db lib spec Gemfile --format clang || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,9 @@ jobs:
 
       - name: Run Specs
         run: |-
-          docker run -t --rm -v ${PWD}/out:/app/out -v ${PWD}/coverage:/app/coverage -e RAILS_ENV=test $DOCKER_IMAGE bundle exec rspec
+          docker run -t --rm -v ${PWD}/out:/app/out -v ${PWD}/coverage:/app/coverage -e RAILS_ENV=test $DOCKER_IMAGE /bin/sh -c 'cd /app; bundle exec rspec'
+          sed -e "s/app\/app/app/g" < coverage/.resultset.json > tmp.file
+          mv tmp.file coverage/.resultset.json
 
       - name: Lint Ruby
         run: |-
@@ -76,7 +78,7 @@ jobs:
 
       - name: Run sonarqube
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: sonar-scanner
            -Dsonar.login=${{ secrets.SONAR_TOKEN }}
            -Dsonar.organization=dfe-digital
@@ -96,7 +98,7 @@ jobs:
              STATE:  ${{job.status}}
              ENVIRON: "Development"
         env:
-            SENTRY_DSN: ${{secrets.DEV_OPS_SENTRY_DSN}}
+             SENTRY_DSN: ${{secrets.DEV_OPS_SENTRY_DSN}}
 
   deploy:
     name: 'Deploy to Development'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run Specs
         run: |-
           docker run -t --rm -v ${PWD}/out:/app/out -v ${PWD}/coverage:/app/coverage -e RAILS_ENV=test $DOCKER_IMAGE /bin/sh -c 'cd /app; bundle exec rspec'
-          sed -e "s/\/app\/app/.\/app/g" < coverage/.resultset.json > tmp.file
+          sed -e "s?/app/app?${PWD}/app?" < coverage/.resultset.json > tmp.file
           sudo mv tmp.file coverage/.resultset.json
 
       - name: Lint Ruby

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,12 @@ jobs:
           sed -e "s?/app/app?${PWD}/app?" < coverage/.resultset.json > tmp.file
           sudo mv tmp.file coverage/.resultset.json
 
+      - name:  Keep Code Coverage Report
+        uses: actions/upload-artifact@v2
+        with:
+          name: Code_Coverage
+          path: ${PWD}/coverage 
+
       - name: Lint Ruby
         run: |-
           docker run -t --rm -e RAILS_ENV=test $DOCKER_IMAGE bundle exec rubocop app config db lib spec Gemfile --format clang || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         run: |-
           docker run -t --rm -v ${PWD}/out:/app/out -v ${PWD}/coverage:/app/coverage -e RAILS_ENV=test $DOCKER_IMAGE /bin/sh -c 'cd /app; bundle exec rspec'
           sed -e "s/app\/app/app/g" < coverage/.resultset.json > tmp.file
-          mv tmp.file coverage/.resultset.json
+          sudo mv tmp.file coverage/.resultset.json
 
       - name: Lint Ruby
         run: |-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Code_Coverage
-          path: ${PWD}/coverage 
+          path: ${{ github.workspace }}/coverage/*
 
       - name: Lint Ruby
         run: |-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run Specs
         run: |-
           docker run -t --rm -v ${PWD}/out:/app/out -v ${PWD}/coverage:/app/coverage -e RAILS_ENV=test $DOCKER_IMAGE /bin/sh -c 'cd /app; bundle exec rspec'
-          sed -e "s/app\/app/app/g" < coverage/.resultset.json > tmp.file
+          sed -e "s/\/app\/app/${PWD}\/app/g" < coverage/.resultset.json > tmp.file
           sudo mv tmp.file coverage/.resultset.json
 
       - name: Lint Ruby

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run Specs
         run: |-
           docker run -t --rm -v ${PWD}/out:/app/out -v ${PWD}/coverage:/app/coverage -e RAILS_ENV=test $DOCKER_IMAGE /bin/sh -c 'cd /app; bundle exec rspec'
-          sed -e "s/\/app\/app/${PWD}\/app/g" < coverage/.resultset.json > tmp.file
+          sed -e "s/\/app\/app/.\/app/g" < coverage/.resultset.json > tmp.file
           sudo mv tmp.file coverage/.resultset.json
 
       - name: Lint Ruby


### PR DESCRIPTION
Trying to resolve a problem where the code coverage report outputs the data as /app/app/models/*** where as the sonarcloud ingestion is expecting /app/models/****
