### PR TITLE
Issue verification code

### DIFF
--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -17,7 +17,7 @@ module WizardSteps
   def update
     @current_step.assign_attributes step_params
 
-    if @current_step.save
+    if @current_step.save!
       redirect_to next_step_path
 
       # Needs to occur after redirect because it purges data after submission

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -3,7 +3,7 @@ module WizardSteps
 
   included do
     class_attribute :wizard_class
-    before_action :load_wizard, :load_current_step, except: %i[index completed]
+    before_action :load_wizard, :load_current_step, except: %i[index completed resend_verification]
   end
 
   def index
@@ -27,6 +27,12 @@ module WizardSteps
 
   def completed
     # current_step is loaded via before_action
+  end
+
+  def resend_verification
+    request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(camelized_identity_data)
+    GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
+    redirect_to params[:redirect_path]
   end
 
 private
@@ -57,5 +63,10 @@ private
 
   def step_param_key
     @current_step.class.model_name.param_key
+  end
+
+  def camelized_identity_data
+    Wizard::Steps::Authenticate.new(nil, wizard_store)
+      .candidate_identity_data
   end
 end

--- a/app/models/teacher_training_adviser/steps/authenticate.rb
+++ b/app/models/teacher_training_adviser/steps/authenticate.rb
@@ -1,0 +1,12 @@
+module TeacherTrainingAdviser
+  module Steps
+    class Authenticate < ::Wizard::Steps::Authenticate
+    protected
+
+      def perform_existing_candidate_request(request)
+        @api ||= GetIntoTeachingApiClient::TeacherTrainingAdviserApi.new
+        @api.get_pre_filled_teacher_training_adviser_sign_up(timed_one_time_password, request)
+      end
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/identity.rb
+++ b/app/models/teacher_training_adviser/steps/identity.rb
@@ -1,5 +1,7 @@
 module TeacherTrainingAdviser::Steps
   class Identity < ::Wizard::Step
+    include Wizard::IssueVerificationCode
+
     attribute :email, :string
     attribute :first_name, :string
     attribute :last_name, :string

