### PR TITLE
only build run accessibility tests on  master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,6 @@ jobs:
   accessibility:
     name: Accessibility Test
     runs-on: ubuntu-latest
-    if: always()
     if: github.ref == 'refs/heads/master'
     needs: deploy
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,6 +209,7 @@ jobs:
     name: Accessibility Test
     runs-on: ubuntu-latest
     if: always()
+    if: github.ref == 'refs/heads/master'
     needs: deploy
     steps:
       - name: Checkout


### PR DESCRIPTION
Only Run the Accessibility Tests on a Master Push
To scan we need the website running and that only happens after a push to master

