### PR TITLE
Add core wizard classes from GiT app

### DIFF
--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -1,0 +1,61 @@
+module WizardSteps
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :wizard_class
+    before_action :load_wizard, :load_current_step, except: %i[index completed]
+  end
+
+  def index
+    redirect_to step_path(wizard_class.first_key)
+  end
+
+  def show
+    # current_step loaded via before_action
+  end
+
+  def update
+    @current_step.assign_attributes step_params
+
+    if @current_step.save
+      redirect_to next_step_path
+
+      # Needs to occur after redirect because it purges data after submission
+      @wizard.complete!
+    end
+  end
+
+  def completed
+    # current_step is loaded via before_action
+  end
+
+private
+
+  def load_wizard
+    @wizard = wizard_class.new(wizard_store, params[:id])
+  end
+
+  def load_current_step
+    @current_step = @wizard.find_current_step
+  end
+
+  def next_step_path
+    if (next_key = @wizard.next_key)
+      step_path next_key
+    elsif (invalid_step = @wizard.first_invalid_step)
+      step_path invalid_step
+    else # all steps valid so completed
+      step_path :completed
+    end
+  end
+
+  def step_params
+    return {} unless params.key?(step_param_key)
+
+    params.require(step_param_key).permit @current_step.attributes.keys
+  end
+
+  def step_param_key
+    @current_step.class.model_name.param_key
+  end
+end

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -1,0 +1,110 @@
+module Wizard
+  class UnknownStep < RuntimeError; end
+
+  class Base
+    class_attribute :steps
+
+    class << self
+      def indexed_steps
+        @indexed_steps ||= steps.index_by(&:key)
+      end
+
+      def step(key)
+        indexed_steps[key] || raise(UnknownStep)
+      end
+
+      def key_index(key)
+        steps.index step(key)
+      end
+
+      def step_keys
+        indexed_steps.keys
+      end
+
+      def first_key
+        step_keys.first
+      end
+    end
+
+    delegate :step, :key_index, :indexed_steps, :step_keys, to: :class
+    delegate :can_proceed?, to: :find_current_step
+    attr_reader :current_key
+
+    def initialize(store, current_key)
+      @store = store
+
+      raise(UnknownStep) unless step_keys.include?(current_key)
+
+      @current_key = current_key
+    end
+
+    def find(key)
+      step(key).new self, @store
+    end
+
+    def find_current_step
+      find current_key
+    end
+
+    def previous_key(key = current_key)
+      earlier_keys(key).reverse.find do |k|
+        !find(k).skipped?
+      end
+    end
+
+    def next_key(key = current_key)
+      later_keys(key).find do |k|
+        !find(k).skipped?
+      end
+    end
+
+    def first_step?
+      previous_key.nil?
+    end
+
+    def last_step?
+      next_key.nil?
+    end
+
+    def valid?
+      active_steps.all?(&:valid?)
+    end
+
+    def complete!
+      last_step? && valid?
+    end
+
+    def invalid_steps
+      active_steps.select(&:invalid?)
+    end
+
+    def first_invalid_step
+      active_steps.find(&:invalid?)
+    end
+
+    def later_keys(key = current_key)
+      steps[(key_index(key) + 1)..].to_a.map(&:key)
+    end
+
+    def earlier_keys(key = current_key)
+      index = key_index(key)
+      return [] unless index.positive?
+
+      steps[0..(index - 1)].map(&:key)
+    end
+
+    def export_data
+      all_steps.map(&:export).reduce({}, :merge)
+    end
+
+  private
+
+    def all_steps
+      step_keys.map(&method(:find))
+    end
+
+    def active_steps
+      all_steps.reject(&:skipped?)
+    end
+  end
+end

--- a/app/models/wizard/step.rb
+++ b/app/models/wizard/step.rb
@@ -1,0 +1,58 @@
+module Wizard
+  class Step
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations::Callbacks
+
+    class << self
+      def key
+        name.split("::").last.underscore
+      end
+    end
+
+    delegate :key, to: :class
+    alias_method :id, :key
+
+    def initialize(wizard, store, attributes = {}, *args)
+      @wizard = wizard
+      @store = store
+      super(*args)
+      assign_attributes attributes_from_store
+      assign_attributes attributes
+    end
+
+    def save
+      return false unless valid?
+
+      persist_to_store
+    end
+
+    def can_proceed?
+      true
+    end
+
+    def persisted?
+      !id.nil?
+    end
+
+    def skipped?
+      false
+    end
+
+    def export
+      return {} if skipped?
+
+      Hash[attributes.keys.zip([])].merge attributes_from_store
+    end
+
+  private
+
+    def attributes_from_store
+      @store.fetch attributes.keys
+    end
+
+    def persist_to_store
+      @store.persist attributes
+    end
+  end
+end