--- a/app/models/teacher_training_adviser/wizard.rb
+++ b/app/models/teacher_training_adviser/wizard.rb
@@ -2,6 +2,7 @@ module TeacherTrainingAdviser
   class Wizard < ::Wizard::Base
     self.steps = [
       Steps::Identity,
+      Steps::Authenticate,
       Steps::ReturningTeacher,
       Steps::HaveADegree,
       Steps::NoDegree,

--- a/app/models/wizard/issue_verification_code.rb
+++ b/app/models/wizard/issue_verification_code.rb
@@ -1,0 +1,32 @@
+module Wizard
+  module IssueVerificationCode
+    extend ActiveSupport::Concern
+
+    def save!
+      @store.purge! if previously_authenticated?
+
+      if valid?
+        begin
+          request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(request_attributes)
+          GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
+          @store["authenticate"] = true
+        rescue GetIntoTeachingApiClient::ApiError
+          # Existing candidate not found or CRM is currently unavailable.
+          @store["authenticate"] = false
+        end
+      end
+
+      super
+    end
+
+  private
+
+    def previously_authenticated?
+      @store["authenticate"]
+    end
+
+    def request_attributes
+      attributes.slice("email", "first_name", "last_name").transform_keys { |k| k.camelize(:lower).to_sym }
+    end
+  end
+end

--- a/app/models/wizard/step.rb
+++ b/app/models/wizard/step.rb
@@ -21,7 +21,7 @@ module Wizard
       assign_attributes attributes
     end
 
-    def save
+    def save!
       return false unless valid?
 
       persist_to_store

--- a/app/models/wizard/steps/authenticate.rb
+++ b/app/models/wizard/steps/authenticate.rb
@@ -1,0 +1,65 @@
+module Wizard
+  module Steps
+    class Authenticate < ::Wizard::Step
+      IDENTITY_ATTRS = %i[email first_name last_name date_of_birth].freeze
+
+      attribute :timed_one_time_password
+
+      validates :timed_one_time_password, length: { is: 6, message: "The verification code should be 6 digits" },
+                                          format: { with: /\A[0-9]*\z/, message: "Please enter the latest verification code sent to your email address" }
+      validate :timed_one_time_password_is_correct, if: :timed_one_time_password_valid?
+
+      before_validation if: :timed_one_time_password do
+        self.timed_one_time_password = timed_one_time_password.to_s.strip
+      end
+
+      def skipped?
+        @store["authenticate"] == false
+      end
+
+      def save!
+        prepopulate_store if valid?
+
+        super
+      end
+
+      def timed_one_time_password=(value)
+        @totp_response = nil if value != timed_one_time_password
+        super(value)
+      end
+
+      def candidate_identity_data
+        @store.fetch(IDENTITY_ATTRS).transform_keys do |k|
+          k.camelize(:lower).to_sym
+        end
+      end
+
+    protected
+
+      def perform_existing_candidate_request(_request)
+        raise NotImplementedError, "subclass must define #perform_existing_candidate_request"
+      end
+
+    private
+
+      def timed_one_time_password_valid?
+        self.class.validators_on(:timed_one_time_password).each do |validator|
+          validator.validate_each(self, :timed_one_time_password, timed_one_time_password)
+        end
+        errors.none?
+      end
+
+      def timed_one_time_password_is_correct
+        request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(candidate_identity_data)
+        @totp_response ||= perform_existing_candidate_request(request)
+      rescue GetIntoTeachingApiClient::ApiError
+        errors.add(:timed_one_time_password, "Please enter the latest verification code sent to your email address")
+      end
+
+      def prepopulate_store
+        hash = @totp_response.to_hash.transform_keys { |k| k.to_s.underscore }
+        @store.persist(hash.except(*@store.keys))
+      end
+    end
+  end
+end

--- a/app/views/teacher_training_adviser/steps/_authenticate.html.erb
+++ b/app/views/teacher_training_adviser/steps/_authenticate.html.erb
@@ -1,0 +1,7 @@
+<%= f.govuk_fieldset legend: { text: 'Verify your email address' } do %>
+<p class="govuk-body">We need you to check your email and enter the verification code to continue.</p>
+
+<%= render "wizard/steps/authenticate", f: f, email: session["sign_up"]["email"], resend_verification_path: resend_verification_teacher_training_adviser_steps_path(
+  redirect_path: teacher_training_adviser_step_path(TeacherTrainingAdviser::Steps::Authenticate.key, verification_resent: true)
+) %>
+<% end %>

--- a/app/views/wizard/steps/_authenticate.html.erb
+++ b/app/views/wizard/steps/_authenticate.html.erb
@@ -1,0 +1,9 @@
+<%
+  link = link_to("resend verification", resend_verification_path)
+  hint_text = "Check your junk mail folder or #{link}."
+  hint_text += "<br /><b>We've sent you another email.</b>" if params[:verification_resent]
+%>
+
+<%= f.govuk_text_field :timed_one_time_password, 
+label: { text: "Enter the verification code sent to #{email}" }, 
+hint_text: hint_text.html_safe %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
               only: %i[index show update] do
       collection do
         get :completed
+        get :resend_verification
       end
     end
   end

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 RSpec.feature "Sign up for a teacher training adviser", type: :feature do
+  before do
+    # Emulate an unsuccessful matchback response from the API.
+    expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+      receive(:create_candidate_access_token)
+      .and_raise(GetIntoTeachingApiClient::ApiError)
+  end
+
   scenario "a candidate that is a returning teacher" do
     visit teacher_training_adviser_steps_path
 

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -1,259 +1,302 @@
 require "rails_helper"
 
 RSpec.feature "Sign up for a teacher training adviser", type: :feature do
-  before do
-    # Emulate an unsuccessful matchback response from the API.
-    expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
-      receive(:create_candidate_access_token)
-      .and_raise(GetIntoTeachingApiClient::ApiError)
+  context "a new candidate" do
+    before do
+      # Emulate an unsuccessful matchback response from the API.
+      expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+        receive(:create_candidate_access_token)
+        .and_raise(GetIntoTeachingApiClient::ApiError)
+    end
+
+    scenario "that is a returning teacher" do
+      visit teacher_training_adviser_steps_path
+
+      expect(page).to have_text "About you"
+      fill_in_identity_step
+      click_on "Continue"
+
+      expect(page).to have_text "Are you returning to teaching?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have your previous teacher reference number?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_text "What is your previous teacher reference number?"
+      fill_in "Teacher reference number (optional)", with: "1234"
+      click_on "Continue"
+
+      expect(page).to have_text "Which main subject did you previously teach?"
+      select "Psychology"
+      click_on "Continue"
+
+      expect(page).to have_text "Which subject would you like to teach if you return to teaching?"
+      choose "Physics"
+      click_on "Continue"
+
+      expect(page).to have_text "Enter your date of birth"
+      fill_in_date_of_birth_step
+      click_on "Continue"
+
+      expect(page).to have_text "Where do you live?"
+      choose "UK"
+      click_on "Continue"
+
+      expect(page).to have_text "What is your address?"
+      fill_in_address_step
+      click_on "Continue"
+
+      expect(page).to have_text "What is your telephone number?"
+      fill_in "UK telephone number (optional)", with: "123456789"
+      click_on "Continue"
+
+      expect(page).to have_text "Check your answers before you continue"
+      click_on "Continue"
+
+      expect(page).to have_text "Read and accept the privacy policy"
+      check "Accept the privacy policy"
+      click_on "Complete"
+
+      expect(page).to have_text "Thank you"
+      expect(page).to have_text "Sign up complete"
+    end
+
+    scenario "with an equivalent degree" do
+      visit teacher_training_adviser_steps_path
+
+      expect(page).to have_text "About you"
+      fill_in_identity_step
+      click_on "Continue"
+
+      expect(page).to have_text "Are you returning to teaching?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have a degree?"
+      choose "I have an equivalent qualification from another country"
+      click_on "Continue"
+
+      expect(page).to have_text "Which stage are you interested in teaching?"
+      choose "Secondary"
+      click_on "Continue"
+
+      expect(page).to have_text "Which subject would you like to teach?"
+      select "Physics"
+      click_on "Continue"
+
+      expect(page).to have_text "When do you want to start your teacher training?"
+      select "2022"
+      click_on "Continue"
+
+      expect(page).to have_text "Enter your date of birth"
+      fill_in_date_of_birth_step
+      click_on "Continue"
+
+      expect(page).to have_text "Where do you live?"
+      choose "Overseas"
+      click_on "Continue"
+
+      expect(page).to have_text "Which country do you live in?"
+      select "Argentina"
+      click_on "Continue"
+
+      expect(page).to have_text "What is your telephone number?"
+      fill_in "Overseas telephone number (optional)", with: "123456789"
+      click_on "Continue"
+
+      expect(page).to have_text "You told us you live overseas"
+      select "(GMT-10:00) Hawaii"
+      click_on "Continue"
+
+      expect(page).to have_text "Check your answers before you continue"
+      click_on "Continue"
+
+      expect(page).to have_text "Read and accept the privacy policy"
+      check "Accept the privacy policy"
+      click_on "Complete"
+
+      expect(page).to have_text "Thank you"
+      expect(page).to have_text "Sign up complete"
+    end
+
+    scenario "studying for a degree" do
+      visit teacher_training_adviser_steps_path
+
+      expect(page).to have_text "About you"
+      fill_in_identity_step
+      click_on "Continue"
+
+      expect(page).to have_text "Are you returning to teaching?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have a degree?"
+      choose "I'm studying for a degree"
+      click_on "Continue"
+
+      expect(page).to have_text "In which year are you studying?"
+      choose "First year"
+      click_on "Continue"
+
+      expect(page).to have_text "What subject is your degree?"
+      select "Maths"
+      click_on "Continue"
+
+      expect(page).to have_text "What degree class are you predicted to get?"
+      select "2:2"
+      click_on "Continue"
+
+      expect(page).to have_text "Which stage are you interested in teaching?"
+      choose "Primary"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have grade 4 (C) or above in GCSE science, or equivalent?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_text "When do you want to start your teacher training?"
+      select "2022"
+      click_on "Continue"
+
+      expect(page).to have_text "Enter your date of birth"
+      fill_in_date_of_birth_step
+      click_on "Continue"
+
+      expect(page).to have_text "Where do you live?"
+      choose "Overseas"
+      click_on "Continue"
+
+      expect(page).to have_text "Which country do you live in?"
+      select "Argentina"
+      click_on "Continue"
+
+      expect(page).to have_text "What is your telephone number?"
+      fill_in "Overseas telephone number (optional)", with: "123456789"
+      click_on "Continue"
+
+      expect(page).to have_text "Check your answers before you continue"
+      click_on "Continue"
+
+      expect(page).to have_text "Read and accept the privacy policy"
+      check "Accept the privacy policy"
+      click_on "Complete"
+
+      expect(page).to have_text "Thank you"
+      expect(page).to have_text "Sign up complete"
+    end
+
+    scenario "without a degree" do
+      visit teacher_training_adviser_steps_path
+
+      expect(page).to have_text "About you"
+      fill_in_identity_step
+      click_on "Continue"
+
+      expect(page).to have_text "Are you returning to teaching?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have a degree?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "If you do not have a degree"
+      expect(page).to_not have_text "Continue"
+    end
+
+    scenario "without GCSEs" do
+      visit teacher_training_adviser_steps_path
+
+      expect(page).to have_text "About you"
+      fill_in_identity_step
+      click_on "Continue"
+
+      expect(page).to have_text "Are you returning to teaching?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have a degree?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_text "What subject is your degree?"
+      select "Maths"
+      click_on "Continue"
+
+      expect(page).to have_text "Which class is your degree?"
+      select "2:2"
+      click_on "Continue"
+
+      expect(page).to have_text "Which stage are you interested in teaching?"
+      choose "Primary"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Are you planning to retake either English or maths (or both) GCSEs, or equivalent?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have grade 4 (C) or above in GCSE science, or equivalent?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Are you planning to retake your science GCSE?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Get the right GCSEs or equivalent qualifications"
+      expect(page).to_not have_text "Continue"
+    end
   end
 
-  scenario "a candidate that is a returning teacher" do
-    visit teacher_training_adviser_steps_path
+  context "an existing candidate" do
+    let(:valid_code) { "123456" }
+    let(:invalid_code) { "111111" }
+    let(:existing_candidate) { GetIntoTeachingApiClient::TeacherTrainingAdviserSignUp.new }
 
-    expect(page).to have_text "About you"
-    fill_in_identity_step
-    click_on "Continue"
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+        receive(:create_candidate_access_token)
+      allow_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to \
+        receive(:get_pre_filled_teacher_training_adviser_sign_up)
+        .with(valid_code, anything)
+        .and_return(existing_candidate)
+      allow_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to \
+        receive(:get_pre_filled_teacher_training_adviser_sign_up)
+        .with(invalid_code, anything)
+        .and_raise(GetIntoTeachingApiClient::ApiError)
+    end
 
-    expect(page).to have_text "Are you returning to teaching?"
-    choose "Yes"
-    click_on "Continue"
+    scenario "matchback" do
+      visit teacher_training_adviser_steps_path
 
-    expect(page).to have_text "Do you have your previous teacher reference number?"
-    choose "Yes"
-    click_on "Continue"
+      expect(page).to have_text "About you"
+      fill_in_identity_step
+      click_on "Continue"
 
-    expect(page).to have_text "What is your previous teacher reference number?"
-    fill_in "Teacher reference number (optional)", with: "1234"
-    click_on "Continue"
+      expect(page).to have_text "Verify your email address"
+      expect(page).to have_text "Enter the verification code sent to john@doe.com"
+      click_on "resend verification"
 
-    expect(page).to have_text "Which main subject did you previously teach?"
-    select "Psychology"
-    click_on "Continue"
+      expect(page).to have_text "We've sent you another email."
+      fill_in "teacher-training-adviser-steps-authenticate-timed-one-time-password-field", with: invalid_code
+      click_on "Continue"
 
-    expect(page).to have_text "Which subject would you like to teach if you return to teaching?"
-    choose "Physics"
-    click_on "Continue"
+      expect(page).to have_text "Please enter the latest verification code sent to your email address"
+      fill_in "teacher-training-adviser-steps-authenticate-timed-one-time-password-field-error", with: valid_code
+      click_on "Continue"
 
-    expect(page).to have_text "Enter your date of birth"
-    fill_in_date_of_birth_step
-    click_on "Continue"
-
-    expect(page).to have_text "Where do you live?"
-    choose "UK"
-    click_on "Continue"
-
-    expect(page).to have_text "What is your address?"
-    fill_in_address_step
-    click_on "Continue"
-
-    expect(page).to have_text "What is your telephone number?"
-    fill_in "UK telephone number (optional)", with: "123456789"
-    click_on "Continue"
-
-    expect(page).to have_text "Check your answers before you continue"
-    click_on "Continue"
-
-    expect(page).to have_text "Read and accept the privacy policy"
-    check "Accept the privacy policy"
-    click_on "Complete"
-
-    expect(page).to have_text "Thank you"
-    expect(page).to have_text "Sign up complete"
-  end
-
-  scenario "a candidate with an equivalent degree" do
-    visit teacher_training_adviser_steps_path
-
-    expect(page).to have_text "About you"
-    fill_in_identity_step
-    click_on "Continue"
-
-    expect(page).to have_text "Are you returning to teaching?"
-    choose "No"
-    click_on "Continue"
-
-    expect(page).to have_text "Do you have a degree?"
-    choose "I have an equivalent qualification from another country"
-    click_on "Continue"
-
-    expect(page).to have_text "Which stage are you interested in teaching?"
-    choose "Secondary"
-    click_on "Continue"
-
-    expect(page).to have_text "Which subject would you like to teach?"
-    select "Physics"
-    click_on "Continue"
-
-    expect(page).to have_text "When do you want to start your teacher training?"
-    select "2022"
-    click_on "Continue"
-
-    expect(page).to have_text "Enter your date of birth"
-    fill_in_date_of_birth_step
-    click_on "Continue"
-
-    expect(page).to have_text "Where do you live?"
-    choose "Overseas"
-    click_on "Continue"
-
-    expect(page).to have_text "Which country do you live in?"
-    select "Argentina"
-    click_on "Continue"
-
-    expect(page).to have_text "What is your telephone number?"
-    fill_in "Overseas telephone number (optional)", with: "123456789"
-    click_on "Continue"
-
-    expect(page).to have_text "You told us you live overseas"
-    select "(GMT-10:00) Hawaii"
-    click_on "Continue"
-
-    expect(page).to have_text "Check your answers before you continue"
-    click_on "Continue"
-
-    expect(page).to have_text "Read and accept the privacy policy"
-    check "Accept the privacy policy"
-    click_on "Complete"
-
-    expect(page).to have_text "Thank you"
-    expect(page).to have_text "Sign up complete"
-  end
-
-  scenario "a candidate studying for a degree" do
-    visit teacher_training_adviser_steps_path
-
-    expect(page).to have_text "About you"
-    fill_in_identity_step
-    click_on "Continue"
-
-    expect(page).to have_text "Are you returning to teaching?"
-    choose "No"
-    click_on "Continue"
-
-    expect(page).to have_text "Do you have a degree?"
-    choose "I'm studying for a degree"
-    click_on "Continue"
-
-    expect(page).to have_text "In which year are you studying?"
-    choose "First year"
-    click_on "Continue"
-
-    expect(page).to have_text "What subject is your degree?"
-    select "Maths"
-    click_on "Continue"
-
-    expect(page).to have_text "What degree class are you predicted to get?"
-    select "2:2"
-    click_on "Continue"
-
-    expect(page).to have_text "Which stage are you interested in teaching?"
-    choose "Primary"
-    click_on "Continue"
-
-    expect(page).to have_text "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?"
-    choose "Yes"
-    click_on "Continue"
-
-    expect(page).to have_text "Do you have grade 4 (C) or above in GCSE science, or equivalent?"
-    choose "Yes"
-    click_on "Continue"
-
-    expect(page).to have_text "When do you want to start your teacher training?"
-    select "2022"
-    click_on "Continue"
-
-    expect(page).to have_text "Enter your date of birth"
-    fill_in_date_of_birth_step
-    click_on "Continue"
-
-    expect(page).to have_text "Where do you live?"
-    choose "Overseas"
-    click_on "Continue"
-
-    expect(page).to have_text "Which country do you live in?"
-    select "Argentina"
-    click_on "Continue"
-
-    expect(page).to have_text "What is your telephone number?"
-    fill_in "Overseas telephone number (optional)", with: "123456789"
-    click_on "Continue"
-
-    expect(page).to have_text "Check your answers before you continue"
-    click_on "Continue"
-
-    expect(page).to have_text "Read and accept the privacy policy"
-    check "Accept the privacy policy"
-    click_on "Complete"
-
-    expect(page).to have_text "Thank you"
-    expect(page).to have_text "Sign up complete"
-  end
-
-  scenario "a candidate without a degree" do
-    visit teacher_training_adviser_steps_path
-
-    expect(page).to have_text "About you"
-    fill_in_identity_step
-    click_on "Continue"
-
-    expect(page).to have_text "Are you returning to teaching?"
-    choose "No"
-    click_on "Continue"
-
-    expect(page).to have_text "Do you have a degree?"
-    choose "No"
-    click_on "Continue"
-
-    expect(page).to have_text "If you do not have a degree"
-    expect(page).to_not have_text "Continue"
-  end
-
-  scenario "a candidate without GCSEs" do
-    visit teacher_training_adviser_steps_path
-
-    expect(page).to have_text "About you"
-    fill_in_identity_step
-    click_on "Continue"
-
-    expect(page).to have_text "Are you returning to teaching?"
-    choose "No"
-    click_on "Continue"
-
-    expect(page).to have_text "Do you have a degree?"
-    choose "Yes"
-    click_on "Continue"
-
-    expect(page).to have_text "What subject is your degree?"
-    select "Maths"
-    click_on "Continue"
-
-    expect(page).to have_text "Which class is your degree?"
-    select "2:2"
-    click_on "Continue"
-
-    expect(page).to have_text "Which stage are you interested in teaching?"
-    choose "Primary"
-    click_on "Continue"
-
-    expect(page).to have_text "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?"
-    choose "No"
-    click_on "Continue"
-
-    expect(page).to have_text "Are you planning to retake either English or maths (or both) GCSEs, or equivalent?"
-    choose "Yes"
-    click_on "Continue"
-
-    expect(page).to have_text "Do you have grade 4 (C) or above in GCSE science, or equivalent?"
-    choose "No"
-    click_on "Continue"
-
-    expect(page).to have_text "Are you planning to retake your science GCSE?"
-    choose "No"
-    click_on "Continue"
-
-    expect(page).to have_text "Get the right GCSEs or equivalent qualifications"
-    expect(page).to_not have_text "Continue"
+      expect(page).to have_text "Are you returning to teaching?"
+    end
   end
 
   def fill_in_identity_step

--- a/spec/models/teacher_training_adviser/steps/authenticate_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/authenticate_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::Authenticate do
+  include_context "wizard step"
+
+  it { is_expected.to be_kind_of(::Wizard::Steps::Authenticate) }
+
+  it "calls get_pre_filled_teacher_training_adviser_sign_up on valid save!" do
+    attributes = { "timed_one_time_password": "123456" }
+    response = GetIntoTeachingApiClient::MailingListAddMember.new
+    expect_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to \
+      receive(:get_pre_filled_teacher_training_adviser_sign_up)
+      .with("123456", anything)
+      .and_return(response)
+    subject.assign_attributes(attributes)
+    subject.save!
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/identity_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/identity_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::Identity do
   include_context "wizard step"
   it_behaves_like "a wizard step"
+  it_behaves_like "an issue verification code wizard step"
 
   context "attributes" do
     it { is_expected.to respond_to :first_name }

--- a/spec/models/teacher_training_adviser/wizard_spec.rb
+++ b/spec/models/teacher_training_adviser/wizard_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
     it do
       is_expected.to eql [
         TeacherTrainingAdviser::Steps::Identity,
+        TeacherTrainingAdviser::Steps::Authenticate,
         TeacherTrainingAdviser::Steps::ReturningTeacher,
         TeacherTrainingAdviser::Steps::HaveADegree,
         TeacherTrainingAdviser::Steps::NoDegree,

--- a/spec/models/wizard/step_spec.rb
+++ b/spec/models/wizard/step_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe Wizard::Step do
     it { expect(subject).to be_can_proceed }
   end
 
-  describe "#save" do
+  describe "#save!" do
     let(:backingstore) { {} }
 
     context "when valid" do
       let(:attributes) { { name: "Jane" } }
-      let!(:result) { subject.save }
+      let!(:result) { subject.save! }
 
       it { expect(result).to be true }
       it { expect(wizardstore[:name]).to eql "Jane" }
@@ -45,7 +45,7 @@ RSpec.describe Wizard::Step do
 
     context "when invalid" do
       let(:attributes) { { age: 30 } }
-      let!(:result) { subject.save }
+      let!(:result) { subject.save! }
 
       it { expect(result).to be false }
       it { is_expected.to have_attributes errors: hash_including(:name) }

--- a/spec/models/wizard/steps/authenticate_spec.rb
+++ b/spec/models/wizard/steps/authenticate_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+RSpec.describe Wizard::Steps::Authenticate do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  before { allow(instance).to receive(:perform_existing_candidate_request).with(anything) { {} } }
+
+  it { is_expected.to respond_to :timed_one_time_password }
+
+  context "validations" do
+    before { instance.valid? }
+    subject { instance.errors.messages }
+    it { is_expected.to include(:timed_one_time_password) }
+  end
+
+  context "timed one time password" do
+    it { is_expected.to allow_value("000000").for :timed_one_time_password }
+    it { is_expected.to allow_value(" 123456").for :timed_one_time_password }
+    it { is_expected.not_to allow_value("abc123").for :timed_one_time_password }
+    it { is_expected.not_to allow_value("1234567").for :timed_one_time_password }
+    it { is_expected.not_to allow_value("12345").for :timed_one_time_password }
+  end
+
+  describe "skipped?" do
+    it "returns true if authenticate is false" do
+      wizardstore["authenticate"] = false
+      expect(subject).to be_skipped
+    end
+
+    it "returns false if authenticate is true" do
+      wizardstore["authenticate"] = true
+      expect(subject).to_not be_skipped
+    end
+  end
+
+  describe "#save!" do
+    before do
+      subject.timed_one_time_password = "123456"
+      wizardstore["email"] = "email@address.com"
+      wizardstore["first_name"] = "First"
+      wizardstore["last_name"] = "Last"
+    end
+
+    let(:request) do
+      GetIntoTeachingApiClient::ExistingCandidateRequest.new(
+        email: wizardstore["email"],
+        firstName: wizardstore["first_name"],
+        lastName: wizardstore["last_name"],
+      )
+    end
+
+    context "when invalid" do
+      it "does not attempt to call the API" do
+        subject.timed_one_time_password = nil
+        subject.save!
+        expect { subject.save! }.to_not raise_error
+      end
+    end
+
+    context "when valid" do
+      it "attempts to call the API exactly once for each valid timed_one_time_password" do
+        expect(subject).to receive(:perform_existing_candidate_request).with(request).exactly(2).times
+        subject.timed_one_time_password = "123456"
+        subject.save!
+        subject.save!
+        subject.timed_one_time_password = "000000"
+        subject.save!
+      end
+
+      it "throws an error if #f is not defined" do
+        expect(instance).to receive(:perform_existing_candidate_request).and_call_original
+        expect { subject.save! }.to raise_error(NotImplementedError)
+      end
+    end
+
+    context "when TOTP is correct" do
+      it "updates the store with the response" do
+        response = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidateId: "abc123")
+        expect(subject).to receive(:perform_existing_candidate_request).with(request) { response }
+        subject.save!
+        expect(wizardstore["candidate_id"]).to eq(response.candidate_id)
+      end
+
+      it "does not overwrite data already in the store" do
+        response = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidateId: "abc123", firstName: "Jim")
+        expect(subject).to receive(:perform_existing_candidate_request).with(request) { response }
+        subject.save!
+        expect(wizardstore["candidate_id"]).to eq(response.candidate_id)
+        expect(wizardstore["first_name"]).to eq("First")
+      end
+    end
+
+    context "when TOTP is incorrect" do
+      it "is marked as invalid" do
+        expect(subject).to receive(:perform_existing_candidate_request).with(request)
+          .and_raise(GetIntoTeachingApiClient::ApiError)
+        expect(subject).to be_invalid
+      end
+    end
+  end
+end

