### PR TITLE
Use the name of the cookie we list in the cookie policy

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,6 +54,7 @@ Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
 
   config.session_store :cache_store,
-                       key: "_#{Rails.application.class.parent_name}_session",
+                       key: "_dfe_session",
+                       same_site: :lax,
                        expire_after: 1.day
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -106,6 +106,7 @@ Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
 
   config.session_store :cache_store,
-                       key: "_#{Rails.application.class.parent_name}_session",
+                       key: "_dfe_session",
+                       same_site: :lax,
                        expire_after: 1.day
 end


### PR DESCRIPTION
### JIRA ticket number

GITPB-575

### Context

We specify a cookie name of `_dfe_session` in our cookie policy so that is the cookie we should be using

### Changes proposed in this pull request

1. set the name of the cookie
2. Set the same_site setting to Lax



