### PR TITLE
Add new TTA journey using the wizard

### DIFF
--- a/app/controllers/teacher_training_adviser/steps_controller.rb
+++ b/app/controllers/teacher_training_adviser/steps_controller.rb
@@ -1,0 +1,21 @@
+module TeacherTrainingAdviser
+  class StepsController < ApplicationController
+    include WizardSteps
+    self.wizard_class = TeacherTrainingAdviser::Wizard
+
+  private
+
+    def step_path(step = params[:id])
+      teacher_training_adviser_step_path step
+    end
+    helper_method :step_path
+
+    def wizard_store
+      ::Wizard::Store.new session_store
+    end
+
+    def session_store
+      session[:sign_up] ||= {}
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,4 +15,23 @@ module ApplicationHelper
 
     tag.body attributes, &block
   end
+
+  def govuk_form_for(*args, **options, &block)
+    merged = options.dup
+    merged[:builder] = GOVUKDesignSystemFormBuilder::FormBuilder
+    merged[:html] ||= {}
+    merged[:html][:novalidate] = true
+
+    form_for(*args, **merged, &block)
+  end
+
+  def back_link(path = :back, text: "Back", **options)
+    options[:class] = "govuk-back-link #{options[:class]}".strip
+
+    link_to text, path, **options
+  end
+
+  def link_to_change_answer(step)
+    link_to "Change", teacher_training_adviser_step_path(step.key)
+  end
 end

--- a/app/models/teacher_training_adviser/steps/accept_privacy_policy.rb
+++ b/app/models/teacher_training_adviser/steps/accept_privacy_policy.rb
@@ -1,0 +1,7 @@
+module TeacherTrainingAdviser::Steps
+  class AcceptPrivacyPolicy < Wizard::Step
+    attribute :accepted_policy_id, :string
+
+    validates :accepted_policy_id, policy: { method: :get_privacy_policy, message: "You must accept the privacy policy in order to talk to a teacher training adviser" }
+  end
+end

--- a/app/models/teacher_training_adviser/steps/date_of_birth.rb
+++ b/app/models/teacher_training_adviser/steps/date_of_birth.rb
@@ -1,0 +1,44 @@
+module TeacherTrainingAdviser::Steps
+  class DateOfBirth < Wizard::Step
+    attribute :date_of_birth, :date
+    attribute "date_of_birth(3i)", :string
+    attribute "date_of_birth(2i)", :string
+    attribute "date_of_birth(1i)", :string
+
+    before_validation :make_a_date
+
+    validates :date_of_birth, presence: { message: "You need to enter your date of birth" }
+    validate :date_cannot_be_in_the_future, :age_limit, :upper_age_limit
+
+    def date_cannot_be_in_the_future
+      if date_of_birth.present? && date_of_birth > Time.zone.today
+        errors.add(:date_of_birth, "Date can't be in the future")
+      end
+    end
+
+    def age_limit
+      if date_of_birth.present? && date_of_birth > Time.zone.today.years_ago(18)
+        errors.add(:date_of_birth, "You must be 18 years or older to use this service")
+      end
+    end
+
+    def upper_age_limit
+      if date_of_birth.present? && date_of_birth < Time.zone.today.years_ago(70)
+        errors.add(:date_of_birth, "You must be less than 70 years old")
+      end
+    end
+
+    def make_a_date
+      year = send("date_of_birth(1i)").to_i
+      month = send("date_of_birth(2i)").to_i
+      day = send("date_of_birth(3i)").to_i
+
+      begin
+        self.date_of_birth = Date.new(year, month, day)
+      # catch invalid dates, e.g. 31 Feb
+      rescue ArgumentError
+        nil
+      end
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
@@ -1,0 +1,17 @@
+module TeacherTrainingAdviser::Steps
+  class GcseMathsEnglish < Wizard::Step
+    attribute :has_gcse_maths_and_english_id, :integer
+
+    validates :has_gcse_maths_and_english_id, types: { method: :get_candidate_retake_gcse_status, message: "You must select either yes or no" }
+
+    OPTIONS = Crm::OPTIONS
+
+    def skipped?
+      @store["returning_to_teaching"] ||
+        [
+          TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying],
+          TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree],
+        ].none?(@store["degree_options"])
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_science.rb
@@ -1,0 +1,18 @@
+module TeacherTrainingAdviser::Steps
+  class GcseScience < Wizard::Step
+    attribute :has_gcse_science_id, :integer
+
+    validates :has_gcse_science_id, types: { method: :get_candidate_retake_gcse_status, message: "You must select either yes or no" }
+
+    OPTIONS = Crm::OPTIONS
+
+    def skipped?
+      @store["returning_to_teaching"] ||
+        @store["preferred_education_phase_id"] == TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary] ||
+        [
+          TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying],
+          TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree],
+        ].none?(@store["degree_options"])
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/has_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/has_teacher_id.rb
@@ -1,0 +1,11 @@
+module TeacherTrainingAdviser::Steps
+  class HasTeacherId < Wizard::Step
+    attribute :has_id, :boolean
+
+    validates :has_id, inclusion: { in: [true, false], message: "You must select either yes or no" }
+
+    def skipped?
+      !@store["returning_to_teaching"]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/have_a_degree.rb
+++ b/app/models/teacher_training_adviser/steps/have_a_degree.rb
@@ -1,0 +1,49 @@
+module TeacherTrainingAdviser::Steps
+  class HaveADegree < Wizard::Step
+    attribute :degree_options, :string
+    attribute :degree_status_id, :integer
+    attribute :degree_type_id, :integer
+
+    DEGREE_OPTIONS = { degree: "degree", no: "no", studying: "studying", equivalent: "equivalent" }.freeze
+    STUDYING = -1 # degree_status_id will be overriden on subsequent step.
+    DEGREE_STATUS_OPTIONS = { yes: 222_750_000, no: 222_750_004, studying: STUDYING, first_year: 222_750_003, second_year: 222_750_002, final_year: 222_750_001, equivalent: 222_750_005 }.freeze
+    DEGREE_TYPE = { degree: 222_750_000, equivalent: 222_750_005 }.freeze
+
+    validates :degree_options, inclusion: { in: DEGREE_OPTIONS.values, message: "Select an option from the list" }
+
+    with_options if: -> { degree_options.present? } do |degree_option|
+      degree_option.validates :degree_status_id, inclusion: { in: DEGREE_STATUS_OPTIONS.values, message: "Select an option from the list" }
+      degree_option.validates :degree_type_id, inclusion: { in: DEGREE_TYPE.values }
+    end
+
+    def degree_options=(value)
+      super
+      set_degree_status
+      set_degree_type
+    end
+
+    def skipped?
+      @store["returning_to_teaching"]
+    end
+
+    def set_degree_status
+      self.degree_status_id = case degree_options
+                              when DEGREE_OPTIONS[:no]
+                                DEGREE_STATUS_OPTIONS[:no]
+                              when DEGREE_OPTIONS[:studying]
+                                DEGREE_STATUS_OPTIONS[:studying]
+                              else
+                                DEGREE_STATUS_OPTIONS[:yes]
+                              end
+    end
+
+    def set_degree_type
+      self.degree_type_id = case degree_options
+                            when DEGREE_OPTIONS[:equivalent]
+                              DEGREE_TYPE[:equivalent]
+                            else
+                              DEGREE_TYPE[:degree]
+                            end
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/identity.rb
+++ b/app/models/teacher_training_adviser/steps/identity.rb
@@ -1,0 +1,11 @@
+module TeacherTrainingAdviser::Steps
+  class Identity < ::Wizard::Step
+    attribute :email, :string
+    attribute :first_name, :string
+    attribute :last_name, :string
+
+    validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "You need to enter you email address" }, length: { maximum: 100 }
+    validates :first_name, presence: { message: "You need to enter your first name" }, length: { maximum: 256 }
+    validates :last_name, presence: { message: "You need to enter your last name" }, length: { maximum: 256 }
+  end
+end

--- a/app/models/teacher_training_adviser/steps/no_degree.rb
+++ b/app/models/teacher_training_adviser/steps/no_degree.rb
@@ -1,0 +1,11 @@
+module TeacherTrainingAdviser::Steps
+  class NoDegree < Wizard::Step
+    def can_proceed?
+      false
+    end
+
+    def skipped?
+      @store["degree_options"] != TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:no]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/overseas_callback.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_callback.rb
@@ -1,0 +1,13 @@
+module TeacherTrainingAdviser::Steps
+  class OverseasCallback < UkCallback
+    attribute :time_zone, :string
+
+    validates :time_zone, presence: { message: "Select a time zone" }
+
+    def skipped?
+      @store["returning_to_teaching"] ||
+        @store["degree_options"] != TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent] ||
+        @store["uk_or_overseas"] != TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/overseas_country.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_country.rb
@@ -1,0 +1,17 @@
+module TeacherTrainingAdviser::Steps
+  class OverseasCountry < Wizard::Step
+    extend ApiOptions
+    # overwrites UK default
+    attribute :country_id, :string
+
+    validates :country_id, types: { method: :get_country_types }
+
+    def self.options
+      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_country_types)
+    end
+
+    def skipped?
+      @store["uk_or_overseas"] == TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/overseas_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_telephone.rb
@@ -2,12 +2,7 @@ module TeacherTrainingAdviser::Steps
   class OverseasTelephone < Wizard::Step
     attribute :telephone, :string
 
-    validates :telephone,
-              length: { in: 5..20,
-                        too_short: "Telephone number is too short (minimum is 5 characters)",
-                        too_long: "Telephone number is too long (maximum is 20 characters)" },
-              format: { with: /\A[0-9\s+]+\z/, message: "Enter a telephone number in the correct format" },
-              allow_blank: true
+    validates :telephone, telephone: true, allow_blank: true
 
     def skipped?
       @store["uk_or_overseas"] == TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]

