### PR TITLE
Show 404 for unknown page template in pages controller

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  rescue_from ActionView::MissingTemplate, with: :rescue_missing_template
+
   def show
     render template: "pages/#{params[:page]}"
   end
@@ -19,5 +21,21 @@ class PagesController < ApplicationController
                       end
 
     render template: "pages/privacy_policy"
+  end
+
+private
+
+  def rescue_missing_template
+    respond_to do |format|
+      format.html do
+        render \
+          template: "errors/not_found",
+          status: :not_found
+      end
+
+      format.all do
+        render status: :not_found, body: nil
+      end
+    end
   end
 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -38,4 +38,20 @@ RSpec.describe PagesController, type: :request do
       expect(response).to have_http_status(200)
     end
   end
+
+  context "#show" do
+    subject { response }
+
+    context "for known page" do
+      before { get "/home" }
+      it { is_expected.to have_http_status :success }
+      it { expect(response.body).to match "Sign up to get an adviser" }
+    end
+
+    context "for unknown page" do
+      before { get "/unknown" }
+      it { is_expected.to have_http_status :not_found }
+      it { expect(response.body).to match "The page you were looking for doesn't exist" }
+    end
+  end
 end


### PR DESCRIPTION
### JIRA ticket number

GITPB-681

### Context

As a user visiting a non existant page, I expect to see the "Page not found" screen rather than the "There has been an error" screen which is currently shown.

### Changes proposed in this pull request

1. Show 404 page for missing templates
2. Added to request spec to check 
    1. known pages are shown correctly
    2. unknown pages are shown as a 404



