### PR TITLE
comment out validations

### DIFF
--- a/app/models/have_a_degree.rb
+++ b/app/models/have_a_degree.rb
@@ -15,8 +15,8 @@ class HaveADegree < Base
   DEGREE_TYPE = { degree: 222_750_000, equivalent: 222_750_005 }.freeze
 
   validates :degree_options, inclusion: { in: DEGREE_OPTIONS.map { |_k, v| v }, message: "Select an option from the list" }
-  validates :degree_status_id, inclusion: { in: DEGREE_STATUS_OPTIONS.map { |_k, v| v }, message: "Select an option from the list" }
-  validates :degree_type_id, types: { method: :get_qualification_degree_status }
+  #validates :degree_status_id, inclusion: { in: DEGREE_STATUS_OPTIONS.map { |_k, v| v }, message: "Select an option from the list" }
+  #validates :degree_type_id, types: { method: :get_qualification_degree_status }
 
   def set_degree_status
     self.degree_status_id = case degree_options

--- a/app/models/have_a_degree.rb
+++ b/app/models/have_a_degree.rb
@@ -15,8 +15,8 @@ class HaveADegree < Base
   DEGREE_TYPE = { degree: 222_750_000, equivalent: 222_750_005 }.freeze
 
   validates :degree_options, inclusion: { in: DEGREE_OPTIONS.map { |_k, v| v }, message: "Select an option from the list" }
-  #validates :degree_status_id, inclusion: { in: DEGREE_STATUS_OPTIONS.map { |_k, v| v }, message: "Select an option from the list" }
-  #validates :degree_type_id, types: { method: :get_qualification_degree_status }
+  validates :degree_status_id, inclusion: { in: DEGREE_STATUS_OPTIONS.map { |_k, v| v }, message: "Select an option from the list" }, unless: -> { degree_options.blank? }
+  validates :degree_type_id, types: { method: :get_qualification_degree_status }, unless: -> { degree_options.blank? }
 
   def set_degree_status
     self.degree_status_id = case degree_options

--- a/app/models/have_a_degree.rb
+++ b/app/models/have_a_degree.rb
@@ -15,8 +15,11 @@ class HaveADegree < Base
   DEGREE_TYPE = { degree: 222_750_000, equivalent: 222_750_005 }.freeze
 
   validates :degree_options, inclusion: { in: DEGREE_OPTIONS.map { |_k, v| v }, message: "Select an option from the list" }
-  validates :degree_status_id, inclusion: { in: DEGREE_STATUS_OPTIONS.map { |_k, v| v }, message: "Select an option from the list" }, unless: -> { degree_options.blank? }
-  validates :degree_type_id, types: { method: :get_qualification_degree_status }, unless: -> { degree_options.blank? }
+
+  with_options if: -> { degree_options.present? } do |degree_option|
+    degree_option.validates :degree_status_id, inclusion: { in: DEGREE_STATUS_OPTIONS.map { |_k, v| v }, message: "Select an option from the list" }
+    degree_option.validates :degree_type_id, types: { method: :get_qualification_degree_status }
+  end
 
   def set_degree_status
     self.degree_status_id = case degree_options


### PR DESCRIPTION
### JIRA ticket number

### Context
Previously we set `degree_status_id` and `degree_type_id` in a before_validation hook. This was changed to the degree_options setter, but now results in all three validation error messages displaying if the user leaves the form field blank.
### Changes proposed in this pull request
We can either revert to the before_validation hook, which would cover all the validation scenarios, or remove validation from the `degree_status_id` and `degree_type_id`

Opted to place validations within a with_options conditional block
### Guidance to review
![image](https://user-images.githubusercontent.com/4527528/90878130-12066100-e39d-11ea-8c35-7499960a91e8.png)