--- a/app/models/teacher_training_adviser/steps/overseas_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_telephone.rb
@@ -1,0 +1,16 @@
+module TeacherTrainingAdviser::Steps
+  class OverseasTelephone < Wizard::Step
+    attribute :telephone, :string
+
+    validates :telephone,
+              length: { in: 5..20,
+                        too_short: "Telephone number is too short (minimum is 5 characters)",
+                        too_long: "Telephone number is too long (maximum is 20 characters)" },
+              format: { with: /\A[0-9\s+]+\z/, message: "Enter a telephone number in the correct format" },
+              allow_blank: true
+
+    def skipped?
+      @store["uk_or_overseas"] == TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
@@ -1,0 +1,9 @@
+module TeacherTrainingAdviser::Steps
+  class PreviousTeacherId < Wizard::Step
+    attribute :teacher_id, :string
+
+    def skipped?
+      !@store["returning_to_teaching"] || @store["has_id"] != true
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/qualification_required.rb
+++ b/app/models/teacher_training_adviser/steps/qualification_required.rb
@@ -1,0 +1,14 @@
+module TeacherTrainingAdviser::Steps
+  class QualificationRequired < Wizard::Step
+    def can_proceed?
+      false
+    end
+
+    def skipped?
+      @store["returning_to_teaching"] || (
+        @store["planning_to_retake_gcse_maths_and_english_id"] != TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no] &&
+        @store["planning_to_retake_gcse_science_id"] != TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:no]
+      )
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
@@ -1,0 +1,15 @@
+module TeacherTrainingAdviser::Steps
+  class RetakeGcseMathsEnglish < Wizard::Step
+    attribute :planning_to_retake_gcse_maths_and_english_id, :integer
+
+    validates :planning_to_retake_gcse_maths_and_english_id, types: { method: :get_candidate_retake_gcse_status, message: "You must select either yes or no" }
+
+    OPTIONS = Crm::OPTIONS
+
+    def skipped?
+      @store["returning_to_teaching"] ||
+        @store["degree_options"] == TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent] ||
+        @store["has_gcse_maths_and_english_id"] != TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/retake_gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_science.rb
@@ -1,0 +1,15 @@
+module TeacherTrainingAdviser::Steps
+  class RetakeGcseScience < Wizard::Step
+    attribute :planning_to_retake_gcse_science_id, :integer
+
+    validates :planning_to_retake_gcse_science_id, types: { method: :get_candidate_retake_gcse_status, message: "You must select either yes or no" }
+
+    OPTIONS = Crm::OPTIONS
+
+    def skipped?
+      @store["returning_to_teaching"] ||
+        @store["degree_options"] == TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent] ||
+        @store["has_gcse_science_id"] != TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:no]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/returning_teacher.rb
+++ b/app/models/teacher_training_adviser/steps/returning_teacher.rb
@@ -1,0 +1,19 @@
+module TeacherTrainingAdviser::Steps
+  class ReturningTeacher < Wizard::Step
+    DEGREE_OPTIONS = { returner: "returner" }.freeze
+
+    attribute :returning_to_teaching, :boolean
+    attribute :degree_options, :string
+    attribute :preferred_education_phase_id
+
+    validates :returning_to_teaching, inclusion: { in: [true, false], message: "You must select either yes or no" }
+
+    def returning_to_teaching=(value)
+      super
+      return unless returning_to_teaching
+
+      self.degree_options = DEGREE_OPTIONS[:returner]
+      self.preferred_education_phase_id = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary].to_i
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/review_answers.rb
+++ b/app/models/teacher_training_adviser/steps/review_answers.rb
@@ -1,0 +1,11 @@
+module TeacherTrainingAdviser::Steps
+  class ReviewAnswers < Wizard::Step
+    attribute :confirmed, :boolean, default: -> { true }
+
+    validates :confirmed, inclusion: { in: [true] }
+
+    def answers
+      @answers ||= @wizard.export_data
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
@@ -1,0 +1,15 @@
+module TeacherTrainingAdviser::Steps
+  class StageInterestedTeaching < Wizard::Step
+    extend ApiOptions
+
+    attribute :preferred_education_phase_id, :integer
+
+    validates :preferred_education_phase_id, types: { method: :get_candidate_preferred_education_phases, message: "You must select either primary or secondary" }
+
+    OPTIONS = { primary: 222_750_000, secondary: 222_750_001 }.freeze
+
+    def skipped?
+      @store["returning_to_teaching"]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/stage_of_degree.rb
+++ b/app/models/teacher_training_adviser/steps/stage_of_degree.rb
@@ -1,0 +1,18 @@
+module TeacherTrainingAdviser::Steps
+  class StageOfDegree < Wizard::Step
+    extend ApiOptions
+    # overwrites session[:sign_up]["degree_status_id"]
+    attribute :degree_status_id, :integer
+
+    validates :degree_status_id, types: { method: :get_qualification_degree_status, message: "You must select an option" }
+
+    def skipped?
+      @store["returning_to_teaching"] ||
+        @store["degree_options"] != TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
+    end
+
+    def self.options
+      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_qualification_degree_status)
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -1,0 +1,34 @@
+module TeacherTrainingAdviser::Steps
+  class StartTeacherTraining < Wizard::Step
+    extend ApiOptions
+
+    attribute :initial_teacher_training_year_id, :integer
+
+    validates :initial_teacher_training_year_id, types: { method: :get_candidate_initial_teacher_training_years, message: "You must select an option from the list" }
+    validate :date_cannot_be_in_the_past, unless: :dont_know
+
+    def self.options
+      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_candidate_initial_teacher_training_years)
+    end
+
+    # sets year range for view, this must be within api range!
+    def year_range(number_of_years)
+      years = GetIntoTeachingApiClient::TypesApi.new.get_candidate_initial_teacher_training_years
+      years.select { |year| year.id.to_i == 12_917 || year.value.to_i.between?(Time.zone.today.year, Time.zone.today.next_year(number_of_years).year) }
+    end
+
+    def date_cannot_be_in_the_past
+      if initial_teacher_training_year_id.present? && initial_teacher_training_year_id.to_i < Time.zone.today.year
+        errors.add(:initial_teacher_training_year_id, "Date can't be in the past")
+      end
+    end
+
+    def dont_know
+      initial_teacher_training_year_id == TeacherTrainingAdviser::Steps::StartTeacherTraining.options["Not sure"].to_i
+    end
+
+    def skipped?
+      @store["returning_to_teaching"]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
@@ -1,0 +1,18 @@
+module TeacherTrainingAdviser::Steps
+  class SubjectInterestedTeaching < Wizard::Step
+    extend ApiOptions
+
+    attribute :preferred_teaching_subject_id, :string
+
+    validates :preferred_teaching_subject_id, types: { method: :get_teaching_subjects, message: "Please select a subject" }
+
+    def self.options
+      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects)
+    end
+
+    def skipped?
+      @store["returning_to_teaching"] ||
+        @store["preferred_education_phase_id"] != TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
+++ b/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
@@ -1,0 +1,17 @@
+module TeacherTrainingAdviser::Steps
+  class SubjectLikeToTeach < Wizard::Step
+    extend ApiOptions
+
+    attribute :preferred_teaching_subject_id, :string
+
+    validates :preferred_teaching_subject_id, types: { method: :get_teaching_subjects, message: "Please select maths, physics or modern foreign language" }
+
+    def self.options
+      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects)
+    end
+
+    def skipped?
+      !@store["returning_to_teaching"]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/subject_taught.rb
+++ b/app/models/teacher_training_adviser/steps/subject_taught.rb
@@ -1,0 +1,11 @@
+module TeacherTrainingAdviser::Steps
+  class SubjectTaught < Wizard::Step
+    attribute :subject_taught_id, :string
+
+    validates :subject_taught_id, types: { method: :get_teaching_subjects }
+
+    def skipped?
+      !@store["returning_to_teaching"]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/uk_address.rb
+++ b/app/models/teacher_training_adviser/steps/uk_address.rb
@@ -1,0 +1,17 @@
+module TeacherTrainingAdviser::Steps
+  class UkAddress < Wizard::Step
+    attribute :address_line1, :string
+    attribute :address_line2, :string
+    attribute :address_city, :string
+    attribute :address_postcode, :string
+
+    validates :address_line1, presence: { message: "Enter the first line of your address" }, length: { maximum: 1024 }
+    validates :address_line2, length: { maximum: 1024 }
+    validates :address_city, presence: { message: "Enter your town or city" }, length: { maximum: 128 }
+    validates :address_postcode, format: { with: /^([A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}|GIR ?0A{2})$/i, multiline: true, message: "Enter a real postcode" }
+
+    def skipped?
+      @store["uk_or_overseas"] != TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/uk_callback.rb
+++ b/app/models/teacher_training_adviser/steps/uk_callback.rb
@@ -1,0 +1,23 @@
+module TeacherTrainingAdviser::Steps
+  class UkCallback < Wizard::Step
+    attribute :telephone, :string
+    attribute :phone_call_scheduled_at, :datetime
+
+    validates :telephone, length: { minimum: 5, too_short: "Telephone number is too short (minimum is 5 characters)" }, format: { with: /\A[0-9\s+]+\z/, message: "Enter a telephone number in the correct format" }
+    validates :phone_call_scheduled_at, presence: true
+
+    def skipped?
+      @store["returning_to_teaching"] ||
+        @store["degree_options"] != TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent] ||
+        @store["uk_or_overseas"] != TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+    end
+
+    class << self
+      def grouped_quotas
+        GetIntoTeachingApiClient::CallbackBookingQuotasApi.new.get_callback_booking_quotas.group_by(&:day).reject do |day|
+          Date.parse(day) == Time.zone.today
+        end
+      end
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/uk_callback.rb
+++ b/app/models/teacher_training_adviser/steps/uk_callback.rb
@@ -3,7 +3,7 @@ module TeacherTrainingAdviser::Steps
     attribute :telephone, :string
     attribute :phone_call_scheduled_at, :datetime
 
-    validates :telephone, length: { minimum: 5, too_short: "Telephone number is too short (minimum is 5 characters)" }, format: { with: /\A[0-9\s+]+\z/, message: "Enter a telephone number in the correct format" }
+    validates :telephone, telephone: true, presence: { message: "Enter a telephone number" }
     validates :phone_call_scheduled_at, presence: true
 
     def skipped?

--- a/app/models/teacher_training_adviser/steps/uk_or_overseas.rb
+++ b/app/models/teacher_training_adviser/steps/uk_or_overseas.rb
@@ -1,0 +1,18 @@
+module TeacherTrainingAdviser::Steps
+  class UkOrOverseas < Wizard::Step
+    attribute :uk_or_overseas, :string
+    attribute :country_id, :string
+
+    OPTIONS = { uk: "UK", overseas: "Overseas" }.freeze
+
+    validates :uk_or_overseas, inclusion: { in: OPTIONS.values, message: "Select if you live in the UK or overseas" }
+    validates :country_id, types: { method: :get_country_types }, allow_nil: true
+
+    def uk_or_overseas=(value)
+      super
+      if value == "UK"
+        self.country_id = GetIntoTeachingApiClient::TypesApi.new.get_country_types.find { |v| v.value = "United Kingdom" }.id
+      end
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/uk_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/uk_telephone.rb
@@ -2,17 +2,7 @@ module TeacherTrainingAdviser::Steps
   class UkTelephone < Wizard::Step
     attribute :telephone, :string
 
-    validates :telephone,
-              length: {
-                in: 5..20,
-                too_short: "Telephone number is too short (minimum is 5 characters)",
-                too_long: "Telephone number is too long (maximum is 20 characters)",
-              },
-              format: {
-                with: /\A[0-9\s+]+\z/,
-                message: "Enter a telephone number in the correct format",
-              },
-              allow_blank: true
+    validates :telephone, telephone: true, allow_blank: true
 
     def skipped?
       @store["uk_or_overseas"] != TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]

--- a/app/models/teacher_training_adviser/steps/uk_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/uk_telephone.rb
@@ -1,0 +1,21 @@
+module TeacherTrainingAdviser::Steps
+  class UkTelephone < Wizard::Step
+    attribute :telephone, :string
+
+    validates :telephone,
+              length: {
+                in: 5..20,
+                too_short: "Telephone number is too short (minimum is 5 characters)",
+                too_long: "Telephone number is too long (maximum is 20 characters)",
+              },
+              format: {
+                with: /\A[0-9\s+]+\z/,
+                message: "Enter a telephone number in the correct format",
+              },
+              allow_blank: true
+
+    def skipped?
+      @store["uk_or_overseas"] != TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/what_degree_class.rb
+++ b/app/models/teacher_training_adviser/steps/what_degree_class.rb
@@ -1,0 +1,25 @@
+module TeacherTrainingAdviser::Steps
+  class WhatDegreeClass < Wizard::Step
+    extend ApiOptions
+
+    attribute :uk_degree_grade_id, :integer
+
+    validates :uk_degree_grade_id, types: { method: :get_qualification_uk_degree_grades, message: "You must select an option" }
+
+    def skipped?
+      @store["returning_to_teaching"] ||
+        [
+          TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying],
+          TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree],
+        ].none?(@store["degree_options"])
+    end
+
+    def studying?
+      @store["degree_options"] == TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
+    end
+
+    def self.options
+      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_qualification_uk_degree_grades)
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/what_subject_degree.rb
+++ b/app/models/teacher_training_adviser/steps/what_subject_degree.rb
@@ -1,0 +1,15 @@
+module TeacherTrainingAdviser::Steps
+  class WhatSubjectDegree < Wizard::Step
+    attribute :degree_subject, :string
+
+    validates :degree_subject, presence: true
+
+    def skipped?
+      @store["returning_to_teaching"] ||
+        [
+          TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying],
+          TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree],
+        ].none?(@store["degree_options"])
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/wizard.rb
+++ b/app/models/teacher_training_adviser/wizard.rb
@@ -1,0 +1,44 @@
+module TeacherTrainingAdviser
+  class Wizard < ::Wizard::Base
+    self.steps = [
+      Steps::Identity,
+      Steps::ReturningTeacher,
+      Steps::HaveADegree,
+      Steps::NoDegree,
+      Steps::StageOfDegree,
+      Steps::WhatSubjectDegree,
+      Steps::WhatDegreeClass,
+      Steps::StageInterestedTeaching,
+      Steps::GcseMathsEnglish,
+      Steps::RetakeGcseMathsEnglish,
+      Steps::QualificationRequired,
+      Steps::GcseScience,
+      Steps::RetakeGcseScience,
+      Steps::QualificationRequired,
+      Steps::SubjectInterestedTeaching,
+      Steps::StartTeacherTraining,
+      Steps::HasTeacherId,
+      Steps::PreviousTeacherId,
+      Steps::SubjectTaught,
+      Steps::SubjectLikeToTeach,
+      Steps::DateOfBirth,
+      Steps::UkOrOverseas,
+      Steps::UkAddress,
+      Steps::UkTelephone,
+      Steps::OverseasCountry,
+      Steps::OverseasTelephone,
+      Steps::UkCallback,
+      Steps::OverseasCallback,
+      Steps::ReviewAnswers,
+      Steps::AcceptPrivacyPolicy,
+    ].freeze
+
+    def complete!
+      super.tap do |result|
+        break unless result
+
+        @store.purge!
+      end
+    end
+  end
+end

--- a/app/validators/telephone_validator.rb
+++ b/app/validators/telephone_validator.rb
@@ -1,0 +1,27 @@
+class TelephoneValidator < ActiveModel::EachValidator
+  TELEPHONE_FORMAT = %r{\A[^a-zA-Z]+\z}.freeze
+  MINIMUM_LENGTH = 6
+  MAXIMUM_LENGTH = 20
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    record.errors.add(attribute, "Enter a telephone number in the correct format") if invalid_format?(value)
+    record.errors.add(attribute, "Telephone number is too short (minimum is 5 characters)") if too_short?(value)
+    record.errors.add(attribute, "Telephone number is too long (maximum is 20 characters)") if too_long?(value)
+  end
+
+private
+
+  def invalid_format?(telephone)
+    TELEPHONE_FORMAT !~ telephone
+  end
+
+  def too_short?(telephone)
+    telephone.to_s.length < MINIMUM_LENGTH
+  end
+
+  def too_long?(telephone)
+    telephone.to_s.length > MAXIMUM_LENGTH
+  end
+end

