### PR TITLE
change title to get an adviser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DFE-Digital Get Teacher Training Adviser Service
+# DFE-Digital Get An Adviser Service
 
 ![Build and Deploy](https://github.com/DFE-Digital/get-teacher-training-adviser-service/workflows/Build%20and%20Deploy/badge.svg)
 
@@ -111,6 +111,7 @@ password protection
 ## DevOps
 
 ### Docker
+
 The built docker container will be stored on the [Docker Hub](https://hub.docker.com/repository/docker/dfedigital/accessibility_crawler)
 
 ### OWASP Scanning
@@ -124,8 +125,9 @@ The following rules have been added:
 - 90022 IGNORE (500 Internal Server Error)
 
 ### Accessibility Scanning
+
 The [Scanner](https://github.com/DFE-Digital/accessibility-scanner) is employed to provide Accessibility Scanning within the pipeline.
 
 ### CVE Scanning
-The [Anchore Scanner](https://github.com/anchore/scan-action) will carry out CVE testing on the docker container. 
 
+The [Anchore Scanner](https://github.com/anchore/scan-action) will carry out CVE testing on the docker container.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
-    <title>Sign up to talk to a teacher training adviser</title>
+    <title>Sign up to get an adviser</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>
@@ -41,7 +41,7 @@
           <% end %>
         </div>
         <div class="govuk-header__content">
-          <%= link_to "Sign up to talk to a teacher training adviser", "/", class: "govuk-header__link govuk-header__link--service-name" %>
+          <%= link_to "Sign up to get an adviser", "/", class: "govuk-header__link govuk-header__link--service-name" %>
       </div>
     </header>
 

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -9,7 +9,7 @@
   <main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Sign up to talk to a teacher training adviser</h1>
+        <h1 class="govuk-heading-l">Sign up to get an adviser</h1>
 
         <p class="govuk-body">This service is for those who want to train to be a teacher in England.</p>
         <p class="govuk-body">All our teacher training advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training.</p>

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -3,6 +3,6 @@ require "rails_helper"
 RSpec.feature "View pages", type: :feature do
   scenario "Navigates to home page" do
     visit "/home"
-    expect(page).to have_text("Sign up to talk to a teacher training adviser\n")
+    expect(page).to have_text("Sign up to get an adviser\n")
   end
 end


### PR DESCRIPTION
### JIRA ticket number

### Context
We need to change title references to teacher training adviser to "get an adviser"
### Changes proposed in this pull request
Change page title, header bar and header text on home page to "get an adviser" 
### Guidance to review

