### PR TITLE
Fix JS error when no back link is present

### DIFF
--- a/app/webpacker/scripts/back_link.js
+++ b/app/webpacker/scripts/back_link.js
@@ -1,4 +1,6 @@
 document.addEventListener("turbolinks:load", function () {
   var x = document.getElementById("backlink");
-  x.style.display = "inline-block";
+  if (x) {
+    x.style.display = "inline-block";
+  }
 });


### PR DESCRIPTION
If a back link is not on the page we get an error trying to modify the style of an undefined element.