### PR TITLE
Prevent candidate from signing up multiple times

### DIFF
--- a/app/models/teacher_training_adviser/steps/already_signed_up.rb
+++ b/app/models/teacher_training_adviser/steps/already_signed_up.rb
@@ -1,0 +1,11 @@
+module TeacherTrainingAdviser::Steps
+  class AlreadySignedUp < Wizard::Step
+    def skipped?
+      !@store["already_subscribed_to_teacher_training_adviser"]
+    end
+
+    def can_proceed?
+      false
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/wizard.rb
+++ b/app/models/teacher_training_adviser/wizard.rb
@@ -5,6 +5,7 @@ module TeacherTrainingAdviser
     self.steps = [
       Steps::Identity,
       Steps::Authenticate,
+      Steps::AlreadySignedUp,
       Steps::ReturningTeacher,
       Steps::HaveADegree,
       Steps::NoDegree,

--- a/app/views/teacher_training_adviser/steps/_already_signed_up.html.erb
+++ b/app/views/teacher_training_adviser/steps/_already_signed_up.html.erb
@@ -1,0 +1,10 @@
+<div class="govuk-form-group">
+  <h1 class="govuk-heading-l">You have already signed up to this service</h1>
+    
+  <p class="govuk-body">The email address <%= mail_to(session["sign_up"]["email"], nil, class: "govuk-link") %> has already been used to sign up for the Get an adviser service.</p>
+
+  <h2>Get support</h2>
+
+  <p class="govuk-body">Send an email to: <%= mail_to("getintoteaching.helpdesk@education.gov.uk", nil, class: "govuk-link") %> or call Freephone <%= link_to("0800 389 2500", "tel://0800 389 2500", class: "govuk-link") %>.</p>
+
+</div>

--- a/spec/models/teacher_training_adviser/steps/already_signed_up_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/already_signed_up_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::AlreadySignedUp do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  it { is_expected.to_not be_can_proceed }
+
+  describe "#skipped?" do
+    it "returns true if already_subscribed_to_teacher_training_adviser is false/nil/undefined" do
+      expect(subject).to be_skipped
+      wizardstore["already_subscribed_to_teacher_training_adviser"] = nil
+      expect(subject).to be_skipped
+      wizardstore["already_subscribed_to_teacher_training_adviser"] = false
+      expect(subject).to be_skipped
+    end
+
+    it "returns false if already_subscribed_to_teacher_training_adviser is true" do
+      wizardstore["already_subscribed_to_teacher_training_adviser"] = true
+      expect(subject).to_not be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/wizard_spec.rb
+++ b/spec/models/teacher_training_adviser/wizard_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
       is_expected.to eql [
         TeacherTrainingAdviser::Steps::Identity,
         TeacherTrainingAdviser::Steps::Authenticate,
+        TeacherTrainingAdviser::Steps::AlreadySignedUp,
         TeacherTrainingAdviser::Steps::ReturningTeacher,
         TeacherTrainingAdviser::Steps::HaveADegree,
         TeacherTrainingAdviser::Steps::NoDegree,


### PR DESCRIPTION
### JIRA ticket number

[GITPB-658](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?selectedIssue=GITPB-658)

### Context

If a candidate has already signed up to the TTA service and successfully matches back, the store will contain a `true` value for `already_subscribed_to_teacher_training_adviser`. When this is the case, we will show them a new step that informs them they have already signed up and directs them to contact support if they think this incorrect.

### Changes proposed in this pull request

- Prevent candidate from signing up multiple times

### Guidance to review

<img width="1316" alt="Screenshot 2020-09-02 at 14 45 59" src="https://user-images.githubusercontent.com/29867726/91991649-0fa3ef80-ed2b-11ea-8872-606e06a784af.png">