--- a/spec/requests/sign_up_spec.rb
+++ b/spec/requests/sign_up_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe TeacherTrainingAdviser::StepsController do
     end
 
     context "with valid data" do
+      before do
+        # Emulate an unsuccessful matchback response from the API.
+        expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token)
+          .and_raise(GetIntoTeachingApiClient::ApiError)
+      end
+
       let(:params) { { first_name: "John", last_name: "Doe", email: "john@doe.com" } }
       it { is_expected.to redirect_to teacher_training_adviser_step_path("returning_teacher") }
     end

--- a/spec/requests/sign_up_spec.rb
+++ b/spec/requests/sign_up_spec.rb
@@ -73,4 +73,17 @@ RSpec.describe TeacherTrainingAdviser::StepsController do
     end
     it { is_expected.to have_http_status :success }
   end
+
+  describe "#resend_verification" do
+    before do
+      expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+        receive(:create_candidate_access_token)
+    end
+
+    subject do
+      get resend_verification_teacher_training_adviser_steps_path(redirect_path: "redirect/path")
+      response
+    end
+    it { is_expected.to redirect_to("redirect/path") }
+  end
 end

--- a/spec/support/shared_examples/wizard_support.rb
+++ b/spec/support/shared_examples/wizard_support.rb
@@ -12,7 +12,7 @@ end
 
 RSpec.shared_examples "a wizard step" do
   it { expect(subject.class).to respond_to :key }
