### PR TITLE
GITPB-683 Add completion logging

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,12 +3,17 @@ module ApplicationHelper
     attributes = attributes.symbolize_keys
 
     analytics = {
-      "analytics-gtm-id".to_sym => ENV["GOOGLE_TAG_MANAGER_ID"],
-      "analytics-hotjar-id".to_sym => ENV["HOTJAR_ID"],
-      "analytics-snapchat-id".to_sym => ENV["SNAPCHAT_ID"],
-      "analytics-pinterest-id".to_sym => ENV["PINTEREST_ID"],
-      "analytics-facebook-id".to_sym => ENV["FACEBOOK_ID"],
-    }
+      "analytics-gtm-id" => ENV["GOOGLE_TAG_MANAGER_ID"],
+      "analytics-hotjar-id" => ENV["HOTJAR_ID"],
+      "analytics-snapchat-id" => ENV["SNAPCHAT_ID"],
+      "analytics-pinterest-id" => ENV["PINTEREST_ID"],
+      "analytics-facebook-id" => ENV["FACEBOOK_ID"],
+      "pinterest-action" => "page",
+      "snapchat-action" => "track",
+      "snapchat-event" => "PAGE_VIEW",
+      "facebook-action" => "track",
+      "facebook-event" => "PageView",
+    }.symbolize_keys
 
     attributes[:data] ||= {}
     attributes[:data] = attributes[:data].merge(analytics)

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -19,6 +19,18 @@
         <p class="govuk-body">
           <a href="https://www.gov.uk/service-manual/service-assessments/get-feedback-page" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
         </p>
+
+        <span data-controller="pinterest"
+              data-pinterest-action="track"
+              data-pinterest-event="signup"></span>
+
+        <span data-controller="snapchat"
+              data-snapchat-action="track"
+              data-snapchat-event="SIGN_UP"></span>
+
+        <span data-controller="facebook"
+              data-facebook-action="track"
+              data-facebook-event="CompleteRegistration"></span>
       </div>
     </div>
   </div>

--- a/app/webpacker/controllers/analytics_base_controller.js
+++ b/app/webpacker/controllers/analytics_base_controller.js
@@ -59,21 +59,25 @@ export default class extends Controller {
   }
 
   get eventData() {
+    if (typeof(this.parsedEventData) != "undefined")
+      return this.parsedEventData ;
+
     let evData = this.data.get('event-data') ;
+    this.parsedEventData = null ;
 
     if (evData && evData != "")
-      return JSON.parse(evData) ;
-    else
-      return null ;
+      this.parsedEventData = JSON.parse(evData) ;
+
+    return this.parsedEventData ;
   }
 
   sendEvent() {
-    let evData = this.eventData ;
-
-    if (evData)
-      this.serviceFunction(this.serviceAction, this.eventName, evData) ;
-    else
+    if (this.eventData)
+      this.serviceFunction(this.serviceAction, this.eventName, this.eventData) ;
+    else if (this.eventName)
       this.serviceFunction(this.serviceAction, this.eventName) ;
+    else
+      this.serviceFunction(this.serviceAction) ;
   }
 
 }


### PR DESCRIPTION
### JIRA ticket number

GITPB-683

### Context

We should be logging all page views on the TTA service to our analytics platforms

### Changes proposed in this pull request

1. Change the sendEvent function to allow actions without events - needed for pinterest, per page views
2. Fire analytics events on all page views
3. Fire 'completed' events upon completion of the TTA flow 

### Guidance to review
1. Can be enabled by setting the appropriate env vars in `.env.local` - see here https://github.com/DFE-Digital/get-into-teaching-app/blob/master/.env.preprod - the env vars for pinterest, snapchat and facebook are the ones affected by this PR
