### PR TITLE
Prevent API check when already authenticated

### DIFF
--- a/spec/models/wizard/steps/authenticate_spec.rb
+++ b/spec/models/wizard/steps/authenticate_spec.rb
@@ -81,6 +81,12 @@ RSpec.describe Wizard::Steps::Authenticate do
         subject.save!
         expect { subject.save! }.to_not raise_error
       end
+
+      it "does not set authenticated to true" do
+        subject.timed_one_time_password = nil
+        subject.save!
+        expect(wizardstore["authenticated"]).to be_falsy
+      end
     end
 
     context "when valid" do
@@ -93,7 +99,14 @@ RSpec.describe Wizard::Steps::Authenticate do
         subject.save!
       end
 
-      it "throws an error if #f is not defined" do
+      it "does not call the API on validation if already authenticated" do
+        expect(subject).to_not receive(:perform_existing_candidate_request)
+        wizardstore["authenticated"] = true
+        subject.timed_one_time_password = "123456"
+        subject.valid?
+      end
+
+      it "throws an error if #perform_existing_candidate_request is not defined" do
         expect(instance).to receive(:perform_existing_candidate_request).and_call_original
         expect { subject.save! }.to raise_error(NotImplementedError)
       end
@@ -113,6 +126,25 @@ RSpec.describe Wizard::Steps::Authenticate do
         subject.save!
         expect(wizardstore["candidate_id"]).to eq(response.candidate_id)
         expect(wizardstore["first_name"]).to eq("First")
+      end
+
+      it "sets authenticated to true" do
+        response = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidateId: "abc123")
+        expect(subject).to receive(:perform_existing_candidate_request).with(request) { response }
+        subject.save!
+        expect(wizardstore["authenticated"]).to be_truthy
+      end
+
+      context "when TOTP is changed to be incorrect" do
+        it "sets authenticated back to false" do
+          response = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidateId: "abc123")
+          expect(subject).to receive(:perform_existing_candidate_request).with(request) { response }
+          subject.save!
+          expect(wizardstore["authenticated"]).to be_truthy
+          subject.timed_one_time_password = nil
+          subject.save!
+          expect(wizardstore["authenticated"]).to be_falsy
+        end
       end
     end
 


### PR DESCRIPTION
### JIRA ticket number

[GITPB-692](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?selectedIssue=GITPB-692)

### Context

When the wizard is about to be completed we check for any invalid steps; this was resulting in another API call to verify the verification code in the `Authenticate` step. If the user takes too long completing the form their code may not be valid by the time they reach they come to submit it, resulting in them being redirected back to the `Authenticate` step.

This PR sets an `authenticated` flag in the store; if this is present the `Authenticate` step will not try and re-verify their code.

### Changes proposed in this pull request

- Prevent API check when already authenticated

### Guidance to review

