### PR TITLE
Set force_ssl in production environments

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,6 +34,9 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
+  unless ENV["SKIPSSL"].in? %w[1 true yes]
+    config.force_ssl = true
+  end
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
### Context

The pen test raised that we are not generating https urls

### Changes proposed in this pull request

Set `config.force_ssl` unless explicitly disabled (eg for running production environments locally)



