### PR TITLE
Switch to Faraday API client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "redis"
 gem "country_select", "~> 4.0"
 
 # api client
-gem "get_into_teaching_api_client", "1.0.6", git: "https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git"
+gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teaching-api-ruby-client", require: "api/client"
 
 gem "sentry-raven"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,17 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: d7030dbe4f867277bbf656b6d0a5b496e6944511
+  revision: 8c2f175fcb86236d68c931be3fee1f2662568b85
   specs:
-    get_into_teaching_api_client (1.0.6)
+    get_into_teaching_api_client (1.1.1)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
+    get_into_teaching_api_client_faraday (0.1.1)
+      activesupport
+      faraday
+      faraday-encoding
+      faraday-http-cache
+      faraday_middleware
+      get_into_teaching_api_client
 
 GEM
   remote: https://rubygems.org/
@@ -109,6 +116,12 @@ GEM
       railties (>= 5.0.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
+    faraday-encoding (0.0.5)
+      faraday
+    faraday-http-cache (2.2.0)
+      faraday (>= 0.8)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
     ffi (1.13.1)
     foreman (0.87.1)
     globalid (0.4.2)
@@ -321,7 +334,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   foreman
-  get_into_teaching_api_client (= 1.0.6)!
+  get_into_teaching_api_client_faraday!
   govuk_design_system_formbuilder
   listen (>= 3.0.5, < 3.3)
   pry-byebug

--- a/config/initializers/get_into_teaching_api_client.rb
+++ b/config/initializers/get_into_teaching_api_client.rb
@@ -6,4 +6,6 @@ GetIntoTeachingApiClient.configure do |config|
   end
 
   config.api_key["Authorization"] = ENV["GIT_API_TOKEN"].presence || Rails.application.credentials.config[:api_key].presence
+
+  config.cache_store = Rails.cache
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,6 +1,6 @@
 VCR.configure do |config|
   config.cassette_library_dir = "spec/vcr"
-  config.hook_into :typhoeus
+  config.hook_into :faraday
   config.configure_rspec_metadata!
   config.before_record do |i|
     i.response.body.force_encoding("UTF-8")


### PR DESCRIPTION
This wraps the auto-generated API client and adds HTTP caching and retries.
