### PR TITLE
Fix showing the GovUK error pages when hitting exceptions and/or missing pages

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ Rails.application.routes.draw do
   get "/sitemap", to: "sitemaps#index"
   get "/healthcheck.json", to: "healthchecks#show", as: :healthcheck
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
-  get "/:page", to: "pages#show"
 
   get "/404", to: "errors#not_found", via: :all
   get "/422", to: "errors#unprocessable_entity", via: :all
@@ -11,4 +10,7 @@ Rails.application.routes.draw do
 
   get "/registrations/*step_name", to: "registrations#new", as: :new_registration
   post "/registrations/*step_name", to: "registrations#create", as: :registrations
+
+  # This route should remain at the bottom to avoid overriding the above routes
+  get "/:page", to: "pages#show"
 end


### PR DESCRIPTION
### Context

We should show clear and appropriately styled error pages when the user encounters a 500 or 404 scenario. Currently instead they are seeing a plain white fallback screen when visiting an unknown page (eg https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/missing)

### Changes proposed in this pull request

1. Move the 'catch all' route for the pages controller below other routes to give others, including the error screens, higher priority.

### Guidance to review

1. Boot to production locally, and visit http://localhost:3000/missing - you should see a GovUK error page

