### PR TITLE
Prevent overriding session store key in test environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,4 +55,8 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
+
+  config.session_store :cache_store,
+                       key: "_#{Rails.application.class.parent_name}_session",
+                       expire_after: 1.day
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,4 +104,8 @@ Rails.application.configure do
   config.cache_store = :redis_cache_store, { namespace: "TTA" }
 
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
+
+  config.session_store :cache_store,
+                       key: "_#{Rails.application.class.parent_name}_session",
+                       expire_after: 1.day
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,0 @@
-Rails.application.config.session_store :cache_store,
-                                       key: "_#{Rails.application.class.parent_name}_session",
-                                       expire_after: 1.day


### PR DESCRIPTION
In the test environment if the session store is overridden it causes the Capybara tests to misbehave; essentially clearing the session between each request (resulting in the sign up flows not working as the order depends on session data from previous steps).

Moves the session store config into development/production environments only.