--- a/app/models/wizard/store.rb
+++ b/app/models/wizard/store.rb
@@ -1,0 +1,40 @@
+module Wizard
+  class Store
+    attr_reader :data
+    delegate :keys, to: :data
+
+    def initialize(data)
+      raise InvalidBackingStore unless data.respond_to?(:[]=)
+
+      @data = data
+    end
+
+    def [](key)
+      data[key.to_s]
+    end
+
+    def []=(key, value)
+      data[key.to_s] = value
+    end
+
+    def fetch(*keys)
+      data.slice(*Array.wrap(keys).flatten.map(&:to_s)).stringify_keys
+    end
+
+    def persist(attributes)
+      data.merge! attributes.stringify_keys
+
+      true
+    end
+
+    def purge!
+      data.clear
+    end
+
+    def to_camelized_hash
+      data.transform_keys { |k| k.camelize(:lower).to_sym }
+    end
+
+    class InvalidBackingStore < RuntimeError; end
+  end
+end

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -1,0 +1,231 @@
+require "rails_helper"
+
+RSpec.describe Wizard::Base do
+  include_context "wizard store"
+
+  let(:wizardclass) { TestWizard }
+  let(:wizard) { wizardclass.new wizardstore, "age" }
+
+  describe ".indexed_steps" do
+    subject { wizardclass.indexed_steps }
+
+    it do
+      is_expected.to eql \
+        "name" => TestWizard::Name,
+        "age" => TestWizard::Age,
+        "postcode" => TestWizard::Postcode
+    end
+  end
+
+  describe ".step" do
+    it "will return steps class for valid step" do
+      expect(wizardclass.step("age")).to eql TestWizard::Age
+    end
+
+    it "will raise exception for unknown step" do
+      expect { wizardclass.step("unknown") }.to \
+        raise_exception(Wizard::UnknownStep)
+    end
+  end
+
+  describe ".key_index" do
+    it "will return index for known step" do
+      expect(wizardclass.key_index("age")).to eql 1
+    end
+
+    it "will raise exception for unknown step" do
+      expect { wizardclass.key_index("unknown") }.to \
+        raise_exception(Wizard::UnknownStep)
+    end
+  end
+
+  describe ".step_keys" do
+    subject { wizardclass.step_keys }
+    it { is_expected.to eql %w[name age postcode] }
+  end
+
+  describe ".first_key" do
+    subject { wizardclass.first_key }
+    it { is_expected.to eql "name" }
+  end
+
+  describe ".new" do
+    it "should return instance for known step" do
+      expect(wizardclass.new(wizardstore, "name")).to be_instance_of wizardclass
+    end
+
+    it "should raise exception for unknown step" do
+      expect { wizardclass.new wizardstore, "unknown" }.to \
+        raise_exception Wizard::UnknownStep
+    end
+  end
+
+  describe "#can_proceed?" do
+    subject { wizardclass.new(wizardstore, "name") }
+    it { is_expected.to be_can_proceed }
+  end
+
+  describe "#current_key" do
+    subject { wizardclass.new(wizardstore, "name").current_key }
+    it { is_expected.to eql "name" }
+  end
+
+  describe "#later_keys" do
+    subject { wizardclass.new(wizardstore, "name").later_keys }
+    it { is_expected.to eql %w[age postcode] }
+  end
+
+  describe "#earlier_keys" do
+    subject { wizardclass.new(wizardstore, "postcode").earlier_keys }
+    it { is_expected.to eql %w[name age] }
+  end
+
+  describe "#find" do
+    subject { wizard.find("age") }
+    it { is_expected.to be_instance_of TestWizard::Age }
+    it { is_expected.to have_attributes age: 35 }
+  end
+
+  describe "#find_current_step" do
+    subject { wizard.find_current_step }
+    it { is_expected.to be_instance_of TestWizard::Age }
+  end
+
+  describe "#previous_key" do
+    context "when there are earlier steps" do
+      subject { wizard.previous_key("age") }
+      it { is_expected.to eql "name" }
+    end
+
+    context "when there are no earlier steps" do
+      subject { wizard.previous_key("name") }
+      it { is_expected.to be_nil }
+    end
+
+    context "when no key supplied" do
+      subject { wizard.previous_key }
+      it { is_expected.to eql "name" }
+    end
+  end
+
+  describe "#next_key" do
+    context "when there are more steps" do
+      subject { wizard.next_key("age") }
+      it { is_expected.to eql "postcode" }
+    end
+
+    context "when there are no more steps" do
+      subject { wizard.next_key("postcode") }
+      it { is_expected.to be_nil }
+    end
+
+    context "when no key supplied" do
+      subject { wizard.next_key }
+      it { is_expected.to eql "postcode" }
+    end
+  end
+
+  describe "#valid?" do
+    let(:backingstore) { { "age" => 30, "postcode" => "TE571NG" } }
+
+    before do
+      allow_any_instance_of(TestWizard::Name).to \
+        receive(:valid?).and_return name_is_valid
+    end
+
+    subject { wizard.valid? }
+
+    context "with all steps completed" do
+      let(:name_is_valid) { true }
+      it { is_expected.to be true }
+    end
+
+    context "with missing step" do
+      let(:name_is_valid) { false }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "complete!" do
+    subject { wizardclass.new wizardstore, "postcode" }
+    before { allow(subject).to receive(:valid?).and_return steps_valid }
+
+    context "when valid" do
+      let(:steps_valid) { true }
+      it { is_expected.to have_attributes complete!: true }
+    end
+
+    context "when invalid" do
+      let(:steps_valid) { false }
+      it { is_expected.to have_attributes complete!: false }
+    end
+  end
+
+  describe "invalid_steps" do
+    let(:backingstore) { { "age" => 30 } }
+    subject { wizard.invalid_steps.map(&:key) }
+    it { is_expected.to eql %w[name postcode] }
+  end
+
+  describe "first_invalid_step" do
+    let(:backingstore) { { "name" => "test" } }
+    subject { wizard.first_invalid_step }
+    it { is_expected.to have_attributes key: "age" }
+  end
+
+  describe "skipped steps" do
+    before do
+      allow_any_instance_of(TestWizard::Age).to \
+        receive(:skipped?).and_return true
+    end
+
+    let(:current_step) { "name" }
+    subject { wizardclass.new wizardstore, current_step }
+
+    context "for the first step" do
+      it { is_expected.to have_attributes first_step?: true }
+      it { is_expected.to have_attributes next_key: "postcode" }
+    end
+
+    context "for the last step" do
+      let(:current_step) { "postcode" }
+      it { is_expected.to have_attributes last_step?: true }
+      it { is_expected.to have_attributes previous_key: "name" }
+    end
+
+    context "when last step skipped" do
+      before do
+        allow_any_instance_of(TestWizard::Postcode).to \
+          receive(:skipped?).and_return true
+      end
+      it { is_expected.to have_attributes next_key: nil }
+      it { is_expected.to have_attributes last_step?: true }
+      it { is_expected.to have_attributes first_step?: true }
+    end
+
+    context "with invalid steps" do
+      let(:backingstore) { { "name" => "test" } }
+      subject { wizard.invalid_steps.map(&:key) }
+      it { is_expected.to eql %w[postcode] }
+    end
+  end
+
+  describe "#export_data" do
+    subject { wizard.export_data }
+
+    it { is_expected.to include "name" => "Joe" }
+    it { is_expected.to include "age" => 35 }
+    it { is_expected.to include "postcode" => nil }
+
+    context "with skipped step" do
+      before do
+        allow_any_instance_of(TestWizard::Age).to \
+          receive(:skipped?).and_return true
+      end
+
+      it { is_expected.to include "name" => "Joe" }
+      it { is_expected.not_to include "age" }
+      it { is_expected.to include "postcode" => nil }
+    end
+  end
+end

