### PR TITLE
Namespace all cache keys in Redis

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,7 +101,7 @@ Rails.application.configure do
 
   config.exceptions_app = routes
 
-  config.cache_store = :redis_cache_store
+  config.cache_store = :redis_cache_store, { namespace: "TTA" }
 
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
 end


### PR DESCRIPTION
### Context

We wish to share a single Redis instance between both apps, this means we need a way to isolate the keys

### Changes proposed in this pull request

1. Namespace all keys under the `TTA` namespace



