### PR TITLE
Issue verification code on matchback

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,7 +1,7 @@
 class RegistrationsController < ApplicationController
   def new
     step_name = params[:step_name]
-    @step = StepFactory.create!(step_name)
+    @step = StepFactory.create!(step_name, store)
   rescue StepFactory::NameNotFoundError => e
     # needs to redirect to root or last valid step
     redirect_to :root, alert: "Error: #{e.message}"
@@ -9,11 +9,11 @@ class RegistrationsController < ApplicationController
 
   def create
     step_name = params[:step_name]
-    @step = StepFactory.create!(step_name)
+    @step = StepFactory.create!(step_name, store)
     @step.assign_attributes(registration_params)
 
     if @step.valid?
-      @step.save!(store)
+      @step.save!
       redirect_to new_registration_path(step_name: @step.next_step)
     else
       render :new

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,7 +1,7 @@
 class RegistrationsController < ApplicationController
   def new
     step_name = params[:step_name]
-    @registration = StepFactory.create!(step_name)
+    @step = StepFactory.create!(step_name)
   rescue StepFactory::NameNotFoundError => e
     # needs to redirect to root or last valid step
     redirect_to :root, alert: "Error: #{e.message}"
@@ -9,12 +9,12 @@ class RegistrationsController < ApplicationController
 
   def create
     step_name = params[:step_name]
-    @registration = StepFactory.create!(step_name)
-    @registration.assign_attributes(registration_params)
+    @step = StepFactory.create!(step_name)
+    @step.assign_attributes(registration_params)
 
-    if @registration.valid?
-      update_session_registration_hash
-      redirect_to new_registration_path(step_name: @registration.next_step)
+    if @step.valid?
+      @step.save!(store)
+      redirect_to new_registration_path(step_name: @step.next_step)
     else
       render :new
     end
@@ -22,14 +22,13 @@ class RegistrationsController < ApplicationController
 
 private
 
-  def update_session_registration_hash
+  def store
     session[:registration] ||= {}
-    session[:registration].merge!(@registration.attributes)
   end
 
   def entity_name
     # check for namespaces
-    @registration.step_name.gsub("/", "_").to_sym
+    @step.step_name.gsub("/", "_").to_sym
   end
 
   def registration_params

--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -10,4 +10,8 @@ class Base
   def to_partial_path
     "registrations/#{step_name}"
   end
+
+  def save!(store)
+    store.merge!(attributes)
+  end
 end

--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -3,6 +3,11 @@ class Base
   include ActiveModel::Attributes
   include ActiveModel::Validations::Callbacks
 
+  def initialize(store = {}, *args)
+    super(*args)
+    @store = store
+  end
+
   def step_name
     model_name.name.underscore
   end
@@ -11,7 +16,7 @@ class Base
     "registrations/#{step_name}"
   end
 
-  def save!(store)
-    store.merge!(attributes)
+  def save!
+    @store.merge!(attributes)
   end
 end

--- a/app/models/concerns/issue_verification_code.rb
+++ b/app/models/concerns/issue_verification_code.rb
@@ -1,0 +1,30 @@
+module IssueVerificationCode
+  extend ActiveSupport::Concern
+
+  def save!
+    @store.clear if previously_authenticated?
+
+    if valid?
+      begin
+        request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(request_attributes)
+        GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
+        @store["authenticate"] = true
+      rescue GetIntoTeachingApiClient::ApiError
+        # Existing candidate not found or CRM is currently unavailable.
+        @store["authenticate"] = false
+      end
+    end
+
+    super
+  end
+
+private
+
+  def previously_authenticated?
+    @store["authenticate"]
+  end
+
+  def request_attributes
+    attributes.slice("email", "first_name", "last_name").transform_keys { |k| k.camelize(:lower).to_sym }
+  end
+end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -1,4 +1,6 @@
 class Identity < Base
+  include IssueVerificationCode
+
   attribute :email, :string
   attribute :first_name, :string
   attribute :last_name, :string

--- a/app/services/step_factory.rb
+++ b/app/services/step_factory.rb
@@ -88,12 +88,12 @@ class StepFactory
   end
 
   class << self