--- a/app/views/teacher_training_adviser/steps/_accept_privacy_policy.html.erb
+++ b/app/views/teacher_training_adviser/steps/_accept_privacy_policy.html.erb
@@ -1,0 +1,12 @@
+<% policy_id = session[:privacy_policy_id].presence || GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy.id %>
+
+<%= f.govuk_check_boxes_fieldset :accepted_policy_id, legend: { text: "Read and accept the privacy policy"} do %>
+  <p class="govuk-body">Our privacy notice explains how we use your personal data. It is important that you have read this notice before continuing.</p>
+
+  <div class="govuk-form-group">
+    <%= link_to "Privacy policy", privacy_policy_path(:id => policy_id) %>
+  </div>
+
+  <%= f.govuk_check_box :accepted_policy_id, policy_id, multiple: false, label: { text: "Accept the privacy policy"} %>
+
+ <% end %>

--- a/app/views/teacher_training_adviser/steps/_date_of_birth.html.erb
+++ b/app/views/teacher_training_adviser/steps/_date_of_birth.html.erb
@@ -1,0 +1,4 @@
+<%= f.govuk_date_field :date_of_birth,
+date_of_birth: true,
+legend: { text: 'Enter your date of birth' },
+hint_text: 'For example, 31 3 1980' %>

--- a/app/views/teacher_training_adviser/steps/_form.html.erb
+++ b/app/views/teacher_training_adviser/steps/_form.html.erb
@@ -1,0 +1,13 @@
+<p>
+  <%= back_link step_path(wizard.previous_key) if wizard.previous_key %>
+</p>
+
+<%= govuk_form_for current_step, url: step_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= render current_step.key, current_step: current_step, f: f %>
+
+  <% if wizard.can_proceed? %>
+    <%= f.govuk_submit(wizard.last_step? ? "Complete" : "Continue") %>
+  <% end %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_gcse_maths_english.html.erb
+++ b/app/views/teacher_training_adviser/steps/_gcse_maths_english.html.erb
@@ -1,0 +1,21 @@
+<%= f.govuk_radio_buttons_fieldset(:has_gcse_maths_and_english_id, legend: { text: 'Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?' }, inline: true ) do %>
+  <%= f.govuk_radio_button :has_gcse_maths_and_english_id, TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:yes], label: { text: 'Yes' } %>
+  <%= f.govuk_radio_button :has_gcse_maths_and_english_id, TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no], label: { text: 'No' } %>
+<% end %>
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      What is a GCSE?
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    GCSE stands for General Certificate of Secondary Education. It&apos;s the part of the National Curriculum taught to pupils aged 14 to 16.<br><br>
+    The Department for Education does not provide a list of qualifications that can be considered equivalent to GCSEs in English, maths and science. <br><br>
+    A training provider will look for evidence that an equivalent qualification:
+    <ul>
+      <li>meets the standard of GCSE grade 4 (C)</li>
+      <li>covers sufficient content</li>
+      <li>contains the breadth of content equal to that of a GCSE grade 4 (C)</li>
+    </ul>
+  </div>
+</details>

--- a/app/views/teacher_training_adviser/steps/_gcse_science.html.erb
+++ b/app/views/teacher_training_adviser/steps/_gcse_science.html.erb
@@ -1,0 +1,4 @@
+<%= f.govuk_radio_buttons_fieldset(:has_gcse_science_id, legend: { text: 'Do you have grade 4 (C) or above in GCSE science, or equivalent?'}, inline: true ) do %>
+  <%= f.govuk_radio_button :has_gcse_science_id, TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:yes], label: { text: 'Yes' } %>
+  <%= f.govuk_radio_button :has_gcse_science_id, TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:no], label: { text: 'No' } %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_has_teacher_id.html.erb
+++ b/app/views/teacher_training_adviser/steps/_has_teacher_id.html.erb
@@ -1,0 +1,4 @@
+<%= f.govuk_radio_buttons_fieldset(:has_id, legend: { text: 'Do you have your previous teacher reference number?'}, inline: true ) do %>
+  <%= f.govuk_radio_button :has_id, true, label: { text: 'Yes' } %>
+  <%= f.govuk_radio_button :has_id, false, label: { text: 'No' } %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_have_a_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_have_a_degree.html.erb
@@ -1,0 +1,7 @@
+<%= f.govuk_radio_buttons_fieldset(:degree_options, legend: { text: 'Do you have a degree?'},
+  hint_text: "You need to have a bachelor's degree, with honours." ) do %>
+  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree],  label: { text: 'Yes' } %>
+  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:no], label: { text: 'No' } %>
+  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying], label: { text: "I'm studying for a degree" } %>
+  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent], label: { text: 'I have an equivalent qualification from another country' } %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -1,0 +1,15 @@
+
+<%= f.govuk_fieldset legend: { text: 'About you' } do %>
+<p class="govuk-body">We need to collect some personal details to complete your registration.</p>
+
+  <%= f.govuk_text_field :first_name, width: 20,
+    label: { text: 'First name' } %>
+  <%= f.govuk_text_field :last_name, width: 20,
+    label: { text: 'Surname' } %>
+    <%= f.govuk_email_field :email, width: 20,
+    label: { text: 'Email address' } %>
+
+  <p class="govuk-body">Your details are protected under the terms of our <%= link_to "privacy notice", privacy_policy_path(:id => session[:privacy_policy_id].presence || GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy.id) %>.</p>
+
+  <p class="govuk-body">Our privacy notice explains how we use your personal data. It is important you have read this notice before signing up to get help from a teacher training advisor.</p>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_no_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_no_degree.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-form-group">
+  <h1 class="govuk-heading-l">If you do not have a degree</h1>
+    
+    <p class="govuk-body">You can study for a degree which includes teacher training and leads to Qualified Teacher Status (QTS).</p>
+
+    <p class="govuk-body">Courses take 1 to 4 years and may include one of these:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        Bachelor of Education degree (BEd)
+      </li>
+      <li>
+        Bachelor of Arts (BA) and Bachelor of Science (Bsc) with QTS
+      </li>
+    </ul>
+
+    <p class="govuk-body">Search <a href="http://ucas.com">UCAS</a> to find a degree leading to Qualified Teacher Status(QTS). </p>
+    
+    <p class="govuk-body">Return to the <a class="govuk-link" href='/'>Get into Teaching</a> home page.</p>
+    
+</div>

--- a/app/views/teacher_training_adviser/steps/_overseas_callback.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_callback.html.erb
@@ -1,0 +1,19 @@
+<%= f.govuk_fieldset legend: { text: 'You told us you live overseas' } do %>
+
+<p class="govuk-body">You need to speak to us and should book a call in advance. We will contact you once your call is booked.</p>
+<p class="govuk-body">You must have the details of your overseas qualifications when we contact you.</p>
+
+<%= f.govuk_phone_field :telephone, width: 20,
+  label: { text: 'Contact telephone number *' } %>
+
+<div class="govuk-form-group">
+  <%= f.label 'Select your time zone', class: "govuk-label" %>
+  <%= f.time_zone_select :time_zone, ActiveSupport::TimeZone.all.drop(1), {}, { class: "govuk-select" }  %>
+</div>
+
+<div class="govuk-form-group">
+  <%= f.label :phone_call_scheduled_at, "Select your preferred day and time for a callback", class: "govuk-label" %>
+  <%= f.select :phone_call_scheduled_at, format_booking_quotas(TeacherTrainingAdviser::Steps::OverseasCallback::grouped_quotas), {}, { class: "govuk-select" } %>
+</div>
+
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_overseas_country.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_country.html.erb
@@ -1,0 +1,9 @@
+<% countries = GetIntoTeachingApiClient::TypesApi.new.get_country_types.sort_by { |k| k.value } %>
+<% countries.delete_if { |k| k.value == "United Kingdom" } %>
+
+<%= f.govuk_collection_select :country_id,
+  countries,
+  :id,
+  :value,
+  label: { text: "Which country do you live in?", tag: "h1", size: "m" }
+%>

--- a/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
@@ -1,0 +1,5 @@
+<%= f.govuk_fieldset legend: { text: 'What is your telephone number?' } do %>
+  <%= f.govuk_phone_field :telephone, width: 20,
+  label: { text: 'Overseas telephone number (optional)' },
+  hint_text: "For international numbers include the country code" %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_previous_teacher_id.html.erb
+++ b/app/views/teacher_training_adviser/steps/_previous_teacher_id.html.erb
@@ -1,0 +1,4 @@
+<%= f.govuk_fieldset legend: { text: 'What is your previous teacher reference number?' } do %>
+  <%= f.govuk_text_field :teacher_id, width: 20,
+  label: { text: 'Teacher reference number (optional).' } %>
+  <% end %>

--- a/app/views/teacher_training_adviser/steps/_qualification_required.html.erb
+++ b/app/views/teacher_training_adviser/steps/_qualification_required.html.erb
@@ -1,0 +1,15 @@
+<h1 class="govuk-heading-l">Get the right GCSEs or equivalent qualifications</h1>
+
+<div class="govuk-form-group">
+
+    <p class="govuk-body">You need to pass the required GCSEs or complete the equivalency test in order to train to teach in England.</p>
+
+    <p class="govuk-body">To get the right GCSEs you will need to find a <a href="https://nationalcareers.service.gov.uk/find-a-course">GCSE training provider</a>.</p>
+
+    <p class="govuk-body">Once you find a training provider they may ask you to sit a GCSE, equivalency test, or offer other evidence to demonstrate your ability.</p>
+
+    <p class="govuk-body">Or</p>
+    
+    <p class="govuk-body">Return to the <a href='/'>Get into Teaching</a> homepage.</p>
+    
+</div>

--- a/app/views/teacher_training_adviser/steps/_retake_gcse_maths_english.html.erb
+++ b/app/views/teacher_training_adviser/steps/_retake_gcse_maths_english.html.erb
@@ -1,0 +1,4 @@
+<%= f.govuk_radio_buttons_fieldset(:planning_to_retake_gcse_maths_and_english_id, legend: { text: 'Are you planning to retake either English or maths (or both) GCSEs, or equivalent?'}, inline: true ) do %>
+  <%= f.govuk_radio_button :planning_to_retake_gcse_maths_and_english_id, TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:yes], label: { text: 'Yes' } %>
+  <%= f.govuk_radio_button :planning_to_retake_gcse_maths_and_english_id, TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no], label: { text: 'No' } %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_retake_gcse_science.html.erb
+++ b/app/views/teacher_training_adviser/steps/_retake_gcse_science.html.erb
@@ -1,0 +1,4 @@
+<%= f.govuk_radio_buttons_fieldset(:planning_to_retake_gcse_science_id, legend: { text: 'Are you planning to retake your science GCSE?'}, inline: true ) do %>
+  <%= f.govuk_radio_button :planning_to_retake_gcse_science_id, TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:yes], label: { text: 'Yes' } %>
+  <%= f.govuk_radio_button :planning_to_retake_gcse_science_id, TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:no], label: { text: 'No' } %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_returning_teacher.html.erb
+++ b/app/views/teacher_training_adviser/steps/_returning_teacher.html.erb
@@ -1,0 +1,4 @@
+<%= f.govuk_radio_buttons_fieldset(:returning_to_teaching, legend: { text: 'Are you returning to teaching?'}, hint_text: "If you have an overseas qualification that's equivalent to our qualified teacher status (QTS), then select the 'yes' option and take the 'returning to teaching' route.", inline: true ) do %>
+  <%= f.govuk_radio_button :returning_to_teaching, true, label: { text: 'Yes' } %>
+  <%= f.govuk_radio_button :returning_to_teaching, false, label: { text: 'No' } %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_review_answers.html.erb
+++ b/app/views/teacher_training_adviser/steps/_review_answers.html.erb
@@ -1,0 +1,50 @@
+<% answers = f.object.answers %>
+
+<div class="govuk-width-container">
+
+  <main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+
+        <h1 class="govuk-heading-l">Check your answers before you continue</h1>
+
+        <h2 class="govuk-heading-m">Personal details</h2>
+
+        <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/name', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/date_of_birth', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/address', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/email', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/telephone', locals: { answers: answers } %>
+        </dl>
+
+        <h2 class="govuk-heading-m">What you've told us</h2>
+
+        <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/returning_teacher', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/previous_teacher_id', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/subject_taught', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/subject_like_to_teach', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/have_a_degree', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/stage_of_degree', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/what_subject_degree', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/what_degree_class', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/stage_interested_teaching', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/subject_interested_teaching', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/gcse_maths_english', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/retake_gcse_maths_english', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/gcse_science', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/retake_gcse_science', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/start_teacher_training', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/uk_or_overseas', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/overseas_country', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/callback_date', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/callback_time', locals: { answers: answers } %>
+          <%= render partial: 'teacher_training_adviser/steps/review_answers/time_zone', locals: { answers: answers } %>
+        </dl>
+
+        <%= f.hidden_field(:confirmed) %>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/teacher_training_adviser/steps/_stage_interested_teaching.html.erb
+++ b/app/views/teacher_training_adviser/steps/_stage_interested_teaching.html.erb
@@ -1,0 +1,5 @@
+<%= f.govuk_radio_buttons_fieldset(:preferred_education_phase_id, legend: { text: 'Which stage are you interested in teaching?'},
+hint_text: "Select a stage even if you're not sure yet, as this will not affect the sign up process.", inline: true ) do %>
+  <%= f.govuk_radio_button :preferred_education_phase_id, TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:primary], label: { text: 'Primary' } %>
+  <%= f.govuk_radio_button :preferred_education_phase_id, TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary], label: { text: 'Secondary' } %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_stage_of_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_stage_of_degree.html.erb
@@ -1,0 +1,6 @@
+<%= f.govuk_radio_buttons_fieldset(:degree_status_id, legend: { text: 'In which year are you studying?'} ) do %>
+  <%= f.govuk_radio_button :degree_status_id, TeacherTrainingAdviser::Steps::StageOfDegree::options["Final year"], label: { text: 'Final year' } %>
+  <%= f.govuk_radio_button :degree_status_id, TeacherTrainingAdviser::Steps::StageOfDegree::options["Second year"], label: { text: 'Second year' } %>
+  <%= f.govuk_radio_button :degree_status_id, TeacherTrainingAdviser::Steps::StageOfDegree::options["First year"], label: { text: "First year" } %>
+  <%= f.govuk_radio_button :degree_status_id, TeacherTrainingAdviser::Steps::StageOfDegree::options["Other"], label: { text: 'Other' } %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_start_teacher_training.html.erb
+++ b/app/views/teacher_training_adviser/steps/_start_teacher_training.html.erb
@@ -1,0 +1,6 @@
+<%= f.govuk_collection_select :initial_teacher_training_year_id,
+  f.object.year_range(3),
+  :id,
+  :value,
+  label: { text: "When do you want to start your teacher training?", tag: "h1", size: "m" }
+%>

