### PR TITLE
Include matchback fields in export

### DIFF
--- a/app/models/wizard/steps/authenticate.rb
+++ b/app/models/wizard/steps/authenticate.rb
@@ -2,6 +2,7 @@ module Wizard
   module Steps
     class Authenticate < ::Wizard::Step
       IDENTITY_ATTRS = %i[email first_name last_name date_of_birth].freeze
+      MATCHBACK_ATTRS = %i[candidate_id qualification_id].freeze
 
       attribute :timed_one_time_password
 
@@ -21,6 +22,16 @@ module Wizard
         prepopulate_store if valid?
 
         super
+      end
+
+      def export
+        return {} if skipped?
+
+        @store.fetch(MATCHBACK_ATTRS)
+      end
+
+      def reviewable_answers
+        {}
       end
 
       def timed_one_time_password=(value)

--- a/spec/models/wizard/steps/authenticate_spec.rb
+++ b/spec/models/wizard/steps/authenticate_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Wizard::Steps::Authenticate do
     it { is_expected.not_to allow_value("12345").for :timed_one_time_password }
   end
 
-  describe "skipped?" do
+  describe "#skipped?" do
     it "returns true if authenticate is false" do
       wizardstore["authenticate"] = false
       expect(subject).to be_skipped
@@ -31,6 +31,31 @@ RSpec.describe Wizard::Steps::Authenticate do
     it "returns false if authenticate is true" do
       wizardstore["authenticate"] = true
       expect(subject).to_not be_skipped
+    end
+  end
+
+  describe "#export" do
+    it "returns a hash containing the matchback fields" do
+      wizardstore["candidate_id"] = "abc-123"
+      wizardstore["qualification_id"] = "def-456"
+      subject.timed_one_time_password = "123456"
+      expect(subject.export).to eq({
+        "candidate_id" => "abc-123",
+        "qualification_id" => "def-456",
+      })
+    end
+
+    it "does not include matchback fields in export if skipped" do
+      wizardstore["candidate_id"] = "abc-123"
+      allow_any_instance_of(described_class).to receive(:skipped?) { true }
+      expect(subject.export.values).to all(be_nil)
+    end
+  end
+
+  describe "#reviewable_answers" do
+    it "returns an empty hash" do
+      subject.timed_one_time_password = "123456"
+      expect(subject.reviewable_answers).to be_empty
     end
   end
 


### PR DESCRIPTION
### JIRA ticket number

[GITPB-684](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?selectedIssue=GITPB-684)

### Context

When an existing candidate successfully matches back to a contact in the CRM we populate the store with their existing details, including `candidate_id` and `qualification_id`. As we scope the information sent back to the API down to only the attributes of steps that weren't skipped - and `candidate_id`/`qualification_id` are not attributes of any step - the ids
weren't being sent back to the API.

This adds `candidate_id` and `qualification_id` to the `export` call on the `Authenticate` step and also ensures no answers to the `Authenticate` step will ever appear in the review answers view.

### Changes proposed in this pull request

- Include matchback fields in export

### Guidance to review