--- a/spec/models/wizard/step_spec.rb
+++ b/spec/models/wizard/step_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe Wizard::Step do
+  include_context "wizard store"
+
+  class FirstStep < Wizard::Step
+    attribute :name
+    attribute :age, :integer
+    validates :name, presence: true
+  end
+
+  let(:attributes) { {} }
+  subject { FirstStep.new nil, wizardstore, attributes }
+
+  describe ".key" do
+    it { expect(described_class.key).to eql "step" }
+    it { expect(FirstStep.key).to eql "first_step" }
+  end
+
+  describe ".new" do
+    let(:attributes) { { age: "20" } }
+    it { is_expected.to be_instance_of FirstStep }
+    it { is_expected.to have_attributes key: "first_step" }
+    it { is_expected.to have_attributes id: "first_step" }
+    it { is_expected.to have_attributes persisted?: true }
+    it { is_expected.to have_attributes name: "Joe" }
+    it { is_expected.to have_attributes age: 20 }
+    it { is_expected.to have_attributes skipped?: false }
+  end
+
+  describe "#can_proceed" do
+    it { expect(subject).to be_can_proceed }
+  end
+
+  describe "#save" do
+    let(:backingstore) { {} }
+
+    context "when valid" do
+      let(:attributes) { { name: "Jane" } }
+      let!(:result) { subject.save }
+
+      it { expect(result).to be true }
+      it { expect(wizardstore[:name]).to eql "Jane" }
+    end
+
+    context "when invalid" do
+      let(:attributes) { { age: 30 } }
+      let!(:result) { subject.save }
+
+      it { expect(result).to be false }
+      it { is_expected.to have_attributes errors: hash_including(:name) }
+    end
+  end
+
+  describe "#export" do
+    let(:backingstore) { { "name" => "Joe" } }
+    let(:instance) { FirstStep.new nil, wizardstore, age: 35 }
+    subject { instance.export }
+    it { is_expected.to include "name" => "Joe" }
+    it { is_expected.to include "age" => nil } # should only export persisted data
+  end
+end