--- a/app/views/teacher_training_adviser/steps/_subject_interested_teaching.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_interested_teaching.html.erb
@@ -1,0 +1,6 @@
+<%= f.govuk_collection_select :preferred_teaching_subject_id,
+  GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects,
+  :id,
+  :value,
+  label: { text: "Which subject would you like to teach?", tag: "h1", size: "m" }
+%>

--- a/app/views/teacher_training_adviser/steps/_subject_like_to_teach.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_like_to_teach.html.erb
@@ -1,0 +1,17 @@
+<%= f.govuk_radio_buttons_fieldset(:preferred_teaching_subject_id, legend: { text: 'Which subject would you like to teach if you return to teaching?' } ) do %>
+  <%= f.govuk_radio_button :preferred_teaching_subject_id, TeacherTrainingAdviser::Steps::SubjectLikeToTeach::options["Maths"], label: { text: 'Maths' } %>
+  <%= f.govuk_radio_button :preferred_teaching_subject_id, TeacherTrainingAdviser::Steps::SubjectLikeToTeach::options["Physics"], label: { text: 'Physics' } %>
+   <%= f.govuk_radio_button :preferred_teaching_subject_id, TeacherTrainingAdviser::Steps::SubjectLikeToTeach::options["Languages (other)"], label: { text: 'Modern foreign language' } %>
+<% end %>
+
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Can't see the subject you would like to teach?
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    If you want to return to teaching with a subject that is not listed above you can get further help by visiting the <a href="https://beta-getintoteaching.education.gov.uk/guidance#9" class="govuk-link">return to teaching guidance</a> page.
+  </div>
+</details>
+

--- a/app/views/teacher_training_adviser/steps/_subject_taught.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_taught.html.erb
@@ -1,0 +1,6 @@
+<%= f.govuk_collection_select :subject_taught_id,
+  GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects,
+  :id,
+  :value,
+  label: { text: "Which main subject did you previously teach?", tag: "h1", size: "m" }
+%>

--- a/app/views/teacher_training_adviser/steps/_uk_address.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_address.html.erb
@@ -1,0 +1,10 @@
+<%= f.govuk_fieldset legend: { text: 'What is your address?' } do %>
+  <%= f.govuk_text_field :address_line1, width: 20,
+    label: { text: 'Address line 1 *' } %>
+  <%= f.govuk_text_field :address_line2, width: 20,
+    label: { text: 'Address line 2' } %>
+  <%= f.govuk_text_field :address_city, width: 20,
+    label: { text: 'Town or City *' } %>
+  <%= f.govuk_text_field :address_postcode, width: 20,
+    label: { text: 'Postcode *' } %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
@@ -1,0 +1,14 @@
+<%= f.govuk_fieldset legend: { text: 'You told us you live in the United Kingdom' } do %>
+
+<p class="govuk-body">You need to speak to a teacher training adviser. You will have to book a call in advance.</p>
+<p class="govuk-body">For this, you must have the details of your overseas qualifications when they contact you.</p>
+
+<%= f.govuk_phone_field :telephone, width: 20,
+  label: { text: 'Contact telephone number *' } %>
+
+<div class="govuk-form-group">
+  <%= f.label :phone_call_scheduled_at, "Select your preferred day and time for a callback", class: "govuk-label" %>
+  <%= f.select :phone_call_scheduled_at, format_booking_quotas(TeacherTrainingAdviser::Steps::UkCallback::grouped_quotas, "London"), {}, { class: "govuk-select" } %>
+</div>
+
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_uk_or_overseas.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_or_overseas.html.erb
@@ -1,0 +1,4 @@
+<%= f.govuk_radio_buttons_fieldset(:uk_or_overseas, legend: { text: 'Where do you live?'}, inline: true) do %>
+  <%= f.govuk_radio_button :uk_or_overseas, 'UK', label: { text: 'UK' } %>
+  <%= f.govuk_radio_button :uk_or_overseas, 'Overseas', label: { text: 'Overseas' } %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
@@ -1,0 +1,4 @@
+<%= f.govuk_fieldset legend: { text: 'What is your telephone number?' } do %>
+  <%= f.govuk_phone_field :telephone, width: 20,
+  label: { text: 'UK telephone number (optional)' } %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_what_degree_class.html.erb
+++ b/app/views/teacher_training_adviser/steps/_what_degree_class.html.erb
@@ -1,0 +1,14 @@
+<% 
+if f.object.studying?
+  text = "What degree class are you predicted to get?"
+else
+  text = "Which class is your degree?"
+end 
+%>
+
+<%= f.govuk_collection_select :uk_degree_grade_id,
+  GetIntoTeachingApiClient::TypesApi.new.get_qualification_uk_degree_grades,
+  :id,
+  :value,
+  label: { text: text, tag: "h1", size: "m" }
+%>

--- a/app/views/teacher_training_adviser/steps/_what_subject_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_what_subject_degree.html.erb
@@ -1,0 +1,7 @@
+<%= f.govuk_collection_select :degree_subject,
+  GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects,
+  :value,
+  :value,
+  label: { text: "What subject is your degree?", tag: "h1", size: "m" },
+  hint_text: "If your subject is not listed choose the option that is nearest to your degree."
+%>

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -1,0 +1,25 @@
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-panel govuk-panel--confirmation">
+          <h1 class="govuk-panel__title">
+            Thank you <br> Sign up complete
+          </h1>
+        </div>
+        <h2 class="govuk-heading-m">What happens next</h2>
+
+        <p class="govuk-body">
+          We&apos;ve received your information. You&apos;ll get an email within 5 working days asking how you want to be contacted by the teacher training adviser.
+        </p>
+        <p class="govuk-body">
+          If you have any questions or you need to update any of the information you provided, speak to one of our advisers on Freephone <a href="tel:08003892500">0800 389 2500</a> between 8am - 8pm Monday to Friday.
+        </p>
+
+        <p class="govuk-body">
+          <a href="https://www.gov.uk/service-manual/service-assessments/get-feedback-page" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+        </p>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_address.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_address.html.erb
@@ -1,0 +1,21 @@
+<% return unless answers.key?("address_line1") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Address
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%
+      address = [
+        answers["address_line1"], 
+        answers["address_line2"], 
+        answers["address_city"], 
+        answers["address_postcode"],
+      ].compact
+    %>
+    <%= safe_format(address.reject(&:empty?).join("\n")) %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::UkAddress) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_callback_date.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_callback_date.html.erb
@@ -1,0 +1,19 @@
+<% return unless answers.key?("phone_call_scheduled_at") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Callback date
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">
+      <%= answers["phone_call_scheduled_at"].to_time.strftime("%d %m %Y") %>
+    </p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+  <% if answers["uk_or_overseas"] == TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk] %>
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::UkCallback) %>
+  <% else %>
+      <%= link_to_change_answer(TeacherTrainingAdviser::Steps::OverseasCallback) %>
+  <% end %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_callback_time.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_callback_time.html.erb
@@ -1,0 +1,19 @@
+<% return unless answers.key?("phone_call_scheduled_at") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Callback time
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">
+      <%= answers["phone_call_scheduled_at"].to_time.strftime("%H:%M") %>
+    </p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+  <% if answers["uk_or_overseas"] == TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk] %>
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::UkCallback) %>
+  <% else %>
+      <%= link_to_change_answer(TeacherTrainingAdviser::Steps::OverseasCallback) %>
+  <% end %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_date_of_birth.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_date_of_birth.html.erb
@@ -1,0 +1,13 @@
+<% return unless answers.key?("date_of_birth") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Date of birth
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= answers["date_of_birth"].to_date.strftime("%d %m %Y") %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::DateOfBirth) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_email.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_email.html.erb
@@ -1,0 +1,13 @@
+<% return unless answers.key?("email") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Email
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body"><%= answers["email"] %></p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::Identity) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_gcse_maths_english.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_gcse_maths_english.html.erb
@@ -1,0 +1,15 @@
+<% return unless answers.key?("has_gcse_maths_and_english_id") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Do you have grade 4 (C) or above in maths and English GCSE, or equivalent?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= 
+      TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS.key(answers["has_gcse_maths_and_english_id"]).to_s.capitalize
+    %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::GcseMathsEnglish) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_gcse_science.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_gcse_science.html.erb
@@ -1,0 +1,15 @@
+<% return unless answers.key?("has_gcse_science_id") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Do you have science GCSE Grade 4 or above?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= 
+      TeacherTrainingAdviser::Steps::GcseScience::OPTIONS.key(answers["has_gcse_science_id"]).to_s.capitalize
+    %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::GcseScience) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_have_a_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_have_a_degree.html.erb
@@ -1,0 +1,27 @@
+<% return unless answers.key?("degree_options") %>
+<% return if answers["returning_to_teaching"] == true %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Do you have a degree?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">
+      <%=
+        case answers["degree_options"]
+        when TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+          "Yes"
+        when TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:no]
+          "No"
+        when TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+          "Equivalent"
+        else
+          "Studying"
+        end
+      %>
+    </p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::HaveADegree) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_name.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_name.html.erb
@@ -1,0 +1,13 @@
+<% return unless answers.key?("first_name") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Name
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= "#{answers["first_name"]} #{answers["last_name"]}" %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::Identity) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_overseas_country.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_overseas_country.html.erb
@@ -1,0 +1,17 @@
+<% return unless answers.key?("country_id") && answers["uk_or_overseas"] == TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas] %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Which country do you live in?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">
+    <%=
+      TeacherTrainingAdviser::Steps::OverseasCountry.options.key(answers["country_id"])
+    %>
+    </p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::OverseasCountry) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_previous_teacher_id.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_previous_teacher_id.html.erb
@@ -1,0 +1,13 @@
+<% return unless answers["returning_to_teaching"] %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    What is your previous teacher reference number?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= answers["teacher_id"] %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::PreviousTeacherId) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_retake_gcse_maths_english.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_retake_gcse_maths_english.html.erb
@@ -1,0 +1,15 @@
+<% return unless answers.key?("planning_to_retake_gcse_maths_and_english_id") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+   Are you planning to retake your English or maths GCSEs?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= 
+      TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS.key(answers["planning_to_retake_gcse_maths_and_english_id"]).to_s.capitalize
+    %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_retake_gcse_science.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_retake_gcse_science.html.erb
@@ -1,0 +1,15 @@
+<% return unless answers.key?("planning_to_retake_gcse_science_id") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+   Are you planning to retake your science GCSE?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= 
+      TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS.key(answers["planning_to_retake_gcse_science_id"]).to_s.capitalize
+    %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::RetakeGcseScience) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_returning_teacher.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_returning_teacher.html.erb
@@ -1,0 +1,13 @@
+<% return unless answers.key?("returning_to_teaching") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Are you returning to teaching?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= answers["returning_to_teaching"] ? "Yes" : "No" %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::ReturningTeacher) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_stage_interested_teaching.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_stage_interested_teaching.html.erb
@@ -1,0 +1,16 @@
+<% return unless answers.key?("preferred_education_phase_id") %>
+<% return if answers["returning_to_teaching"] == true %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Which stage are you interested in teaching?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= 
+      TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS.key(answers["preferred_education_phase_id"]).to_s.capitalize
+    %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::StageInterestedTeaching) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_stage_of_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_stage_of_degree.html.erb
@@ -1,0 +1,16 @@
+<% return unless answers.key?("degree_status_id") %>
+<% return unless answers["degree_options"] == TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying] %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    In which year are you studying?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">
+      <%= GetIntoTeachingApiClient::TypesApi.new.get_qualification_degree_status.find { |status| status.id == answers["degree_status_id"].to_s }.value %>
+    </p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::StageOfDegree) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_start_teacher_training.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_start_teacher_training.html.erb
@@ -1,0 +1,15 @@
+<% return unless answers.key?("initial_teacher_training_year_id") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    When do you want to start teacher training?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= 
+      TeacherTrainingAdviser::Steps::StartTeacherTraining.options.key(answers["initial_teacher_training_year_id"].to_s)
+    %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::StartTeacherTraining) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_subject_interested_teaching.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_subject_interested_teaching.html.erb
@@ -1,0 +1,13 @@
+<% return unless answers.key?("preferred_teaching_subject_id") && answers["degree_options"] == TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent] %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Which subject are you interested in teaching?
+  </dt>
+  <dd class="govuk-summary-list__value">
+      <%= GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects.find { |subject| subject.id == answers["preferred_teaching_subject_id"] }.value %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::SubjectInterestedTeaching) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_subject_like_to_teach.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_subject_like_to_teach.html.erb
@@ -1,0 +1,14 @@
+<% return unless answers.key?("preferred_teaching_subject_id") && answers["returning_to_teaching"] == true %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Which subject would you like to teach if you return to teaching?
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">
+      <%= GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects.find { |subject| subject.id == answers["preferred_teaching_subject_id"] }.value %>
+    </p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::SubjectLikeToTeach) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_subject_taught.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_subject_taught.html.erb
@@ -1,0 +1,13 @@
+<% return unless answers.key?("subject_taught_id") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Which main subject did you previously teach?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects.find { |subject| subject.id == answers["subject_taught_id"] }.value %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::SubjectTaught) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_telephone.html.erb
@@ -1,0 +1,17 @@
+<% return unless answers.key?("telephone") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Telephone
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body"><%= answers["telephone"] %></p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+  <% if answers["uk_or_overseas"] == TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk] %>
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::UkTelephone) %>
+  <% else %>
+      <%= link_to_change_answer(TeacherTrainingAdviser::Steps::OverseasTelephone) %>
+  <% end %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_time_zone.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_time_zone.html.erb
@@ -1,0 +1,17 @@
+<% return unless answers.key?("time_zone") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Time zone
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body"><%= answers["time_zone"] %></p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+  <% if answers["uk_or_overseas"] == TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk] %>
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::UkCallback) %>
+  <% else %>
+      <%= link_to_change_answer(TeacherTrainingAdviser::Steps::OverseasCallback) %>
+  <% end %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_uk_or_overseas.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_uk_or_overseas.html.erb
@@ -1,0 +1,13 @@
+<% return unless answers.key?("uk_or_overseas") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Where do you live?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= answers["uk_or_overseas"] %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::UkOrOverseas) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_what_degree_class.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_what_degree_class.html.erb
@@ -1,0 +1,15 @@
+<% return unless answers.key?("degree_subject") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Which class is your degree?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">
+    <%= TeacherTrainingAdviser::Steps::WhatDegreeClass.options.key(answers["uk_degree_grade_id"].to_s) %>
+    </p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::WhatDegreeClass) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/review_answers/_what_subject_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/review_answers/_what_subject_degree.html.erb
@@ -1,0 +1,13 @@
+<% return unless answers.key?("degree_subject") %>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Which subject is your degree?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body"><%= answers["degree_subject"] %></p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to_change_answer(TeacherTrainingAdviser::Steps::WhatSubjectDegree) %>
+  </dd>
+</div>