-  it { is_expected.to respond_to :save }
+  it { is_expected.to respond_to :save! }
 end
 
 RSpec.shared_examples "a wizard step that exposes API types as options" do |api_method|
@@ -28,6 +28,62 @@ RSpec.shared_examples "a wizard step that exposes API types as options" do |api_
       receive(api_method) { types }
 
     expect(described_class.options).to eq({ "one" => 1, "two" => 2 })
+  end
+end
+
+RSpec.shared_examples "an issue verification code wizard step" do
+  describe "#save!" do
+    before do
+      subject.email = "email@address.com"
+      subject.first_name = "first"
+      subject.last_name = "last"
+    end
+
+    let(:request) do
+      GetIntoTeachingApiClient::ExistingCandidateRequest.new(
+        email: subject.email,
+        firstName: subject.first_name,
+        lastName: subject.last_name,
+      )
+    end
+
+    context "when invalid" do
+      it "does not call the API" do
+        subject.email = nil
+        subject.save!
+        expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to_not \
+          receive(:create_candidate_access_token)
+      end
+    end
+
+    context "when an existing candidate" do
+      before do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token).with(request)
+      end
+
+      it "sends verification code and sets authenticate to true" do
+        subject.save!
+        expect(wizardstore["authenticate"]).to be_truthy
+      end
+
+      it "clears the store if the user previously authenticated" do
+        wizardstore["authenticate"] = true
+        wizardstore["other_user_data"] = "clear me!"
+        subject.save!
+        expect(wizardstore["other_user_data"]).to be_nil
+      end
+    end
+
+    context "when a new candidate or CRM is unavailable" do
+      it "will skip the authenticate step" do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token).with(request)
+          .and_raise(GetIntoTeachingApiClient::ApiError)
+        subject.save!
+        expect(wizardstore["authenticate"]).to be_falsy
+      end
+    end
   end
 end
 


