### PR TITLE
Show qualification required error correctly

### DIFF
--- a/app/models/teacher_training_adviser/steps/qualification_required.rb
+++ b/app/models/teacher_training_adviser/steps/qualification_required.rb
@@ -9,14 +9,17 @@ module TeacherTrainingAdviser::Steps
       returning_teacher = @store["returning_to_teaching"]
       has_gcse_maths_english = @store["has_gcse_maths_and_english_id"] != TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
       retaking_gcse_maths_english = @store["planning_to_retake_gcse_maths_and_english_id"] != TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
+      phase_is_primary = @store["preferred_education_phase_id"] == TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:primary]
       phase_is_secondary = @store["preferred_education_phase_id"] == TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
       has_gcse_science = @store["has_gcse_science_id"] != TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:no]
       retaking_gcse_science = @store["planning_to_retake_gcse_science_id"] != TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:no]
+      has_or_retaking_gcse_maths_english = has_gcse_maths_english || retaking_gcse_maths_english
+      has_or_retaking_gcse_science = has_gcse_science || retaking_gcse_science
 
       equivalent_degree ||
         returning_teacher ||
-        (phase_is_secondary && (has_gcse_maths_english || retaking_gcse_maths_english)) ||
-        (!phase_is_secondary && (has_gcse_science || retaking_gcse_science))
+        (phase_is_secondary && has_or_retaking_gcse_maths_english) ||
+        (phase_is_primary && has_or_retaking_gcse_maths_english && has_or_retaking_gcse_science)
     end
   end
 end

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -219,7 +219,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       expect(page).to_not have_text "Continue"
     end
 
-    scenario "without GCSEs, primary" do
+    scenario "without science GCSEs, primary" do
       visit teacher_training_adviser_steps_path
 
       expect(page).to have_text "About you"
@@ -259,6 +259,45 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Continue"
 
       expect(page).to have_text "Are you planning to retake your science GCSE?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Get the right GCSEs or equivalent qualifications"
+      expect(page).to_not have_text "Continue"
+    end
+
+    scenario "without english/maths GCSEs, primary" do
+      visit teacher_training_adviser_steps_path
+
+      expect(page).to have_text "About you"
+      fill_in_identity_step
+      click_on "Continue"
+
+      expect(page).to have_text "Are you returning to teaching?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have a degree?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_text "What subject is your degree?"
+      select "Maths"
+      click_on "Continue"
+
+      expect(page).to have_text "Which class is your degree?"
+      select "2:2"
+      click_on "Continue"
+
+      expect(page).to have_text "Which stage are you interested in teaching?"
+      choose "Primary"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Are you planning to retake either English or maths (or both) GCSEs, or equivalent?"
       choose "No"
       click_on "Continue"
 


### PR DESCRIPTION
Previously we were not showing the `QualificationRequired` step if the user
chose primary and they did not have the required GCSEs.