--- a/app/views/teacher_training_adviser/steps/show.html.erb
+++ b/app/views/teacher_training_adviser/steps/show.html.erb
@@ -1,0 +1,1 @@
+<%= render "form", current_step: @current_step, wizard: @wizard %>

--- a/app/views/teacher_training_adviser/steps/update.html.erb
+++ b/app/views/teacher_training_adviser/steps/update.html.erb
@@ -1,0 +1,1 @@
+<%= render "form", current_step: @current_step, wizard: @wizard %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,16 @@
 Rails.application.routes.draw do
   root "pages#home"
+
+  namespace :teacher_training_adviser, path: "/teacher_training_adviser" do
+    resources :steps,
+              path: "/sign_up",
+              only: %i[index show update] do
+      collection do
+        get :completed
+      end
+    end
+  end
+
   get "/sitemap", to: "sitemaps#index"
   get "/healthcheck.json", to: "healthchecks#show", as: :healthcheck
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -1,0 +1,270 @@
+require "rails_helper"
+
+RSpec.feature "Sign up for a teacher training adviser", type: :feature do
+  scenario "a candidate that is a returning teacher" do
+    visit teacher_training_adviser_steps_path
+
+    expect(page).to have_text "About you"
+    fill_in_identity_step
+    click_on "Continue"
+
+    expect(page).to have_text "Are you returning to teaching?"
+    choose "Yes"
+    click_on "Continue"
+
+    expect(page).to have_text "Do you have your previous teacher reference number?"
+    choose "Yes"
+    click_on "Continue"
+
+    expect(page).to have_text "What is your previous teacher reference number?"
+    fill_in "Teacher reference number (optional)", with: "1234"
+    click_on "Continue"
+
+    expect(page).to have_text "Which main subject did you previously teach?"
+    select "Psychology"
+    click_on "Continue"
+
+    expect(page).to have_text "Which subject would you like to teach if you return to teaching?"
+    choose "Physics"
+    click_on "Continue"
+
+    expect(page).to have_text "Enter your date of birth"
+    fill_in_date_of_birth_step
+    click_on "Continue"
+
+    expect(page).to have_text "Where do you live?"
+    choose "UK"
+    click_on "Continue"
+
+    expect(page).to have_text "What is your address?"
+    fill_in_address_step
+    click_on "Continue"
+
+    expect(page).to have_text "What is your telephone number?"
+    fill_in "UK telephone number (optional)", with: "123456789"
+    click_on "Continue"
+
+    expect(page).to have_text "Check your answers before you continue"
+    click_on "Continue"
+
+    expect(page).to have_text "Read and accept the privacy policy"
+    check "Accept the privacy policy"
+    click_on "Complete"
+
+    expect(page).to have_text "Thank you"
+    expect(page).to have_text "Sign up complete"
+  end
+
+  scenario "a candidate with an equivalent degree" do
+    visit teacher_training_adviser_steps_path
+
+    expect(page).to have_text "About you"
+    fill_in_identity_step
+    click_on "Continue"
+
+    expect(page).to have_text "Are you returning to teaching?"
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_text "Do you have a degree?"
+    choose "I have an equivalent qualification from another country"
+    click_on "Continue"
+
+    expect(page).to have_text "Which stage are you interested in teaching?"
+    choose "Secondary"
+    click_on "Continue"
+
+    expect(page).to have_text "Which subject would you like to teach?"
+    select "Physics"
+    click_on "Continue"
+
+    expect(page).to have_text "When do you want to start your teacher training?"
+    select "2022"
+    click_on "Continue"
+
+    expect(page).to have_text "Enter your date of birth"
+    fill_in_date_of_birth_step
+    click_on "Continue"
+
+    expect(page).to have_text "Where do you live?"
+    choose "Overseas"
+    click_on "Continue"
+
+    expect(page).to have_text "Which country do you live in?"
+    select "Argentina"
+    click_on "Continue"
+
+    expect(page).to have_text "What is your telephone number?"
+    fill_in "Overseas telephone number (optional)", with: "123456789"
+    click_on "Continue"
+
+    expect(page).to have_text "You told us you live overseas"
+    select "(GMT-10:00) Hawaii"
+    click_on "Continue"
+
+    expect(page).to have_text "Check your answers before you continue"
+    click_on "Continue"
+
+    expect(page).to have_text "Read and accept the privacy policy"
+    check "Accept the privacy policy"
+    click_on "Complete"
+
+    expect(page).to have_text "Thank you"
+    expect(page).to have_text "Sign up complete"
+  end
+
+  scenario "a candidate studying for a degree" do
+    visit teacher_training_adviser_steps_path
+
+    expect(page).to have_text "About you"
+    fill_in_identity_step
+    click_on "Continue"
+
+    expect(page).to have_text "Are you returning to teaching?"
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_text "Do you have a degree?"
+    choose "I'm studying for a degree"
+    click_on "Continue"
+
+    expect(page).to have_text "In which year are you studying?"
+    choose "First year"
+    click_on "Continue"
+
+    expect(page).to have_text "What subject is your degree?"
+    select "Maths"
+    click_on "Continue"
+
+    expect(page).to have_text "What degree class are you predicted to get?"
+    select "2:2"
+    click_on "Continue"
+
+    expect(page).to have_text "Which stage are you interested in teaching?"
+    choose "Primary"
+    click_on "Continue"
+
+    expect(page).to have_text "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?"
+    choose "Yes"
+    click_on "Continue"
+
+    expect(page).to have_text "Do you have grade 4 (C) or above in GCSE science, or equivalent?"
+    choose "Yes"
+    click_on "Continue"
+
+    expect(page).to have_text "When do you want to start your teacher training?"
+    select "2022"
+    click_on "Continue"
+
+    expect(page).to have_text "Enter your date of birth"
+    fill_in_date_of_birth_step
+    click_on "Continue"
+
+    expect(page).to have_text "Where do you live?"
+    choose "Overseas"
+    click_on "Continue"
+
+    expect(page).to have_text "Which country do you live in?"
+    select "Argentina"
+    click_on "Continue"
+
+    expect(page).to have_text "What is your telephone number?"
+    fill_in "Overseas telephone number (optional)", with: "123456789"
+    click_on "Continue"
+
+    expect(page).to have_text "Check your answers before you continue"
+    click_on "Continue"
+
+    expect(page).to have_text "Read and accept the privacy policy"
+    check "Accept the privacy policy"
+    click_on "Complete"
+
+    expect(page).to have_text "Thank you"
+    expect(page).to have_text "Sign up complete"
+  end
+
+  scenario "a candidate without a degree" do
+    visit teacher_training_adviser_steps_path
+
+    expect(page).to have_text "About you"
+    fill_in_identity_step
+    click_on "Continue"
+
+    expect(page).to have_text "Are you returning to teaching?"
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_text "Do you have a degree?"
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_text "If you do not have a degree"
+    expect(page).to_not have_text "Continue"
+  end
+
+  scenario "a candidate without GCSEs" do
+    visit teacher_training_adviser_steps_path
+
+    expect(page).to have_text "About you"
+    fill_in_identity_step
+    click_on "Continue"
+
+    expect(page).to have_text "Are you returning to teaching?"
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_text "Do you have a degree?"
+    choose "Yes"
+    click_on "Continue"
+
+    expect(page).to have_text "What subject is your degree?"
+    select "Maths"
+    click_on "Continue"
+
+    expect(page).to have_text "Which class is your degree?"
+    select "2:2"
+    click_on "Continue"
+
+    expect(page).to have_text "Which stage are you interested in teaching?"
+    choose "Primary"
+    click_on "Continue"
+
+    expect(page).to have_text "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?"
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_text "Are you planning to retake either English or maths (or both) GCSEs, or equivalent?"
+    choose "Yes"
+    click_on "Continue"
+
+    expect(page).to have_text "Do you have grade 4 (C) or above in GCSE science, or equivalent?"
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_text "Are you planning to retake your science GCSE?"
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_text "Get the right GCSEs or equivalent qualifications"
+    expect(page).to_not have_text "Continue"
+  end
+
+  def fill_in_identity_step
+    fill_in "First name", with: "John"
+    fill_in "Surname", with: "Doe"
+    fill_in "Email address", with: "john@doe.com"
+  end
+
+  def fill_in_date_of_birth_step
+    fill_in "Day", with: "24"
+    fill_in "Month", with: "03"
+    fill_in "Year", with: "1966"
+  end
+
+  def fill_in_address_step
+    fill_in "Address line 1 *", with: "7"
+    fill_in "Address line 2", with: "Main Street"
+    fill_in "Town or City *", with: "Edinburgh"
+    fill_in "Postcode *", with: "EH12 8JF"
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -54,4 +54,31 @@ RSpec.describe ApplicationHelper do
       it { is_expected.to have_css "body.homepage" }
     end
   end
