### PR TITLE
Feature/validation message changes

### DIFF
--- a/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
@@ -2,7 +2,7 @@ module TeacherTrainingAdviser::Steps
   class GcseMathsEnglish < Wizard::Step
     attribute :has_gcse_maths_and_english_id, :integer
 
-    validates :has_gcse_maths_and_english_id, types: { method: :get_candidate_retake_gcse_status, message: "You must select either yes or no" }
+    validates :has_gcse_maths_and_english_id, types: { method: :get_candidate_retake_gcse_status, message: "Select yes if you have grade 4(C) or above in English and Maths GCSE or equivalent" }
 
     OPTIONS = Crm::OPTIONS
 

--- a/app/models/teacher_training_adviser/steps/gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_science.rb
@@ -2,7 +2,7 @@ module TeacherTrainingAdviser::Steps
   class GcseScience < Wizard::Step
     attribute :has_gcse_science_id, :integer
 
-    validates :has_gcse_science_id, types: { method: :get_candidate_retake_gcse_status, message: "You must select either yes or no" }
+    validates :has_gcse_science_id, types: { method: :get_candidate_retake_gcse_status, message: "Select yes if you have Science GCSE or equivalent" }
 
     OPTIONS = Crm::OPTIONS
 

--- a/app/models/teacher_training_adviser/steps/has_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/has_teacher_id.rb
@@ -2,7 +2,7 @@ module TeacherTrainingAdviser::Steps
   class HasTeacherId < Wizard::Step
     attribute :has_id, :boolean
 
-    validates :has_id, inclusion: { in: [true, false], message: "You must select either yes or no" }
+    validates :has_id, inclusion: { in: [true, false], message: "Select yes if you have a previous teacher reference number" }
 
     def reviewable_answers
       super.tap do |answers|

--- a/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
@@ -2,7 +2,7 @@ module TeacherTrainingAdviser::Steps
   class RetakeGcseMathsEnglish < Wizard::Step
     attribute :planning_to_retake_gcse_maths_and_english_id, :integer
 
-    validates :planning_to_retake_gcse_maths_and_english_id, types: { method: :get_candidate_retake_gcse_status, message: "Select yes if you are planning to retake English or Maths (or both) GCSE or equivalent" }
+    validates :planning_to_retake_gcse_maths_and_english_id, types: { method: :get_candidate_retake_gcse_status, message: "Select yes if you are planning to retake either English or maths (or both) GCSEs, or equivalent" }
 
     OPTIONS = Crm::OPTIONS
 

--- a/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
@@ -2,7 +2,7 @@ module TeacherTrainingAdviser::Steps
   class RetakeGcseMathsEnglish < Wizard::Step
     attribute :planning_to_retake_gcse_maths_and_english_id, :integer
 
-    validates :planning_to_retake_gcse_maths_and_english_id, types: { method: :get_candidate_retake_gcse_status, message: "You must select either yes or no" }
+    validates :planning_to_retake_gcse_maths_and_english_id, types: { method: :get_candidate_retake_gcse_status, message: "Select yes if you are planning to retake English or Maths (or both) GCSE or equivalent" }
 
     OPTIONS = Crm::OPTIONS
 

--- a/app/models/teacher_training_adviser/steps/retake_gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_science.rb
@@ -2,7 +2,7 @@ module TeacherTrainingAdviser::Steps
   class RetakeGcseScience < Wizard::Step
     attribute :planning_to_retake_gcse_science_id, :integer
 
-    validates :planning_to_retake_gcse_science_id, types: { method: :get_candidate_retake_gcse_status, message: "You must select either yes or no" }
+    validates :planning_to_retake_gcse_science_id, types: { method: :get_candidate_retake_gcse_status, message: "Select yes if you are planning to retake Science GCSE or equivalent" }
 
     OPTIONS = Crm::OPTIONS
 

--- a/app/models/teacher_training_adviser/steps/returning_teacher.rb
+++ b/app/models/teacher_training_adviser/steps/returning_teacher.rb
@@ -6,7 +6,7 @@ module TeacherTrainingAdviser::Steps
     attribute :degree_options, :string
     attribute :preferred_education_phase_id
 
-    validates :returning_to_teaching, inclusion: { in: [true, false], message: "You must select either yes or no" }
+    validates :returning_to_teaching, inclusion: { in: [true, false], message: "Select yes if you are returning to teaching" }
 
     def returning_to_teaching=(value)
       super

--- a/app/models/teacher_training_adviser/steps/stage_of_degree.rb
+++ b/app/models/teacher_training_adviser/steps/stage_of_degree.rb
@@ -4,7 +4,7 @@ module TeacherTrainingAdviser::Steps
     # overwrites session[:sign_up]["degree_status_id"]
     attribute :degree_status_id, :integer
 
-    validates :degree_status_id, types: { method: :get_qualification_degree_status, message: "You must select an option" }
+    validates :degree_status_id, types: { method: :get_qualification_degree_status, message: "Select which year you are currently studying" }
 
     def skipped?
       returning_teacher = @store["returning_to_teaching"]


### PR DESCRIPTION
"Select an option"
is not enough context in a validation message for screen reader users

Updated all the validation messages where this phrase is used and had Darren look over the wording of them

https://trello.com/c/h3qvtwyl/292-tta-flow-you-must-select-either-yes-or-no

