### PR TITLE
duplication of main role causing DAC failures

### DIFF
--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,8 +1,8 @@
-<main role="main" class="govuk-main-wrapper" id="main-content">
+<div class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">We're sorry, but something went wrong.</h1>
       <p class="govuk-body">If you are the application owner check the logs for more information.</p>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,4 +1,4 @@
-<main role="main" class="govuk-main-wrapper" id="main-content">
+<div class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">The page you were looking for doesn't exist.</h1>
@@ -6,4 +6,4 @@
       <p class="govuk-body">If you are the application owner check the logs for more information.</p>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,4 +1,4 @@
-<main role="main" class="govuk-main-wrapper" id="main-content">
+<div class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>
@@ -6,4 +6,4 @@
       <p class="govuk-body">If you are the application owner check the logs for more information.</p>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,7 +46,7 @@
     </header>
 
     <div class="govuk-width-container">
-      <main class="govuk-main-wrapper " id="main-content" role="main">
+      <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= yield %>
       </main>
     </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-width-container">
-  <main class="govuk-main-wrapper " id="main-content" role="main">
+  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Sign up to get an adviser</h1>
@@ -38,5 +38,5 @@
       </div>
 
     </div>
-  </main>
+  </div>
 </div>

--- a/app/views/teacher_training_adviser/steps/_review_answers.html.erb
+++ b/app/views/teacher_training_adviser/steps/_review_answers.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-width-container">
 
-  <main class="govuk-main-wrapper " id="main-content" role="main">
+  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
 
@@ -23,5 +23,5 @@
         </dl>
       </div>
     </div>
-  </main>
+  </div>
 </div>

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-width-container">
-  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+  <div class="govuk-main-wrapper govuk-main-wrapper--l">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-panel govuk-panel--confirmation">
@@ -21,5 +21,5 @@
         </p>
       </div>
     </div>
-  </main>
+  </div>
 </div>


### PR DESCRIPTION
https://trello.com/c/lwbvOFRO/277-tta-flow-duplicate-ids

role="main" and id="main-content" have been incorrectly copied and pasted throughout the TTA flow and have been flagged in the DAC report as being problematic for screen reader users

there is a role main at the top level in the layout file, so this PR simply converts <main> tags to divs and removes the roles and ids which are not required