### PR TITLE
Fix error linking on returning teacher

### DIFF
--- a/app/views/teacher_training_adviser/steps/_returning_teacher.html.erb
+++ b/app/views/teacher_training_adviser/steps/_returning_teacher.html.erb
@@ -1,4 +1,4 @@
 <%= f.govuk_radio_buttons_fieldset(:returning_to_teaching, legend: { text: 'Are you returning to teaching?'}, hint_text: "If you have an overseas qualification that's equivalent to our qualified teacher status (QTS), then select the 'yes' option and take the 'returning to teaching' route.", inline: true ) do %>
-  <%= f.govuk_radio_button :returning_to_teaching, true, label: { text: 'Yes' } %>
+  <%= f.govuk_radio_button :returning_to_teaching, true, label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :returning_to_teaching, false, label: { text: 'No' } %>
 <% end %>


### PR DESCRIPTION
### Context

Radio buttons on the returning teacher page are not linking correctly

### Changes proposed in this pull request

1. Added the `link_errors: true` option to the first radio button



