### PR TITLE
Remove sign up steps from sitemap

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,7 +1,6 @@
 class SitemapsController < ApplicationController
   def index
     @host = "#{request.protocol}#{request.host}"
-    @steps = StepFactory::STEP_NAMES
     respond_to do |format|
       format.xml
     end

--- a/app/views/sitemaps/index.xml.erb
+++ b/app/views/sitemaps/index.xml.erb
@@ -11,10 +11,4 @@
     <lastmod><%= Time.now.strftime("%Y-%m-%dT%H:%M:%S")%></lastmod>
   </url>
   <% end %>
-  <% @steps.each do |step| %>
-  <url>
-    <loc><%= "#{@host}" + "#{new_registration_path step.underscore}" %></loc>
-    <lastmod><%= Time.now.strftime("%Y-%m-%dT%H:%M:%S")%></lastmod>
-  </url>
-  <% end %>
 </urlset>


### PR DESCRIPTION
### Context

It doesn't make sense to expose the sign up steps to be indexed by search engines as they can't be accessed directly; only by progressing through the sign up flow.

### Changes proposed in this pull request

Remove sign up steps from sitemap