-    def create(name)
+    def create(name, store)
       classified_name = name.camelize
       # need to redirect to root or last valid step.
       raise NameNotFoundError, classified_name unless STEP_NAMES.include?(classified_name)
 
-      Object.const_get(classified_name).new
+      Object.const_get(classified_name).new(store)
     end
     alias_method :create!, :create
   end

--- a/app/views/registrations/_form.html.erb
+++ b/app/views/registrations/_form.html.erb
@@ -1,5 +1,5 @@
 <%= link_to 'Back', 'javascript:history.go(-1);', class: "govuk-back-link hidden", id: "backlink" %>
-<%= form_for @registration, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: registrations_path do |f| %>
+<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: registrations_path do |f| %>
   <%= f.govuk_error_summary %>
-  <%= render @registration, f: f %>
+  <%= render @step, f: f %>
 <% end %>

--- a/app/views/registrations/_start_teacher_training.html.erb
+++ b/app/views/registrations/_start_teacher_training.html.erb
@@ -1,5 +1,5 @@
 <%= f.govuk_collection_select :initial_teacher_training_year_id,
-  @registration.year_range(3),
+  @step.year_range(3),
   :id,
   :value,
   label: { text: "When do you want to start your teacher training?", tag: "h1", size: "m" }

--- a/spec/models/base_spec.rb
+++ b/spec/models/base_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+module StepSection
+  class StubStep < Base
+    attribute :name, :string
+  end
+end
+
+RSpec.describe Base do
+  let(:step) { StepSection::StubStep.new }
+
+  describe "#step_name" do
+    subject { step.step_name }
+
+    it { is_expected.to eq("step_section/stub_step") }
+  end
+
+  describe "#to_partial_path" do
+    subject { step.to_partial_path }
+
+    it { is_expected.to eq("registrations/step_section/stub_step") }
+  end
+
+  describe "save" do
+    it "merges the store with the model attributes" do
+      store = { "name" => "Josh", "age" => 10 }
+      step.name = "James"
+      step.save!(store)
+      expect(store).to eq({ "name" => "James", "age" => 10 })
+    end
+  end
+end

--- a/spec/models/base_spec.rb
+++ b/spec/models/base_spec.rb
@@ -7,7 +7,8 @@ module StepSection
 end
 
 RSpec.describe Base do
-  let(:step) { StepSection::StubStep.new }
+  let(:store) { { "name" => "Josh", "age" => 10 } }
+  let(:step) { StepSection::StubStep.new(store) }
 
   describe "#step_name" do
     subject { step.step_name }
@@ -23,9 +24,8 @@ RSpec.describe Base do
 
   describe "save" do
     it "merges the store with the model attributes" do
-      store = { "name" => "Josh", "age" => 10 }
       step.name = "James"
-      step.save!(store)
+      step.save!
       expect(store).to eq({ "name" => "James", "age" => 10 })
     end
   end

--- a/spec/models/date_of_birth_spec.rb
+++ b/spec/models/date_of_birth_spec.rb
@@ -1,14 +1,15 @@
 require "rails_helper"
 
 RSpec.describe DateOfBirth do