### PR DESCRIPTION
### JIRA ticket number

[GITPB-415](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?selectedIssue=GITPB-415)

### Context

When a candidate enters their first/last/email we want to check if we have a matching candidate in the system already. If we do, a verification code should be emailed to the candidate that they can then use to 'authenticate' and we can pre-fill the sign up form.

### Changes proposed in this pull request

- Send verification code on matchback

If a candidate enters a first/last/email that matches an existing candidate in the CRM we want to email them a verification code that can be used in a subsequent step to retrieve their details and pre-fill the form.

- Add authenticate step

Add the authenticate step that is shown if a match-back is successful. Allows the user to resend the verification code in case they didn't receive it. The store is pre-filled with the existing candidate information off the back of exchanging the verification code for candidate details.

### Guidance to review

Pretty much all of this is lifted/shifted from the get-into-teaching-app.

<img width="1008" alt="Screenshot 2020-08-24 at 14 09 58" src="https://user-images.githubusercontent.com/29867726/91131088-9eb66500-e6a4-11ea-9874-9d61651927df.png">
<img width="632" alt="Screenshot 2020-08-24 at 14 10 24" src="https://user-images.githubusercontent.com/29867726/91131091-9f4efb80-e6a4-11ea-9f3f-1d2c6eabaa81.png">


