### PR TITLE
Specify Version 0.12.28

### DIFF
--- a/terraform/paas/versions.tf
+++ b/terraform/paas/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.28"
 }


### PR DESCRIPTION
Github must be rolling out 0.12.29 as I have found it had upgraded one of the state files, but it mainly uses 0.12.28 and that causes problems if it is upgraded.  
Been more specific with the version to prevent this