### PR TITLE
Fix review answer display issues

### DIFF
--- a/app/models/concerns/api_options.rb
+++ b/app/models/concerns/api_options.rb
@@ -1,5 +1,5 @@
 module ApiOptions
   def generate_api_options(api_call)
-    api_call.reduce({}) { |options, type| options.update(type.value => type.id) }
+    api_call.reduce({}) { |options, type| options.update(type.value => type.id.to_s) }
   end
 end

--- a/app/models/teacher_training_adviser/steps/have_a_degree.rb
+++ b/app/models/teacher_training_adviser/steps/have_a_degree.rb
@@ -24,7 +24,7 @@ module TeacherTrainingAdviser::Steps
 
     def reviewable_answers
       {
-        "degree_options" => degree_options.capitalize,
+        "degree_options" => I18n.t("have_a_degree.degree_options.#{degree_options}"),
       }
     end
 

--- a/app/models/teacher_training_adviser/steps/stage_of_degree.rb
+++ b/app/models/teacher_training_adviser/steps/stage_of_degree.rb
@@ -15,7 +15,7 @@ module TeacherTrainingAdviser::Steps
 
     def reviewable_answers
       super.tap do |answers|
-        answers["degree_status_id"] = self.class.options.key(degree_status_id)
+        answers["degree_status_id"] = self.class.options.key(degree_status_id.to_s)
       end
     end
 

--- a/app/models/teacher_training_adviser/steps/what_degree_class.rb
+++ b/app/models/teacher_training_adviser/steps/what_degree_class.rb
@@ -26,7 +26,7 @@ module TeacherTrainingAdviser::Steps
 
     def reviewable_answers
       super.tap do |answers|
-        answers["uk_degree_grade_id"] = self.class.options.key(uk_degree_grade_id)
+        answers["uk_degree_grade_id"] = self.class.options.key(uk_degree_grade_id.to_s)
       end
     end
   end

--- a/app/views/teacher_training_adviser/steps/_have_a_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_have_a_degree.html.erb
@@ -1,7 +1,7 @@
 <%= f.govuk_radio_buttons_fieldset(:degree_options, legend: { text: 'Do you have a degree?'},
   hint_text: "You need to have a bachelor's degree, with honours." ) do %>
-  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree],  label: { text: 'Yes' } %>
-  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:no], label: { text: 'No' } %>
-  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying], label: { text: "I'm studying for a degree" } %>
-  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent], label: { text: 'I have an equivalent qualification from another country' } %>
+  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree],  label: { text: t("have_a_degree.degree_options.degree") } %>
+  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:no], label: { text: t("have_a_degree.degree_options.no") } %>
+  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying], label: { text: t("have_a_degree.degree_options.studying") } %>
+  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent], label: { text: t("have_a_degree.degree_options.equivalent") } %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,12 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
+  have_a_degree:
+    degree_options:
+      degree: "Yes"
+      no: "No"
+      studying: "I'm studying for a degree"
+      equivalent: "I have an equivalent qualification from another country"
   answers:
     identity:
       name: "Name"

--- a/spec/models/teacher_training_adviser/steps/have_a_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/have_a_degree_spec.rb
@@ -82,6 +82,6 @@ RSpec.describe TeacherTrainingAdviser::Steps::HaveADegree do
   describe "#reviewable_answers" do
     subject { instance.reviewable_answers }
     before { instance.degree_options = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying] }
-    it { is_expected.to eq({ "degree_options" => "Studying" }) }
+    it { is_expected.to eq({ "degree_options" => "I'm studying for a degree" }) }
   end
 end

--- a/spec/support/shared_examples/wizard_support.rb
+++ b/spec/support/shared_examples/wizard_support.rb
@@ -27,7 +27,7 @@ RSpec.shared_examples "a wizard step that exposes API types as options" do |api_
     allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
       receive(api_method) { types }
 
-    expect(described_class.options).to eq({ "one" => 1, "two" => 2 })
+    expect(described_class.options).to eq({ "one" => "1", "two" => "2" })
   end
 end
 


### PR DESCRIPTION
A couple of the review answer values either weren't populating due to a type mismatch when keying a hash and another was showing an incorrect value for the `HaveADegree` answer (it was using the value we store, capitalized instead of what we display to the user).