### PR TITLE
Display review answers correctly when steps have been missed

### DIFF
--- a/app/models/teacher_training_adviser/steps/have_a_degree.rb
+++ b/app/models/teacher_training_adviser/steps/have_a_degree.rb
@@ -24,7 +24,7 @@ module TeacherTrainingAdviser::Steps
 
     def reviewable_answers
       {
-        "degree_options" => I18n.t("have_a_degree.degree_options.#{degree_options}"),
+        "degree_options" => degree_options ? I18n.t("have_a_degree.degree_options.#{degree_options}") : nil,
       }
     end
 

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -15,7 +15,7 @@ module TeacherTrainingAdviser::Steps
 
     def reviewable_answers
       super.tap do |answers|
-        answers["initial_teacher_training_year_id"] = year_range.find { |y| y.id.to_s == initial_teacher_training_year_id.to_s }.value
+        answers["initial_teacher_training_year_id"] = year_range.find { |y| y.id.to_s == initial_teacher_training_year_id.to_s }&.value
       end
     end
 

--- a/spec/models/teacher_training_adviser/steps/have_a_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/have_a_degree_spec.rb
@@ -83,5 +83,10 @@ RSpec.describe TeacherTrainingAdviser::Steps::HaveADegree do
     subject { instance.reviewable_answers }
     before { instance.degree_options = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying] }
     it { is_expected.to eq({ "degree_options" => "I'm studying for a degree" }) }
+
+    context "when degree_options is nil" do
+      before { instance.degree_options = nil }
+      it { is_expected.to eq({ "degree_options" => nil }) }
+    end
   end
 end

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -76,5 +76,10 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
     end
 
     it { is_expected.to eq({ "initial_teacher_training_year_id" => "Value" }) }
+
+    context "when initial_teacher_training_year_id is nil" do
+      before { instance.initial_teacher_training_year_id = nil }
+      it { is_expected.to eq({ "initial_teacher_training_year_id" => nil }) }
+    end
   end
 end


### PR DESCRIPTION
### JIRA ticket number

[GITPB-688](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?selectedIssue=GITPB-688)

### Context

It is currently possible for a user to miss a step; you can jump straight to the review answers step if you have the URL (though if you try and complete the submission it will redirect to the first invalid step).

If a candidate does this it causes an exception due to not expecting a non-skipped step to have a `nil` value (which happens if they manually plug a future step URL in). This commit updates the `reviewable_answers` to ensure an exception will never be raised, instead displaying an empty answer in the review answers step for any they have missed.

A better long-term solution may be to redirect to an invalid step if the candidate attempts to access a future step manually via the URL.

### Changes proposed in this pull request

- Display review answers correctly when steps have been missed

### Guidance to review