-  let(:date_of_birth) { described_class.new({ "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => "2001" }) }
-  let(:invalid_month) { described_class.new({ "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "13", "date_of_birth(1i)" => "2001" }) }
-  let(:invalid_day) { described_class.new({ "date_of_birth(3i)" => "32", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => "2001" }) }
-  let(:invalid_year) { described_class.new({ "date_of_birth(3i)" => "32", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => Time.zone.now.year + 1 }) }
-  let(:impossible_date) { described_class.new({ "date_of_birth(3i)" => "31", "date_of_birth(2i)" => "2", "date_of_birth(1i)" => Time.zone.now.year }) }
-  let(:too_young) { described_class.new({ "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "2", "date_of_birth(1i)" => Time.zone.now.years_ago(15) }) }
-  let(:upper_limit) { described_class.new({ "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "2", "date_of_birth(1i)" => Time.zone.now.years_ago(71) }) }
-  let(:in_future) { described_class.new({ "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "2", "date_of_birth(1i)" => Time.zone.now.year - 1 }) }
+  let(:store) { {} }
+  let(:date_of_birth) { described_class.new(store, { "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => "2001" }) }
+  let(:invalid_month) { described_class.new(store, { "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "13", "date_of_birth(1i)" => "2001" }) }
+  let(:invalid_day) { described_class.new(store, { "date_of_birth(3i)" => "32", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => "2001" }) }
+  let(:invalid_year) { described_class.new(store, { "date_of_birth(3i)" => "32", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => Time.zone.now.year + 1 }) }
+  let(:impossible_date) { described_class.new(store, { "date_of_birth(3i)" => "31", "date_of_birth(2i)" => "2", "date_of_birth(1i)" => Time.zone.now.year }) }
+  let(:too_young) { described_class.new(store, { "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "2", "date_of_birth(1i)" => Time.zone.now.years_ago(15) }) }
+  let(:upper_limit) { described_class.new(store, { "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "2", "date_of_birth(1i)" => Time.zone.now.years_ago(71) }) }
+  let(:in_future) { described_class.new(store, { "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "2", "date_of_birth(1i)" => Time.zone.now.year - 1 }) }
 
   describe "validation" do
     context "with required attributes" do

--- a/spec/models/degree/date_of_birth_spec.rb
+++ b/spec/models/degree/date_of_birth_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Degree::DateOfBirth do
-  let(:date_of_birth) { described_class.new({ "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => "2001" }) }
+  let(:store) { {} }
+  let(:date_of_birth) { described_class.new(store, { "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => "2001" }) }
 
   describe "#next_step" do
     it "returns the next step" do

--- a/spec/models/equivalent/date_of_birth_spec.rb
+++ b/spec/models/equivalent/date_of_birth_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Equivalent::DateOfBirth do
-  let(:date_of_birth) { described_class.new({ "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => "2001" }) }
-  let(:invalid_month) { described_class.new({ "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "13", "date_of_birth(1i)" => "2001" }) }
-  let(:invalid_day) { described_class.new({ "date_of_birth(3i)" => "32", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => "2001" }) }
-  let(:invalid_year) { described_class.new({ "date_of_birth(3i)" => "32", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => Time.zone.now.year + 1 }) }
+  let(:store) { {} }
+  let(:date_of_birth) { described_class.new(store, { "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => "2001" }) }
+  let(:invalid_month) { described_class.new(store, { "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "13", "date_of_birth(1i)" => "2001" }) }
+  let(:invalid_day) { described_class.new(store, { "date_of_birth(3i)" => "32", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => "2001" }) }
+  let(:invalid_year) { described_class.new(store, { "date_of_birth(3i)" => "32", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => Time.zone.now.year + 1 }) }
 
   describe "validation" do
     context "with required attributes" do

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Identity do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+  it_behaves_like "an issue verification code wizard step"
+
   let(:identity) { build(:identity) }
   let(:no_name) { build(:identity, first_name: "") }
 

--- a/spec/models/studying/date_of_birth_spec.rb
+++ b/spec/models/studying/date_of_birth_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Studying::DateOfBirth do
-  let(:date_of_birth) { described_class.new({ "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => "2001" }) }
+  let(:store) { {} }
+  let(:date_of_birth) { described_class.new(store, { "date_of_birth(3i)" => "1", "date_of_birth(2i)" => "12", "date_of_birth(1i)" => "2001" }) }
 
   describe "#next_step" do
     it "returns the next step" do

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -23,6 +23,9 @@ RSpec.describe RegistrationsController, type: :request do
   describe "post /registrations/:step_name" do
     context "with a valid step name and payload" do
       it "returns a success response" do
+        # Emulate an unsuccessful matchback response from the API.
+        expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)
         params = { identity: { email: "email@address.com", first_name: "first", last_name: "last" } }
         post registrations_path(identity.step_name), params: params
         expect(response).to redirect_to(new_registration_path(identity.next_step))

--- a/spec/services/step_factory_spec.rb
+++ b/spec/services/step_factory_spec.rb
@@ -2,17 +2,18 @@ require "rails_helper"
 
 RSpec.describe StepFactory do
   subject { described_class }
+  let(:store) { {} }
 
   describe "#create" do
     context "with a valid constant" do
       it "instantiates the class" do
-        expect(subject.create("identity")).to be_an_instance_of(Identity)
+        expect(subject.create("identity", store)).to be_an_instance_of(Identity)
       end
     end
 
     context "with an invalid constant" do
       it "raises a custom NameNotFoundError" do
-        expect { subject.create("Invalid") }.to raise_error do |error|
+        expect { subject.create("Invalid", store) }.to raise_error do |error|
           expect(error).to be_a(StepFactory::NameNotFoundError)
           expect(error.message).to eq("Step name not found for Invalid")
         end

--- a/spec/support/shared_examples/step_support.rb
+++ b/spec/support/shared_examples/step_support.rb
@@ -1,0 +1,70 @@
+RSpec.shared_context "wizard store" do
+  let(:wizardstore) { { "name" => "Joe", "age" => 35 } }
+end
+
+RSpec.shared_context "wizard step" do
+  include_context "wizard store"
+  let(:attributes) { {} }
+  let(:instance) { described_class.new wizardstore, attributes }
+  subject { instance }
+end
+
+RSpec.shared_examples "a wizard step" do
+  it { is_expected.to respond_to :save! }
+end
+
+RSpec.shared_examples "an issue verification code wizard step" do
+  let(:wizardstore) { { "name" => "Joe", "age" => 35 } }
+
+  describe "#save!" do
+    before do
+      subject.email = "email@address.com"
+      subject.first_name = "first"
+      subject.last_name = "last"
+    end
+
+    let(:request) do
+      GetIntoTeachingApiClient::ExistingCandidateRequest.new(
+        email: subject.email,
+        firstName: subject.first_name,
+        lastName: subject.last_name,
+      )
+    end
+
+    context "when invalid" do
+      it "does not call the API" do
+        subject.email = nil
+        subject.save!
+        expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to_not receive(:create_candidate_access_token)
+      end
+    end
+
+    context "when an existing candidate" do
+      before do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token).with(request)
+      end
+
+      it "sends verification code and sets authenticate to true" do
+        subject.save!
+        expect(wizardstore["authenticate"]).to be_truthy
+      end
+
+      it "clears the store if the user previously authenticated" do
+        wizardstore["authenticate"] = true
+        wizardstore["other_user_data"] = "clear me!"
+        subject.save!
+        expect(wizardstore["other_user_data"]).to be_nil
+      end
+    end
+
+    context "when a new candidate or CRM is unavailable" do
+      it "will skip the authenticate step" do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request)
+          .and_raise(GetIntoTeachingApiClient::ApiError)
+        subject.save!
+        expect(wizardstore["authenticate"]).to be_falsy
+      end
+    end
+  end
+end


### PR DESCRIPTION
### JIRA ticket number

[GITPB-415](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?selectedIssue=GITPB-415)

### Context

When a candidate enters their first/last/email we want to check if we have a matching candidate in the system already. If we do, a verification code should be emailed to the candidate that they can then use to 'authenticate' and we can pre-fill the sign up form.

### Changes proposed in this pull request

- Move logic to save into the step model

This will enable us to perform other model-specific actions - such as requesting out to issue a verification code on the `Identity` step - on save.

Also renames `@registration` to `@step` for clarity.

- Move responsibility of updating store to the steps

Previously the `RegistrationsController` updated the store; this is now encapsulated into the `Step` model so that we can more easily structure the authentication/matchback logic (i.e. clear the store prior to pre-populating on successful matchback).

- Send verification code on matchback

If a candidate enters a first/last/email that matches an existing candidate in the CRM we want to email them a verification code that can be used in a subsequent step to retrieve their details and pre-fill the form.

### Guidance to review

The `IssueVerificationCode` concern is pretty much lifted/shifted from the get-into-teaching-app; the other minor changes aim to align this registration process with the app as well.

<img width="620" alt="Screenshot 2020-08-19 at 15 46 14" src="https://user-images.githubusercontent.com/29867726/90649934-23335e80-e233-11ea-8c4e-49e21370769c.png">
