### PR TITLE
Changed default RSpec logger back to default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,9 +68,11 @@ jobs:
 
       - name: Run Specs
         run: |-
-          docker run -t --rm -v ${PWD}/out:/app/out -v ${PWD}/coverage:/app/coverage -e RAILS_ENV=test $DOCKER_IMAGE /bin/sh -c 'cd /app; bundle exec rspec'
-          sed -e "s?/app/app?${PWD}/app?" < coverage/.resultset.json > tmp.file
-          sudo mv tmp.file coverage/.resultset.json
+          docker run -t --rm -v ${PWD}/out:/app/out -v ${PWD}/coverage:/app/coverage -e RAILS_ENV=test $DOCKER_IMAGE \
+            rspec --format RspecSonarqubeFormatter --out /app/out/test-report.xml --format documentation
+
+      - name: Fixup report file paths
+        run: sudo sed -i "s?\"/app/?\"${PWD}/?" coverage/.resultset.json
 
       - name:  Keep Code Coverage Report
         uses: actions/upload-artifact@v2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,10 +21,6 @@ end
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  # Adding formatter
-  config.formatter = "documentation"
-  config.add_formatter("RspecSonarqubeFormatter", "out/test-report.xml")
-
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
### Context

The default RSpec logger is more concise when running specs locally. We still need the documentation and SonarQube loggers when running in CI though

### Changes proposed in this pull request

1. Drop the hard coded use of the documentation logger
2. Dynamically enable the use of the documentation and sonarqube loggers in CI



