### PR TITLE
Update vcap configuration

### DIFF
--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -2,16 +2,5 @@
 require File.expand_path("production.rb", __dir__)
 
 Rails.application.configure do
-  # Override any production defaults here
-  # Use a different cache store in preprod.
-  redis_url = JSON.parse(ENV["VCAP_SERVICES"])["redis"][0]["credentials"]["uri"]
-  config.cache_store = :redis_cache_store, {
-    url: redis_url,
-    reconnect_attempts: 1,
-    error_handler: ->(method:, returning:, exception:) {
-    # report errors
-    },
-  }
-
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,5 +101,7 @@ Rails.application.configure do
 
   config.exceptions_app = routes
 
+  config.cache_store = :redis_cache_store
+
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
 end

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -2,17 +2,5 @@
 require File.expand_path("production.rb", __dir__)
 
 Rails.application.configure do
-  # Override any production defaults here
-
-  # Use a different cache store in rolling.
-  redis_url = JSON.parse(ENV["VCAP_SERVICES"])["redis"][0]["credentials"]["uri"]
-  config.cache_store = :redis_cache_store, {
-    url: redis_url,
-    reconnect_attempts: 1,
-    error_handler: ->(method:, returning:, exception:) {
-    # report errors
-    },
-  }
-
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
 end

--- a/config/initializers/01_vcap_services.rb
+++ b/config/initializers/01_vcap_services.rb
@@ -1,0 +1,3 @@
+if ENV["VCAP_SERVICES"].present?
+  Rails.application.config.x.vcap_services = JSON.parse(ENV["VCAP_SERVICES"])
+end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,10 @@
+if ENV["REDIS_URL"].blank? && Rails.application.config.x.vcap_services.present?
+  redis_url = Rails.application.config.x.vcap_services.dig \
+    "redis", 0, "credentials", "uri"
+
+  ENV["REDIS_URL"] = redis_url if redis_url.present?
+end
+
+if ENV["REDIS_URL"].present? && Redis.current.ping != "PONG"
+  raise "Cannot connect to Redis"
+end


### PR DESCRIPTION
### Context

The current preprod and rolling environments assume the presence of the VCAP_SERVICES env var - and the production environment does not use the VCAP_SERVICES env var to configure redis.

This prevents testing preprod and rolling environments locally and will also require further configuration of the production environment when it is deployed onto PaaS.

### Changes proposed in this pull request

1. Always parse VCAP_SERVICES configuration into the `Rails.application.config` hash if it is set
2. If `REDIS_URL` is not set, and a redis config is present in the VCAP_SERVICES, use that to configure Redis
3. Check for Redis connectivity at boot and fail if not present.

### Guidance to review

This is set to deploy straight through to the rolling environment at present, as if it was on `master`. If that environment is still working than these changes are configured up correctly.

### Merge notes

Last commit is for testing purposes and needs to be dropped before merge to `master`.
