### PR TITLE
Fix typo in GCSE maths/english attribute

### DIFF
--- a/app/models/teacher_training_adviser/steps/qualification_required.rb
+++ b/app/models/teacher_training_adviser/steps/qualification_required.rb
@@ -7,8 +7,8 @@ module TeacherTrainingAdviser::Steps
     def skipped?
       equivalent_degree = @store["degree_options"] == "equivalent"
       returning_teacher = @store["returning_to_teaching"]
-      has_gcse_maths_english = @store["has_gcse_maths_english_id"] != TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
-      retaking_gcse_maths_english = @store["planning_to_retake_gcse_maths_english_id"] != TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
+      has_gcse_maths_english = @store["has_gcse_maths_and_english_id"] != TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
+      retaking_gcse_maths_english = @store["planning_to_retake_gcse_maths_and_english_id"] != TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
       phase_is_secondary = @store["preferred_education_phase_id"] == TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
       has_gcse_science = @store["has_gcse_science_id"] != TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:no]
       retaking_gcse_science = @store["planning_to_retake_gcse_science_id"] != TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:no]

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -219,7 +219,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       expect(page).to_not have_text "Continue"
     end
 
-    scenario "without GCSEs" do
+    scenario "without GCSEs, primary" do
       visit teacher_training_adviser_steps_path
 
       expect(page).to have_text "About you"
@@ -259,6 +259,45 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Continue"
 
       expect(page).to have_text "Are you planning to retake your science GCSE?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Get the right GCSEs or equivalent qualifications"
+      expect(page).to_not have_text "Continue"
+    end
+
+    scenario "without GCSEs, secondary" do
+      visit teacher_training_adviser_steps_path
+
+      expect(page).to have_text "About you"
+      fill_in_identity_step
+      click_on "Continue"
+
+      expect(page).to have_text "Are you returning to teaching?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have a degree?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_text "What subject is your degree?"
+      select "Maths"
+      click_on "Continue"
+
+      expect(page).to have_text "Which class is your degree?"
+      select "2:2"
+      click_on "Continue"
+
+      expect(page).to have_text "Which stage are you interested in teaching?"
+      choose "Secondary"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Are you planning to retake either English or maths (or both) GCSEs, or equivalent?"
       choose "No"
       click_on "Continue"
 

--- a/spec/models/teacher_training_adviser/steps/qualification_required_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/qualification_required_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::QualificationRequired do
   describe "#skipped?" do
     it "returns false if has gcse maths/english, primary, doesn't have or retaking gcse science" do
       wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:primary]
-      wizardstore["has_gcse_maths_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:yes]
+      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:yes]
       wizardstore["has_gcse_science_id"] = TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:no]
       wizardstore["planning_to_retake_gcse_science_id"] = TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:no]
       expect(subject).to_not be_skipped
@@ -17,8 +17,8 @@ RSpec.describe TeacherTrainingAdviser::Steps::QualificationRequired do
 
     it "returns false if does not have or planning to retake gcse maths/english, secondary" do
       wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
-      wizardstore["has_gcse_maths_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
-      wizardstore["planning_to_retake_gcse_maths_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
+      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
+      wizardstore["planning_to_retake_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
       expect(subject).to_not be_skipped
     end
 
@@ -34,13 +34,13 @@ RSpec.describe TeacherTrainingAdviser::Steps::QualificationRequired do
 
     it "returns true if preferred_education_phase_id is primary and has gcse maths/english" do
       wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
-      wizardstore["has_gcse_maths_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:yes]
+      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:yes]
       expect(subject).to be_skipped
     end
 
     it "returns true if preferred_education_phase_id is primary and retaking gcse maths/english" do
       wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
-      wizardstore["planning_to_retake_gcse_maths_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:yes]
+      wizardstore["planning_to_retake_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:yes]
       expect(subject).to be_skipped
     end
 


### PR DESCRIPTION
Fixes a typo in the GCSE maths/english attribute name and adds test coverage for the secondary path when the candidate has no GCSE's.