+
+  describe "#govuk_form_for" do
+    it "renders a form with GOV.UK form builder" do
+      expect(govuk_form_for(StubModel.new, url: "http://test.com") {}).to eq(
+        "<form class=\"new_stub_model\" id=\"new_stub_model\" novalidate=\"novalidate\" "\
+        "action=\"http://test.com\" accept-charset=\"UTF-8\" method=\"post\"></form>",
+      )
+    end
+  end
+
+  describe "#back_link" do
+    it "renders a back link with GOV.UK class names" do
+      expect(back_link).to eq("<a class=\"govuk-back-link\" href=\"javascript:history.back()\">Back</a>")
+    end
+  end
+
+  describe "#link_to_change_answer" do
+    it "returns a link to the sign up step" do
+      expect(link_to_change_answer(TeacherTrainingAdviser::Steps::Identity)).to eq(
+        "<a href=\"/teacher_training_adviser/sign_up/identity\">Change</a>",
+      )
+    end
+  end
+
+  class StubModel
+    include ActiveModel::Model
+  end
 end

--- a/spec/models/teacher_training_adviser/steps/accept_privacy_policy_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/accept_privacy_policy_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::AcceptPrivacyPolicy do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  it { is_expected.to respond_to :accepted_policy_id }
+
+  context "accepted_policy_id" do
+    it "allows a valid privacy policy id" do
+      policy = GetIntoTeachingApiClient::PrivacyPolicy.new(id: "invalid-id")
+      allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+        receive(:get_privacy_policy).with(policy.id) { policy }
+      expect(subject).to allow_value(policy.id).for :accepted_policy_id
+    end
+    it { is_expected.to_not allow_value("invalid-id").for :accepted_policy_id }
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/date_of_birth_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/date_of_birth_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::DateOfBirth do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :date_of_birth }
+    it { is_expected.to respond_to "date_of_birth(3i)" }
+    it { is_expected.to respond_to "date_of_birth(2i)" }
+    it { is_expected.to respond_to "date_of_birth(1i)" }
+  end
+
+  describe "date_of_birth" do
+    it { is_expected.to_not allow_value(nil).for :date_of_birth }
+    it { is_expected.to_not allow_value(Date.new(1900, 1, 1)).for :date_of_birth }
+    it { is_expected.to_not allow_value(1.year.from_now).for :date_of_birth }
+    it { is_expected.to allow_value(18.years.ago).for :date_of_birth }
+  end
+
+  it "maps individual components to date_of_birth" do
+    subject.send("date_of_birth(1i)=", 2001)
+    subject.send("date_of_birth(2i)=", 4)
+    subject.send("date_of_birth(3i)=", 20)
+    subject.valid?
+    expect(subject.date_of_birth).to eq(Date.new(2001, 4, 20))
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/gcse_maths_english_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/gcse_maths_english_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::GcseMathsEnglish do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :has_gcse_maths_and_english_id }
+  end
+
+  describe "has_gcse_maths_and_english_id" do
+    it { is_expected.to_not allow_values(nil, 123).for :has_gcse_maths_and_english_id }
+    it { is_expected.to allow_values(*TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS.values).for :has_gcse_maths_and_english_id }
+  end
+
+  describe "#skipped?" do
+    it "returns false if degree_options is studying/degree" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
+      expect(subject).to_not be_skipped
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if degree_options is not studying/degree" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/gcse_science_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/gcse_science_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::GcseScience do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :has_gcse_science_id }
+  end
+
+  describe "has_gcse_science_id" do
+    it { is_expected.to_not allow_values(nil, 123).for :has_gcse_science_id }
+    it { is_expected.to allow_values(*TeacherTrainingAdviser::Steps::GcseScience::OPTIONS.values).for :has_gcse_science_id }
+  end
+
+  describe "#skipped?" do
+    it "returns false if degree_options is studying/degree and preferred_education_phase_id primary" do
+      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:primary]
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
+      expect(subject).to_not be_skipped
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if degree_options is not studying/degree" do
+      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:primary]
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if preferred_education_phase_id is secondary" do
+      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/has_teacher_id_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/has_teacher_id_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::HasTeacherId do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :has_id }
+  end
+
+  describe "has_id" do
+    it { is_expected.to_not allow_value(nil).for :has_id }
+    it { is_expected.to allow_values(true, false).for :has_id }
+  end
+
+  describe "#skipped?" do
+    it "returns false if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if returning_to_teaching is false" do
+      wizardstore["returning_to_teaching"] = false
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/have_a_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/have_a_degree_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::HaveADegree do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :degree_options }
+    it { is_expected.to respond_to :degree_status_id }
+    it { is_expected.to respond_to :degree_type_id }
+  end
+
+  describe "degree_options" do
+    it { is_expected.to_not allow_values("random", "", nil).for :degree_options }
+    it { is_expected.to allow_values(*TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS.values).for :degree_options }
+  end
+
+  describe "degree_status_id" do
+    context "when degree_options is set" do
+      before { subject.degree_options = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree] }
+
+      it { is_expected.to_not allow_values(1234, nil).for :degree_status_id }
+      it { is_expected.to allow_values(*TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_STATUS_OPTIONS.values).for :degree_status_id }
+    end
+
+    context "when degree_options is not set" do
+      it { is_expected.to allow_values(1234, nil).for :degree_status_id }
+    end
+  end
+
+  describe "degree_type_id" do
+    context "when degree_options is set" do
+      before { subject.degree_options = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree] }
+
+      it { is_expected.to_not allow_values(1234, nil).for :degree_type_id }
+      it { is_expected.to allow_values(*TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_TYPE.values).for :degree_type_id }
+    end
+
+    context "when degree_options is not set" do
+      it { is_expected.to allow_values(1234, nil).for :degree_type_id }
+    end
+  end
+
+  describe "#degree_option=" do
+    it "sets the correct degree_status_id/degree_type_id for value of degree" do
+      subject.degree_options = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      expect(subject.degree_status_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_STATUS_OPTIONS[:yes])
+      expect(subject.degree_type_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_TYPE[:degree])
+    end
+
+    it "sets the correct degree_status_id/degree_type_id when no" do
+      subject.degree_options = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:no]
+      expect(subject.degree_status_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_STATUS_OPTIONS[:no])
+      expect(subject.degree_type_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_TYPE[:degree])
+    end
+
+    it "sets the correct degree_status_id/degree_type_id when studying" do
+      subject.degree_options = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
+      expect(subject.degree_status_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_STATUS_OPTIONS[:studying])
+      expect(subject.degree_type_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_TYPE[:degree])
+    end
+
+    it "sets the correct degree_status_id/degree_type_id when equivalent" do
+      subject.degree_options = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      expect(subject.degree_status_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_STATUS_OPTIONS[:yes])
+      expect(subject.degree_type_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_TYPE[:equivalent])
+    end
+  end
+
+  describe "#skipped?" do
+    it "returns false if returning_to_teaching is false" do
+      wizardstore["returning_to_teaching"] = false
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/identity_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/identity_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::Identity do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :first_name }
+    it { is_expected.to respond_to :last_name }
+    it { is_expected.to respond_to :email }
+  end
+
+  describe "first_name" do
+    it { is_expected.to_not allow_values(nil, "", "a" * 257).for :first_name }
+    it { is_expected.to allow_values("John").for :first_name }
+  end
+
+  describe "last_name" do
+    it { is_expected.to_not allow_values(nil, "", "a" * 257).for :last_name }
+    it { is_expected.to allow_values("John").for :last_name }
+  end
+
+  describe "email" do
+    it { is_expected.to_not allow_values(nil, "", "a@#{"a" * 101}.com").for :email }
+    it { is_expected.to allow_values("test@test.com", "test%.mctest@domain.co.uk").for :email }
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/identity_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/identity_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::Identity do
   end
 
   describe "email" do
-    it { is_expected.to_not allow_values(nil, "", "a@#{"a" * 101}.com").for :email }
+    it { is_expected.to_not allow_values(nil, "", "a@#{'a' * 101}.com").for :email }
     it { is_expected.to allow_values("test@test.com", "test%.mctest@domain.co.uk").for :email }
   end
 end

--- a/spec/models/teacher_training_adviser/steps/no_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/no_degree_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::NoDegree do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  it { is_expected.to_not be_can_proceed }
+
+  describe "#skipped?" do
+    it "returns false if degree_options is no" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:no]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if degree_options is not no" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/overseas_callback_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_callback_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::OverseasCallback do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  it { expect(described_class).to be < TeacherTrainingAdviser::Steps::UkCallback }
+
+  context "attributes" do
+    it { is_expected.to respond_to :time_zone }
+  end
+
+  context "time_zone" do
+    it { is_expected.to_not allow_values("", nil).for :time_zone }
+    it { is_expected.to allow_values(ActiveSupport::TimeZone.all).for :time_zone }
+  end
+
+  describe "#skipped?" do
+    it "returns false if degree_options is equivalent and uk_or_overseas is overseas" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+      wizardstore["returning_to_teaching"] = false
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if degree_options is not equivalent" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+      wizardstore["returning_to_teaching"] = false
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if uk_or_overseas is not overseas" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+      wizardstore["returning_to_teaching"] = false
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if returning_to_teaching is true" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/overseas_country_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_country_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::OverseasCountry do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+  it_behaves_like "a wizard step that exposes API types as options", :get_country_types
+
+  context "attributes" do
+    it { is_expected.to respond_to :country_id }
+  end
+
+  describe "country_id" do
+    it "allows a valid country id" do
+      country = GetIntoTeachingApiClient::TypeEntity.new(id: "abc-123")
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_country_types) { [country] }
+      expect(subject).to allow_value(country.id).for :country_id
+    end
+    it { is_expected.to_not allow_values(nil, "", "def-123").for :country_id }
+  end
+
+  describe "#skipped?" do
+    it "returns false if uk_or_overseas is Overseas" do
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if uk_or_overseas is UK" do
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::OverseasTelephone do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :telephone }
+  end
+
+  describe "telephone" do
+    it { is_expected.to_not allow_values("abc12345", "12", "93837537372758327832726823").for :telephone }
+    it { is_expected.to allow_values(nil, "", "123456789").for :telephone }
+  end
+
+  describe "#skipped?" do
+    it "returns false if uk_or_overseas is Overseas" do
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if uk_or_overseas is UK" do
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTelephone do
   end
 
   describe "telephone" do
-    it { is_expected.to_not allow_values("abc12345", "12", "93837537372758327832726823").for :telephone }
-    it { is_expected.to allow_values(nil, "", "123456789").for :telephone }
+    it { is_expected.to_not allow_values("abc12345", "12", "1" * 21).for :telephone }
+    it { is_expected.to allow_values(nil, "123456789").for :telephone }
   end
 
   describe "#skipped?" do

