### PR TITLE
Sanitise user-inputted text values

### DIFF
--- a/app/models/teacher_training_adviser/steps/identity.rb
+++ b/app/models/teacher_training_adviser/steps/identity.rb
@@ -10,6 +10,8 @@ module TeacherTrainingAdviser::Steps
     validates :first_name, presence: { message: "You need to enter your first name" }, length: { maximum: 256 }
     validates :last_name, presence: { message: "You need to enter your last name" }, length: { maximum: 256 }
 
+    before_validation :sanitize_input
+
     def self.contains_personal_details?
       true
     end
@@ -20,6 +22,14 @@ module TeacherTrainingAdviser::Steps
           answers["name"] = "#{answers['first_name']} #{answers['last_name']}"
         }
         .without("first_name", "last_name")
+    end
+
+  private
+
+    def sanitize_input
+      self.first_name = first_name.to_s.strip.presence if first_name
+      self.last_name = last_name.to_s.strip.presence if last_name
+      self.email = email.to_s.strip.presence if email
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_telephone.rb
@@ -4,6 +4,10 @@ module TeacherTrainingAdviser::Steps
 
     validates :telephone, telephone: true, allow_blank: true
 
+    before_validation if: :telephone do
+      self.telephone = telephone.to_s.strip.presence
+    end
+
     def self.contains_personal_details?
       true
     end

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -15,7 +15,7 @@ module TeacherTrainingAdviser::Steps
 
     def reviewable_answers
       super.tap do |answers|
-        answers["initial_teacher_training_year_id"] = year_range.first { |y| y.value == initial_teacher_training_year_id }.value
+        answers["initial_teacher_training_year_id"] = year_range.find { |y| y.id.to_s == initial_teacher_training_year_id.to_s }.value
       end
     end
 

--- a/app/models/teacher_training_adviser/steps/uk_address.rb
+++ b/app/models/teacher_training_adviser/steps/uk_address.rb
@@ -10,6 +10,8 @@ module TeacherTrainingAdviser::Steps
     validates :address_city, presence: { message: "Enter your town or city" }, length: { maximum: 128 }
     validates :address_postcode, format: { with: /^([A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}|GIR ?0A{2})$/i, multiline: true, message: "Enter a real postcode" }
 
+    before_validation :sanitize_input
+
     def self.contains_personal_details?
       true
     end
@@ -31,6 +33,15 @@ module TeacherTrainingAdviser::Steps
       {
         "address" => address.reject(&:empty?).join("\n"),
       }
+    end
+
+  private
+
+    def sanitize_input
+      self.address_line1 = address_line1.to_s.strip.presence if address_line1
+      self.address_line2 = address_line2.to_s.strip.presence if address_line2
+      self.address_city = address_city.to_s.strip.presence if address_city
+      self.address_postcode = address_postcode.to_s.strip.presence if address_postcode
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/uk_callback.rb
+++ b/app/models/teacher_training_adviser/steps/uk_callback.rb
@@ -6,6 +6,10 @@ module TeacherTrainingAdviser::Steps
     validates :telephone, telephone: true, presence: { message: "Enter a telephone number" }
     validates :phone_call_scheduled_at, presence: true
 
+    before_validation if: :telephone do
+      self.telephone = telephone.to_s.strip.presence
+    end
+
     def reviewable_answers
       {
         "callback_date" => phone_call_scheduled_at.to_date,

--- a/app/models/teacher_training_adviser/steps/uk_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/uk_telephone.rb
@@ -4,6 +4,10 @@ module TeacherTrainingAdviser::Steps
 
     validates :telephone, telephone: true, allow_blank: true
 
+    before_validation if: :telephone do
+      self.telephone = telephone.to_s.strip.presence
+    end
+
     def self.contains_personal_details?
       true
     end

--- a/spec/models/teacher_training_adviser/steps/identity_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/identity_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::Identity do
   include_context "wizard step"
   it_behaves_like "a wizard step"
   it_behaves_like "an issue verification code wizard step"
+  include_context "sanitize fields", %i[first_name last_name email]
 
   it { is_expected.to be_contains_personal_details }
 

--- a/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::OverseasTelephone do
   include_context "wizard step"
   it_behaves_like "a wizard step"
+  include_context "sanitize fields", %i[telephone]
 
   it { is_expected.to be_contains_personal_details }
 

--- a/spec/models/teacher_training_adviser/steps/uk_address_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_address_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::UkAddress do
   include_context "wizard step"
   it_behaves_like "a wizard step"
+  include_context "sanitize fields", %i[address_line1 address_line2 address_city address_postcode]
 
   it { is_expected.to be_contains_personal_details }
 

--- a/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
   include_context "wizard step"
   it_behaves_like "a wizard step"
+  include_context "sanitize fields", %i[telephone]
 
   context "attributes" do
     it { is_expected.to respond_to :phone_call_scheduled_at }

--- a/spec/models/teacher_training_adviser/steps/uk_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_telephone_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::UkTelephone do
   include_context "wizard step"
   it_behaves_like "a wizard step"
+  include_context "sanitize fields", %i[telephone]
 
   it { is_expected.to be_contains_personal_details }
 

--- a/spec/support/shared_examples/sanitize_input.rb
+++ b/spec/support/shared_examples/sanitize_input.rb
@@ -1,0 +1,13 @@
+RSpec.shared_examples "sanitize fields" do |fields|
+  fields.each do |field|
+    it "sanitizes input on the #{field} field" do
+      setter = "#{field}="
+      subject.send(setter, "   input  ")
+      subject.valid?
+      expect(subject.send(field)).to eq("input")
+      subject.send(setter, "   ")
+      subject.valid?
+      expect(subject.send(field)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
- Sanitize text input fields

On user inputted-text we want to ensure that white space is stripped from the leading/trailing edges and if the user enters an empty string we save it as `nil`.

- Find correct year from year_range

