### PR TITLE
Remove use of html_safe on show_uk_address

### DIFF
--- a/app/helpers/session_helper.rb
+++ b/app/helpers/session_helper.rb
@@ -30,7 +30,7 @@ module SessionHelper
     address_postcode = session[:registration]["address_postcode"]
     # do we need these capitalized etc?
     address = [addr1, addr2, city, address_postcode]
-    address.join("<br />").html_safe
+    address.join("\n")
   end
 
   def show_name

--- a/app/views/check_answers/_uk_candidate.html.erb
+++ b/app/views/check_answers/_uk_candidate.html.erb
@@ -3,7 +3,7 @@
     Address
   </dt>
   <dd class="govuk-summary-list__value">
-    <%= show_uk_address %>
+    <%= safe_format(show_uk_address) %>
   </dd>
   <dd class="govuk-summary-list__actions">
     <% if defined?(link) %>

--- a/spec/helpers/session_helper_spec.rb
+++ b/spec/helpers/session_helper_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe SessionHelper, type: :helper do
                                  "address_line2" => "acacia avenue",
                                  "address_city" => "bradford",
                                  "address_postcode" => "tr1 1uf" }
-      expect(show_uk_address).to eq("22<br />acacia avenue<br />bradford<br />tr1 1uf")
+      expect(show_uk_address).to eq("22\nacacia avenue\nbradford\ntr1 1uf")
     end
   end
 


### PR DESCRIPTION
Prevents an exploit where JS can be inputted into the address fields then evaluated on the review answers page.

Currently uses the `safe_format` method from privacy policy helper, but this will be refactored later on - the fix needs to go in now for the pen testers to verify.

Introduces a minor UI glitch (extra space from wrapping `<p>` tags)

<img width="672" alt="Screenshot 2020-08-25 at 15 49 02" src="https://user-images.githubusercontent.com/29867726/91189713-ae589c80-e6ea-11ea-9c6e-7967b986a3b9.png">