--- a/spec/models/teacher_training_adviser/steps/previous_teacher_id_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/previous_teacher_id_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::PreviousTeacherId do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :teacher_id }
+  end
+
+  describe "#skipped?" do
+    it "returns false if returning_to_teaching is true and has_id is true" do
+      wizardstore["returning_to_teaching"] = true
+      wizardstore["has_id"] = true
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if has_id is false" do
+      wizardstore["returning_to_teaching"] = true
+      wizardstore["has_id"] = false
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if returning_to_teaching is false" do
+      wizardstore["returning_to_teaching"] = false
+      wizardstore["has_id"] = true
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if returning_to_teaching is false" do
+      wizardstore["uk_or_overseas"] = false
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/qualification_required_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/qualification_required_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::QualificationRequired do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  it { is_expected.to_not be_can_proceed }
+
+  describe "#skipped?" do
+    it "returns false if planning_to_retake_gcse_maths_and_english_id is no" do
+      wizardstore["planning_to_retake_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns false if planning_to_retake_gcse_science_id is no" do
+      wizardstore["planning_to_retake_gcse_science_id"] = TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:no]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if planning_to_retake_gcse_maths_and_english_id is not no" do
+      wizardstore["planning_to_retake_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:yes]
+      expect(subject).to be_skipped
+      wizardstore["planning_to_retake_gcse_maths_and_english_id"] = nil
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/retake_gcse_maths_english_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/retake_gcse_maths_english_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :planning_to_retake_gcse_maths_and_english_id }
+  end
+
+  describe "planning_to_retake_gcse_maths_and_english_id" do
+    it { is_expected.to_not allow_values(nil, 123).for :planning_to_retake_gcse_maths_and_english_id }
+    it { is_expected.to allow_values(*TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS.values).for :planning_to_retake_gcse_maths_and_english_id }
+  end
+
+  describe "#skipped?" do
+    it "returns false if has_gcse_maths_and_english_id is no" do
+      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if degree_options is equivalent" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if has_gcse_maths_and_english_id is not not no" do
+      wizardstore["has_gcse_maths_and_english_id"] = nil
+      expect(subject).to be_skipped
+      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:yes]
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/retake_gcse_science_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/retake_gcse_science_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::RetakeGcseScience do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :planning_to_retake_gcse_science_id }
+  end
+
+  describe "planning_to_retake_gcse_science_id" do
+    it { is_expected.to_not allow_values(nil, 123).for :planning_to_retake_gcse_science_id }
+    it { is_expected.to allow_values(*TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS.values).for :planning_to_retake_gcse_science_id }
+  end
+
+  describe "#skipped?" do
+    it "returns false if has_gcse_science_id is no" do
+      wizardstore["has_gcse_science_id"] = TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:no]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if degree_options is equivalent" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if has_gcse_science_id is not not no" do
+      wizardstore["has_gcse_science_id"] = nil
+      expect(subject).to be_skipped
+      wizardstore["has_gcse_science_id"] = TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:yes]
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/returning_teacher_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/returning_teacher_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::ReturningTeacher do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :returning_to_teaching }
+    it { is_expected.to respond_to :degree_options }
+    it { is_expected.to respond_to :preferred_education_phase_id }
+  end
+
+  describe "#returning_to_teaching" do
+    it { is_expected.to_not allow_values("", nil).for :returning_to_teaching }
+    it { is_expected.to allow_value(true, false).for :returning_to_teaching }
+  end
+
+  describe "#returning_to_teaching=" do
+    it "sets degree_options and preferred_education_phase_id if returning_to_teaching is true" do
+      subject.returning_to_teaching = true
+      expect(subject.degree_options).to eq(TeacherTrainingAdviser::Steps::ReturningTeacher::DEGREE_OPTIONS[:returner])
+      expect(subject.preferred_education_phase_id).to eq(TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary])
+    end
+
+    it "does not set degree_options or preferred_education_phase_id if returning_to_teaching is false" do
+      subject.returning_to_teaching = false
+      expect(subject.degree_options).to be_nil
+      expect(subject.preferred_education_phase_id).to be_nil
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/review_answers_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/review_answers_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::ReviewAnswers do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  it { is_expected.to respond_to :confirmed }
+
+  describe "#confirmed" do
+    it "defaults to true" do
+      expect(subject.confirmed).to be_truthy
+    end
+
+    it { is_expected.to_not allow_value(false).for :confirmed }
+    it { is_expected.to allow_value(true).for :confirmed }
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/stage_interested_teaching_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/stage_interested_teaching_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::StageInterestedTeaching do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :preferred_education_phase_id }
+  end
+
+  describe "#preferred_education_phase_id" do
+    it { is_expected.to_not allow_values("", nil, 123).for :preferred_education_phase_id }
+    it { is_expected.to allow_value(*TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS.values).for :preferred_education_phase_id }
+  end
+
+  describe "#skipped?" do
+    it "returns false if returning_to_teaching is false" do
+      wizardstore["returning_to_teaching"] = false
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/stage_of_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/stage_of_degree_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::StageOfDegree do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+  it_behaves_like "a wizard step that exposes API types as options", :get_qualification_degree_status
+
+  context "attributes" do
+    it { is_expected.to respond_to :degree_status_id }
+  end
+
+  describe "#degree_status_id" do
+    it "allows a valid degree status id" do
+      status = GetIntoTeachingApiClient::TypeEntity.new(id: 123)
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_qualification_degree_status) { [status] }
+      expect(subject).to allow_value(status.id).for :degree_status_id
+    end
+
+    it { is_expected.to_not allow_values("", nil, 456).for :degree_status_id }
+  end
+
+  describe "#skipped?" do
+    it "returns false if degree_options is studying" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if degree_options is not studying" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+  it_behaves_like "a wizard step that exposes API types as options", :get_candidate_initial_teacher_training_years
+
+  context "attributes" do
+    it { is_expected.to respond_to :initial_teacher_training_year_id }
+  end
+
+  describe "#initial_teacher_training_year_id" do
+    it "allows a valid initial_teacher_training_year_id" do
+      year = GetIntoTeachingApiClient::TypeEntity.new(id: 12_917)
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_candidate_initial_teacher_training_years) { [year] }
+      expect(subject).to allow_value(12_917).for :initial_teacher_training_year_id
+    end
+
+    it { is_expected.to_not allow_values("", nil, 456).for :initial_teacher_training_year_id }
+  end
+
+  describe "#year_range" do
+    before do
+      year1 = GetIntoTeachingApiClient::TypeEntity.new(id: 12_917, value: "Not sure")
+      year2 = GetIntoTeachingApiClient::TypeEntity.new(id: 12_918, value: 2020)
+      year3 = GetIntoTeachingApiClient::TypeEntity.new(id: 12_919, value: 2021)
+      year4 = GetIntoTeachingApiClient::TypeEntity.new(id: 12_920, value: 2022)
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_candidate_initial_teacher_training_years) { [year1, year2, year3, year4] }
+    end
+
+    let(:years) { subject.year_range(1) }
+
+    it "returns 'Not sure', the current year and the next year" do
+      expect(years.map(&:value)).to eq(["Not sure", 2020, 2021])
+    end
+  end
+
+  describe "#dont_know" do
+    it "returns true if the set year is 'Dont know'" do
+      subject.initial_teacher_training_year_id = TeacherTrainingAdviser::Steps::StartTeacherTraining.options["Not sure"]
+      expect(subject.dont_know).to be_truthy
+    end
+
+    it "returns false if the set year is not 'Dont know'" do
+      subject.initial_teacher_training_year_id = -1
+      expect(subject.dont_know).to be_falsy
+    end
+  end
+
+  describe "#skipped?" do
+    it "returns false if returning_to_teaching is false" do
+      wizardstore["returning_to_teaching"] = false
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::SubjectInterestedTeaching do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+  it_behaves_like "a wizard step that exposes API types as options", :get_teaching_subjects
+
+  context "attributes" do
+    it { is_expected.to respond_to :preferred_teaching_subject_id }
+  end
+
+  describe "#preferred_teaching_subject_id" do
+    it "allows a valid preferred_teaching_subject_id" do
+      subject_type = GetIntoTeachingApiClient::TypeEntity.new(id: "abc-123")
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_teaching_subjects) { [subject_type] }
+      expect(subject).to allow_value(subject_type.id).for :preferred_teaching_subject_id
+    end
+
+    it { is_expected.to_not allow_values("", nil, "invalid-id").for :preferred_teaching_subject_id }
+  end
+
+  describe "#skipped?" do
+    it "returns false if returning_to_teaching is false and preferred_education_phase_id is secondary" do
+      wizardstore["returning_to_teaching"] = false
+      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if preferred_education_phase_id is not secondary" do
+      wizardstore["returning_to_teaching"] = false
+      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:primary]
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if returning_to_teaching is not false" do
+      wizardstore["returning_to_teaching"] = true
+      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/subject_like_to_teach_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_like_to_teach_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::SubjectLikeToTeach do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+  it_behaves_like "a wizard step that exposes API types as options", :get_teaching_subjects
+
+  context "attributes" do
+    it { is_expected.to respond_to :preferred_teaching_subject_id }
+  end
+
+  describe "#preferred_teaching_subject_id" do
+    it "allows a valid preferred_teaching_subject_id" do
+      subject_type = GetIntoTeachingApiClient::TypeEntity.new(id: "abc-123")
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_teaching_subjects) { [subject_type] }
+      expect(subject).to allow_value(subject_type.id).for :preferred_teaching_subject_id
+    end
+
+    it { is_expected.to_not allow_values("", nil, "invalid-id").for :preferred_teaching_subject_id }
+  end
+
+  describe "#skipped?" do
+    it "returns false if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if returning_to_teaching is false" do
+      wizardstore["returning_to_teaching"] = false
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::SubjectTaught do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :subject_taught_id }
+  end
+
+  describe "#subject_taught_id" do
+    it "allows a valid subject_taught_id" do
+      subject_type = GetIntoTeachingApiClient::TypeEntity.new(id: "abc-123")
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_teaching_subjects) { [subject_type] }
+      expect(subject).to allow_value(subject_type.id).for :subject_taught_id
+    end
+
+    it { is_expected.to_not allow_values("", nil, "invalid-id").for :subject_taught_id }
+  end
+
+  describe "#skipped?" do
+    it "returns false if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if returning_to_teaching is false" do
+      wizardstore["returning_to_teaching"] = false
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/uk_address_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_address_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::UkAddress do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :address_line1 }
+    it { is_expected.to respond_to :address_line2 }
+    it { is_expected.to respond_to :address_city }
+    it { is_expected.to respond_to :address_postcode }
+  end
+
+  describe "#address_line1" do
+    it { is_expected.to_not allow_values("", nil, "a" * 1025).for :address_line1 }
+    it { is_expected.to allow_values("7", "7 Main Street").for :address_line1 }
+  end
+
+  describe "#address_line2" do
+    it { is_expected.to_not allow_values("a" * 1025).for :address_line2 }
+end
+
+  describe "#address_city" do
+    it { is_expected.to_not allow_values("", nil, "a" * 129).for :address_city }
+    it { is_expected.to allow_value("Manchester").for :address_city }
+  end
+
+  describe "#address_postcode" do
+    it { is_expected.to_not allow_values("", nil).for :address_postcode }
+    it { is_expected.to allow_values("eh3 9eh", "TR1 1XY", "hs13eq").for :address_postcode }
+  end
+
+  describe "#skipped?" do
+    it "returns false if uk_or_overseas is UK" do
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if returning_to_teaching is Overseas" do
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/uk_address_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_address_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkAddress do
 
   describe "#address_line2" do
     it { is_expected.to_not allow_values("a" * 1025).for :address_line2 }
-end
+  end
 
   describe "#address_city" do
     it { is_expected.to_not allow_values("", nil, "a" * 129).for :address_city }

--- a/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
   end
 
   context "telephone" do
-    it { is_expected.to_not allow_values("", "12345uh", "123-123-123").for :telephone }
-    it { is_expected.to allow_values("123456", "123456 90").for :telephone }
+    it { is_expected.to_not allow_values(nil, "", "abc12345", "12", "1" * 21).for :telephone }
+    it { is_expected.to allow_values("123456789").for :telephone }
   end
 
   describe "#skipped?" do

--- a/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :phone_call_scheduled_at }
+    it { is_expected.to respond_to :telephone }
+  end
+
+  context "phone_call_scheduled_at" do
+    it { is_expected.to_not allow_values("", nil, "invalid_date").for :phone_call_scheduled_at }
+    it { is_expected.to allow_value(Time.zone.now).for :phone_call_scheduled_at }
+  end
+
+  context "telephone" do
+    it { is_expected.to_not allow_values("", "12345uh", "123-123-123").for :telephone }
+    it { is_expected.to allow_values("123456", "123456 90").for :telephone }
+  end
+
+  describe "#skipped?" do
+    it "returns false if degree_options is equivalent and uk_or_overseas is UK" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+      wizardstore["returning_to_teaching"] = false
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if degree_options is not equivalent" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+      wizardstore["returning_to_teaching"] = false
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if uk_or_overseas is not UK" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+      wizardstore["returning_to_teaching"] = false
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if returning_to_teaching is true" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to be_skipped
+    end
+  end
+
+  describe "#self.grouped_quotas" do
+    it "returns all quotas excluding today's date" do
+      today = DateTime.now
+      tomorrow = DateTime.now + 1.day
+
+      quotas = [
+        GetIntoTeachingApiClient::CallbackBookingQuota.new(day: today.strftime, start_at: today, end_at: today + 1.hour),
+        GetIntoTeachingApiClient::CallbackBookingQuota.new(day: tomorrow.strftime, start_at: tomorrow, end_at: tomorrow + 1.hour),
+      ]
+      allow_any_instance_of(GetIntoTeachingApiClient::CallbackBookingQuotasApi).to \
+        receive(:get_callback_booking_quotas).and_return(quotas)
+
+      grouped_quotas = described_class.grouped_quotas
+      expect(grouped_quotas.keys.any? { |day| Date.parse(day) == Time.zone.today }).to be_falsy
+      expect(grouped_quotas.keys.any? { |day| Date.parse(day) == Time.zone.tomorrow }).to be_truthy
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/uk_or_overseas_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_or_overseas_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::UkOrOverseas do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :uk_or_overseas }
+    it { is_expected.to respond_to :country_id }
+  end
+
+  describe "#uk_or_overseas" do
+    it { is_expected.to_not allow_value("").for :uk_or_overseas }
+    it { is_expected.to_not allow_value(nil).for :uk_or_overseas }
+    it { is_expected.to_not allow_value("Denmark").for :uk_or_overseas }
+    it { is_expected.to allow_values(*TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS.values).for :uk_or_overseas }
+  end
+
+  describe "#country_id" do
+    it "allows a valid country_id" do
+      country = GetIntoTeachingApiClient::TypeEntity.new(id: "abc-123")
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_country_types) { [country] }
+      expect(subject).to allow_value(country.id).for :country_id
+    end
+
+    it { is_expected.to allow_values(nil).for :country_id }
+    it { is_expected.to_not allow_value("").for :country_id }
+  end
+
+  describe "#uk_or_overseas=" do
+    it "sets country_id when UK" do
+      country = GetIntoTeachingApiClient::TypeEntity.new(id: "abc-123", value: "United Kingdom")
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_country_types) { [country] }
+
+      subject.uk_or_overseas = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+      expect(subject.country_id).to eq(country.id)
+    end
+
+    it "does nothing when overseas" do
+      subject.uk_or_overseas = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+      expect(subject.country_id).to be_nil
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/uk_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_telephone_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkTelephone do
   end
 
   describe "telephone" do
