### PR TITLE
Submit the Candidate information to the API

### DIFF
--- a/app/models/teacher_training_adviser/wizard.rb
+++ b/app/models/teacher_training_adviser/wizard.rb
@@ -1,5 +1,7 @@
 module TeacherTrainingAdviser
   class Wizard < ::Wizard::Base
+    include ::Wizard::ApiClientSupport
+
     self.steps = [
       Steps::Identity,
       Steps::Authenticate,
@@ -38,8 +40,17 @@ module TeacherTrainingAdviser
       super.tap do |result|
         break unless result
 
+        sign_up_candidate
         @store.purge!
       end
+    end
+
+  private
+
+    def sign_up_candidate
+      request = GetIntoTeachingApiClient::TeacherTrainingAdviserSignUp.new(export_camelized_hash)
+      api = GetIntoTeachingApiClient::TeacherTrainingAdviserApi.new
+      api.sign_up_teacher_training_adviser_candidate(request)
     end
   end
 end

--- a/app/models/wizard/api_client_support.rb
+++ b/app/models/wizard/api_client_support.rb
@@ -1,0 +1,13 @@
+module Wizard
+  module ApiClientSupport
+    def export_camelized_hash
+      camelize_hash export_data
+    end
+
+  private
+
+    def camelize_hash(hash)
+      hash.transform_keys { |k| k.camelize(:lower).to_sym }
+    end
+  end
+end

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -57,6 +57,10 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
 
       expect(page).to have_text "Read and accept the privacy policy"
       check "Accept the privacy policy"
+
+      expect_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to \
+        receive(:sign_up_teacher_training_adviser_candidate).once
+
       click_on "Complete"
 
       expect(page).to have_text "Thank you"
@@ -115,6 +119,10 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
 
       expect(page).to have_text "Read and accept the privacy policy"
       check "Accept the privacy policy"
+
+      expect_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to \
+        receive(:sign_up_teacher_training_adviser_candidate).once
+
       click_on "Complete"
 
       expect(page).to have_text "Thank you"
@@ -185,6 +193,10 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
 
       expect(page).to have_text "Read and accept the privacy policy"
       check "Accept the privacy policy"
+
+      expect_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to \
+        receive(:sign_up_teacher_training_adviser_candidate).once
+
       click_on "Complete"
 
       expect(page).to have_text "Thank you"

--- a/spec/models/teacher_training_adviser/wizard_spec.rb
+++ b/spec/models/teacher_training_adviser/wizard_spec.rb
@@ -50,9 +50,18 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
       }
     end
     let(:wizardstore) { Wizard::Store.new store }
+    let(:request) do
+      GetIntoTeachingApiClient::TeacherTrainingAdviserSignUp.new(
+        { email: "email@address.com", firstName: "Joe", lastName: "Joseph" },
+      )
+    end
 
     subject { described_class.new wizardstore, "accept_privacy_policy" }
 
+    before do
+      expect_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to \
+        receive(:sign_up_teacher_training_adviser_candidate).with(request).once
+    end
     before { allow(subject).to receive(:valid?).and_return true }
     before { subject.complete! }
 

--- a/spec/models/wizard/api_client_support_spec.rb
+++ b/spec/models/wizard/api_client_support_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Wizard::ApiClientSupport do
+  class ApiClientTestWizard
+    include ::Wizard::ApiClientSupport
+
+    def export_data
+      { "first_name" => "Joe", "last_name" => "Bloggs" }
+    end
+  end
+
+  let(:instance) { ApiClientTestWizard.new }
+  subject { instance }
+
+  describe "#export_camelized_hash" do
+    subject { instance.export_camelized_hash }
+    it { is_expected.to include firstName: "Joe" }
+    it { is_expected.to include lastName: "Bloggs" }
+  end
+end

--- a/spec/requests/sign_up_spec.rb
+++ b/spec/requests/sign_up_spec.rb
@@ -45,6 +45,9 @@ RSpec.describe TeacherTrainingAdviser::StepsController do
           steps.each do |step|
             allow_any_instance_of(step).to receive(:valid?).and_return true
           end
+
+          expect_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to \
+            receive(:sign_up_teacher_training_adviser_candidate).once
         end
 
         it { is_expected.to redirect_to completed_teacher_training_adviser_steps_path }
@@ -56,6 +59,9 @@ RSpec.describe TeacherTrainingAdviser::StepsController do
         before do
           steps.each do |step|
             allow_any_instance_of(step).to receive(:valid?).and_return true
+
+            expect_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to_not \
+              receive(:sign_up_teacher_training_adviser_candidate)
           end
 
           allow_any_instance_of(invalid_step).to receive(:valid?).and_return false


### PR DESCRIPTION
### JIRA ticket number

[GITPB-592](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?issueParent=19117&selectedIssue=GITPB-592)

### Context

When the candidate has finished filling in the sign up form they hit 'complete', at which point a request should send all the gathered information to the API, which then puts it on a queue to go to the CRM.

### Changes proposed in this pull request

- Submit payload to API at end of sign up

When the user completes the sign up we bundle the information they entered into a request that sends it to the API, where it gets queued before going on to the CRM.

### Guidance to review

Mostly a lift/shift from the GiT website - follows the same pattern.
