### PR TITLE
Decouple classes from the ApiClient

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,10 +12,10 @@ class PagesController < ApplicationController
 
     @privacy_policy = if policy_id
                         session[:privacy_policy_id] = policy_id
-                        ApiClient.get_privacy_policy(policy_id)
+                        GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_privacy_policy(policy_id)
                       else
                         # this should be removed when we have url checking
-                        ApiClient.get_latest_privacy_policy
+                        GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
                       end
 
     render template: "pages/privacy_policy"

--- a/app/validators/policy_validator.rb
+++ b/app/validators/policy_validator.rb
@@ -1,7 +1,7 @@
 class PolicyValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     begin
-      policy = ApiClient.send(options[:method], value)
+      policy = GetIntoTeachingApiClient::PrivacyPoliciesApi.new.send(options[:method], value) if value.present?
     rescue GetIntoTeachingApiClient::ApiError => e
       Rails.logger.error e # how do we handle a Bad Request ?
     end

--- a/app/validators/types_validator.rb
+++ b/app/validators/types_validator.rb
@@ -1,6 +1,6 @@
 class TypesValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    types = ApiClient.send(options[:method])
+    types = GetIntoTeachingApiClient::TypesApi.new.send(options[:method])
 
     unless types.map { |type| type.id.to_s }.include?(value.to_s)
       record.errors[attribute] << (options[:message] || "is not included in the list")

--- a/spec/validators/policy_validator_spec.rb
+++ b/spec/validators/policy_validator_spec.rb
@@ -1,14 +1,39 @@
 require "rails_helper"
 
-RSpec.describe PolicyValidator, type: :validator do
-  subject { build :accept_privacy_policy }
+class PolicyValidatable
+  include ActiveModel::Model
 
-  it "passes when accepted_policy_id exists" do
+  attr_accessor :policy_id
+
+  validates :policy_id, policy: { method: :get_privacy_policy }
+end
+
+RSpec.describe PolicyValidator, type: :validator do
+  subject { PolicyValidatable.new }
+
+  it "is valid when matches a policy" do
+    policy = GetIntoTeachingApiClient::PrivacyPolicy.new(id: "abc-123")
+
+    expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+      receive(:get_privacy_policy).with(policy.id).and_return(policy)
+
+    subject.policy_id = policy.id
     expect(subject).to be_valid
   end
 
-  it "raises invalid error when accepted_policy_id not returned by Api" do
-    subject.accepted_policy_id = "invalid_id"
+  it "is invalid when does not match a policy" do
+    expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+      receive(:get_privacy_policy).with("def-678").and_raise(GetIntoTeachingApiClient::ApiError)
+
+    subject.policy_id = "def-678"
+    expect(subject).to be_invalid
+  end
+
+  it "is invalid when given a nil policy id" do
+    expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to_not \
+      receive(:get_privacy_policy)
+
+    subject.policy_id = nil
     expect(subject).to be_invalid
   end
 end

--- a/spec/validators/types_validator_spec.rb
+++ b/spec/validators/types_validator_spec.rb
@@ -12,8 +12,10 @@ RSpec.describe TypesValidator, type: :validator do
   subject { TypeValidatable.new }
 
   before do
-    expect(ApiClient).to receive(:get_teaching_subjects)
-      .and_return([OpenStruct.new({ id: 1, value: "one" })])
+    expect_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+      receive(:get_teaching_subjects).and_return(
+        [OpenStruct.new({ id: 1, value: "one" })],
+      )
   end
 
   it "is invalid when null" do


### PR DESCRIPTION
The ApiClient will be removed along with the existing journey (once the new wizard is in place); instead we will call the GetIntoTeachingApiClient directly (adding the ApiClient is a needless abstraction; originally we thought it may do more, such as caching but that will be done in the gem itself going forward).

It is being decoupled in this commit from any classes/modules that will remain in the app once the old registrations flow is removed.