-    it { is_expected.to_not allow_values("abc12345", "12", "93837537372758327832726823").for :telephone }
-    it { is_expected.to allow_values(nil, "", "123456789").for :telephone }
+    it { is_expected.to_not allow_values("abc12345", "12", "1" * 21).for :telephone }
+    it { is_expected.to allow_values(nil, "123456789").for :telephone }
   end
 
   describe "#skipped?" do

--- a/spec/models/teacher_training_adviser/steps/uk_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_telephone_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::UkTelephone do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :telephone }
+  end
+
+  describe "telephone" do
+    it { is_expected.to_not allow_values("abc12345", "12", "93837537372758327832726823").for :telephone }
+    it { is_expected.to allow_values(nil, "", "123456789").for :telephone }
+  end
+
+  describe "#skipped?" do
+    it "returns false if uk_or_overseas is UK" do
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if returning_to_teaching is Overseas" do
+      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/what_degree_class_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/what_degree_class_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::WhatDegreeClass do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+  it_behaves_like "a wizard step that exposes API types as options", :get_qualification_uk_degree_grades
+
+  context "attributes" do
+    it { is_expected.to respond_to :uk_degree_grade_id }
+  end
+
+  describe "#uk_degree_grade_id" do
+    it "allows a valid uk_degree_grade_id" do
+      grade = GetIntoTeachingApiClient::TypeEntity.new(id: 123)
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_qualification_uk_degree_grades) { [grade] }
+      expect(subject).to allow_value(grade.id).for :uk_degree_grade_id
+    end
+
+    it { is_expected.to_not allow_values("", nil, 456).for :uk_degree_grade_id }
+  end
+
+  describe "#skipped?" do
+    it "returns false if degree_options is studying/degree" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
+      expect(subject).to_not be_skipped
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if degree_options is not studying/degree" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to be_skipped
+    end
+  end
+
+  describe "#studying?" do
+    it "returns true if degree_options is studying" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
+      expect(subject).to be_studying
+    end
+
+    it "returns false if degree_options is not studying" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      expect(subject).to_not be_studying
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::WhatSubjectDegree do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :degree_subject }
+  end
+
+  describe "#degree_subject" do
+    it { is_expected.to_not allow_values("", nil).for :degree_subject }
+    it { is_expected.to allow_value("Maths").for :degree_subject }
+  end
+
+  describe "#skipped?" do
+    it "returns false if degree_options is studying/degree" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
+      expect(subject).to_not be_skipped
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if degree_options is not studying/degree" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if returning_to_teaching is true" do
+      wizardstore["returning_to_teaching"] = true
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/wizard_spec.rb
+++ b/spec/models/teacher_training_adviser/wizard_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Wizard do
+  describe ".steps" do
+    subject { described_class.steps }
+
+    it do
+      is_expected.to eql [
+        TeacherTrainingAdviser::Steps::Identity,
+        TeacherTrainingAdviser::Steps::ReturningTeacher,
+        TeacherTrainingAdviser::Steps::HaveADegree,
+        TeacherTrainingAdviser::Steps::NoDegree,
+        TeacherTrainingAdviser::Steps::StageOfDegree,
+        TeacherTrainingAdviser::Steps::WhatSubjectDegree,
+        TeacherTrainingAdviser::Steps::WhatDegreeClass,
+        TeacherTrainingAdviser::Steps::StageInterestedTeaching,
+        TeacherTrainingAdviser::Steps::GcseMathsEnglish,
+        TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish,
+        TeacherTrainingAdviser::Steps::QualificationRequired,
+        TeacherTrainingAdviser::Steps::GcseScience,
+        TeacherTrainingAdviser::Steps::RetakeGcseScience,
+        TeacherTrainingAdviser::Steps::QualificationRequired,
+        TeacherTrainingAdviser::Steps::SubjectInterestedTeaching,
+        TeacherTrainingAdviser::Steps::StartTeacherTraining,
+        TeacherTrainingAdviser::Steps::HasTeacherId,
+        TeacherTrainingAdviser::Steps::PreviousTeacherId,
+        TeacherTrainingAdviser::Steps::SubjectTaught,
+        TeacherTrainingAdviser::Steps::SubjectLikeToTeach,
+        TeacherTrainingAdviser::Steps::DateOfBirth,
+        TeacherTrainingAdviser::Steps::UkOrOverseas,
+        TeacherTrainingAdviser::Steps::UkAddress,
+        TeacherTrainingAdviser::Steps::UkTelephone,
+        TeacherTrainingAdviser::Steps::OverseasCountry,
+        TeacherTrainingAdviser::Steps::OverseasTelephone,
+        TeacherTrainingAdviser::Steps::UkCallback,
+        TeacherTrainingAdviser::Steps::OverseasCallback,
+        TeacherTrainingAdviser::Steps::ReviewAnswers,
+        TeacherTrainingAdviser::Steps::AcceptPrivacyPolicy,
+      ]
+    end
+  end
+
+  describe "#complete!" do
+    let(:store) do
+      {
+        "email" => "email@address.com",
+        "first_name" => "Joe",
+        "last_name" => "Joseph",
+      }
+    end
+    let(:wizardstore) { Wizard::Store.new store }
+
+    subject { described_class.new wizardstore, "accept_privacy_policy" }
+
+    before { allow(subject).to receive(:valid?).and_return true }
+    before { subject.complete! }
+
+    it { is_expected.to have_received(:valid?) }
+    it { expect(store).to eql({}) }
+  end
+end

--- a/spec/requests/invalid_authenticity_token_spec.rb
+++ b/spec/requests/invalid_authenticity_token_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Invalid Authenticity Token", type: :request do
-  let(:identity) { build(:identity) }
-
   before do
     ActionController::Base.allow_forgery_protection = true
     allow(Raven).to receive(:capture_exception)
@@ -14,8 +12,9 @@ RSpec.describe "Invalid Authenticity Token", type: :request do
 
   describe "with an invalid authenticity token" do
     it "redirects to the session_expired page" do
-      params = { "authenticity_token" => "expired", identity: { email: "email@address.com", first_name: "first", last_name: "last" } }
-      post registrations_path(identity.step_name), params: params
+      identity_params = { email: "email@address.com", first_name: "first", last_name: "last" }
+      params = { "authenticity_token" => "expired", identity: identity_params }
+      put teacher_training_adviser_step_path(:identity), params: params
       expect(response).to redirect_to session_expired_path
       expect(Raven).to have_received(:capture_exception)
     end

--- a/spec/requests/sign_up_spec.rb
+++ b/spec/requests/sign_up_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::StepsController do
+  let(:model) { TeacherTrainingAdviser::Steps::Identity }
+  let(:step_path) { teacher_training_adviser_step_path model.key }
+
+  describe "#show" do
+    before { get step_path }
+    subject { response }
+    it { is_expected.to have_http_status :success }
+  end
+
+  describe "#update" do
+    let(:key) { model.model_name.param_key }
+
+    subject do
+      patch step_path, params: { key => params }
+      response
+    end
+
+    context "with valid data" do
+      let(:params) { { first_name: "John", last_name: "Doe", email: "john@doe.com" } }
+      it { is_expected.to redirect_to teacher_training_adviser_step_path("returning_teacher") }
+    end
+
+    context "with invalid data" do
+      let(:params) { { "email" => "invaild-email" } }
+      it { is_expected.to have_http_status :success }
+    end
+
+    context "for last step" do
+      let(:steps) { TeacherTrainingAdviser::Wizard.steps }
+      let(:model) { steps.last }
+      let(:params) { { accepted_policy_id: "abc-123" } }
+
+      context "when all valid" do
+        before do
+          steps.each do |step|
+            allow_any_instance_of(step).to receive(:valid?).and_return true
+          end
+        end
+
+        it { is_expected.to redirect_to completed_teacher_training_adviser_steps_path }
+      end
+
+      context "when there is an invalid step" do
+        let(:invalid_step) { steps.first }
+
+        before do
+          steps.each do |step|
+            allow_any_instance_of(step).to receive(:valid?).and_return true
+          end
+
+          allow_any_instance_of(invalid_step).to receive(:valid?).and_return false
+        end
+
+        it { is_expected.to redirect_to teacher_training_adviser_step_path(invalid_step.key) }
+      end
+    end
+  end
+
+  describe "#completed" do
+    subject do
+      get completed_teacher_training_adviser_steps_path
+      response
+    end
+    it { is_expected.to have_http_status :success }
+  end
+end

--- a/spec/validators/telephone_validator_spec.rb
+++ b/spec/validators/telephone_validator_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe TelephoneValidator do
+  class TelephoneTestModel
+    include ActiveModel::Model
+    attr_accessor :telephone
+    validates :telephone, telephone: true
+  end
+
+  before { instance.valid? }
+  subject { instance.errors.to_h }
+
+  context "when too short" do
+    let(:instance) { TelephoneTestModel.new(telephone: "123") }
+    it { is_expected.to include telephone: "Telephone number is too short (minimum is 5 characters)" }
+  end
+
+  context "when too long" do
+    let(:instance) { TelephoneTestModel.new(telephone: "1" * 21) }
+    it { is_expected.to include telephone: "Telephone number is too long (maximum is 20 characters)" }
+  end
+
+  context "when invalid format" do
+    let(:instance) { TelephoneTestModel.new(telephone: "abc123") }
+    it { is_expected.to include telephone: "Enter a telephone number in the correct format" }
+  end
+end

--- a/spec/vcr/https_/get-into-teaching-api-dev_london_cloudapps_digital/api/privacy_policies/invalid-id.yml
+++ b/spec/vcr/https_/get-into-teaching-api-dev_london_cloudapps_digital/api/privacy_policies/invalid-id.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://get-into-teaching-api-dev.london.cloudapps.digital/api/privacy_policies/invalid-id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swagger-Codegen/1.0.6/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - ENV[api_key]
+      Expect:
+      - ''
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      date:
+      - Sat, 22 Aug 2020 13:27:21 GMT
+      content-type:
+      - application/problem+json; charset=utf-8
+      content-length:
+      - '220'
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-vcap-request-id:
+      - cc2f367c-31f3-4e7e-77fe-5508573a881b
+    body:
+      encoding: UTF-8
+      string: '{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.1","title":"One
+        or more validation errors occurred.","status":400,"traceId":"|b5d48eaf-4e740aa9776a1edc.","errors":{"id":["The
+        value ''invalid-id'' is not valid."]}}'
+    http_version: '2'
+    adapter_metadata:
+      effective_url: https://get-into-teaching-api-dev.london.cloudapps.digital/api/privacy_policies/invalid-id
+  recorded_at: Sat, 22 Aug 2020 13:27:21 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
### Context

The current registration flow contains a lot of duplicate steps where the only difference is the contents of the `next_step` method. The models explicitly contain the branching information for every permutation, which makes the model hierarchy verbose: 

`models/start_teacher_training`
`models/equivalent/start_teacher_training`
`models/degree/start_teacher_training`
...etc...

Instead, the steps can be thought of as linear and a branch is simply skipping steps that are not in that particular journey. This is how the GiT app wizards work for mailing list/event sign ups and it results in more concise modelling.

Transitioning the TTA app to use the same wizard logic will have lots of benefits:

- The two apps will be more similar; if you understand how the wizard works you can rationalise both of the apps more easily. We could also extract the shared core/base wizard classes/modules into a shared gem.
- There will only need to be one model per step, instead of one model per step, per branch. This should reduce the complexity and amount of code.
- The answered steps can be determined by iterating over the list of steps, making the review answers step simpler.

### Changes proposed in this pull request

- Create models/views/wizard representing linear flow

Re-purposes the existing TTA sign up models and views; consolidating them so the same steps are reused throughout (instead of having a different model for the various branches, as the steps don't actually change). The journey is then controlled by a single wizard, with the steps determining if they should be shown or not depending on the data in the store from previous steps.

- Add controller/views for the wizard

Introduce the `StepsController` to control the Teacher Training Adviser wizard, along with the required views for `show`/`update`/`completed`.

Add feature tests for the core journeys and request specs to ensure it has the `WizardSteps` concern.

- Add custom telephone validator

Currently the telephone validation is done in each model, instead this creates a custom telephone validator and ensures it replicates the API validation logic (allow any non-letter character, between 5 and 20 characters in length).

- Update specs to hit new journey 

### Guidance to review

Best reviewed by-commit; it's a lot of changes but the commits are in logical order.

Although there are a lot of changes here, most of the code is copy/pasted from the existing registrations process (the models were already close to what we need for the linear flow) so the change shouldn't be as big/risky as it perhaps seems on the surface.

I've added a decent amount of feature tests to cover the different TTA journeys and they line up with the current Miro board flow diagram.

I'm not totally happy with the `ReviewAnswers` step at the moment; I've kept it close to how it was in the existing registrations flow to minimise the amount of changes here, but I expect to do a follow up PR to try and make it more generic - so the steps are determining which information appears in the completion flow via a single partial, instead of having conditional logic in lots of different partials (it's going to be slightly awkward as a step can result in multiple rows of information, not always adjacent to each other).