--- a/spec/models/wizard/store_spec.rb
+++ b/spec/models/wizard/store_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe Wizard::Store do
+  let(:backingstore) do
+    { "first_name" => "Joe", "age" => 20, "region" => "Manchester" }
+  end
+  let(:instance) { described_class.new backingstore }
+  subject { instance }
+
+  describe ".new" do
+    context "with valid source data" do
+      it { is_expected.to be_instance_of(Wizard::Store) }
+      it { is_expected.to have_attributes data: backingstore }
+      it { is_expected.to respond_to :[] }
+      it { is_expected.to respond_to :[]= }
+    end
+
+    context "with invalid source data" do
+      subject { described_class.new nil }
+
+      it "should raise an InvalidBackingStore" do
+        expect { subject }.to raise_exception(Wizard::Store::InvalidBackingStore)
+      end
+    end
+  end
+
+  describe "#[]" do
+    context "first_name" do
+      subject { instance["first_name"] }
+      it { is_expected.to eql "Joe" }
+    end
+
+    context "age" do
+      subject { instance["age"] }
+      it { is_expected.to eql 20 }
+    end
+  end
+
+  describe "#[]=" do
+    it "will update stored value" do
+      expect { subject["first_name"] = "Jane" }.to \
+        change { subject["first_name"] }.from("Joe").to("Jane")
+    end
+  end
+
+  describe "#fetch" do
+    context "with multiple keys" do
+      subject { instance.fetch :first_name, :region }
+      it "will return hash of requested keys" do
+        is_expected.to eql({ "first_name" => "Joe", "region" => "Manchester" })
+      end
+    end
+
+    context "with array of keys" do
+      subject { instance.fetch %w[first_name region] }
+      it "will return hash of requested keys" do
+        is_expected.to eql({ "first_name" => "Joe", "region" => "Manchester" })
+      end
+    end
+  end
+
+  describe "#purge!" do
+    before { instance.purge! }
+    subject { instance.keys }
+
+    it "will remove all keys" do
+      is_expected.to have_attributes empty?: true
+    end
+  end
+
+  describe "#to_camelized_hash" do
+    subject { instance.to_camelized_hash }
+    it "returns returns a hash with camelCase keys" do
+      is_expected.to eq(firstName: "Joe", age: 20, region: "Manchester")
+    end
+  end
+end

--- a/spec/support/shared_examples/wizard_support.rb
+++ b/spec/support/shared_examples/wizard_support.rb
@@ -1,0 +1,51 @@
+RSpec.shared_context "wizard store" do
+  let(:backingstore) { { "name" => "Joe", "age" => 35 } }
+  let(:wizardstore) { Wizard::Store.new backingstore }
+end
+
+RSpec.shared_context "wizard step" do
+  include_context "wizard store"
+  let(:attributes) { {} }
+  let(:instance) { described_class.new nil, wizardstore, attributes }
+  subject { instance }
+end
+
+RSpec.shared_examples "a wizard step" do
+  it { expect(subject.class).to respond_to :key }
+  it { is_expected.to respond_to :save }
+end
+
+RSpec.shared_examples "a wizard step that exposes API types as options" do |api_method|
+  it { expect(subject.class).to respond_to :options }
+
+  it "it exposes API types as options" do
+    types = [
+      GetIntoTeachingApiClient::TypeEntity.new(id: 1, value: "one"),
+      GetIntoTeachingApiClient::TypeEntity.new(id: 2, value: "two"),
+    ]
+
+    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+      receive(api_method) { types }
+
+    expect(described_class.options).to eq({ "one" => 1, "two" => 2 })
+  end
+end
+
+class TestWizard < Wizard::Base
+  class Name < Wizard::Step
+    attribute :name
+    validates :name, presence: true
+  end
+
+  class Age < Wizard::Step
+    attribute :age, :integer
+    validates :age, presence: true
+  end
+
+  class Postcode < Wizard::Step
+    attribute :postcode
+    validates :postcode, presence: true
+  end
+
+  self.steps = [Name, Age, Postcode].freeze
+end


### PR DESCRIPTION
We are going to transition the TTA sign up to use the same format/classes as the GiT app mailing list/event wizards. This commit adds the base/core classes for the Wizard, Store and Step models.

We should look to move these classes into a gem going forward so that we can reuse them between both apps.
