### PR TITLE
Add BETA feedback banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,8 +42,22 @@
         </div>
         <div class="govuk-header__content">
           <%= link_to "Sign up to get an adviser", "/", class: "govuk-header__link govuk-header__link--service-name" %>
+        </div>
       </div>
     </header>
+
+    <div class="govuk-width-container">
+      <div class="govuk-phase-banner">
+        <p class="govuk-phase-banner__content">
+          <strong class="govuk-tag govuk-phase-banner__content__tag">
+            beta
+          </strong>
+          <span class="govuk-phase-banner__text">
+            This is a new service – your <a class="govuk-link" target="blank" href="https://docs.google.com/forms/d/e/1FAIpQLSfIBfaYUk07Fb6dxUKAokiPoGGL73ZYVGHM1mSNyA-K-6QRbA/viewform">feedback</a> will help us to improve it.
+          </span>
+        </p>
+      </div>
+    </div>
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/spec/requests/beta_feedback_banner_spec.rb
+++ b/spec/requests/beta_feedback_banner_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "BETA feedback banner", type: :request do
+  before { get root_path }
+  subject { response.body }
+
+  it { is_expected.to match(/beta/) }
+  it { is_expected.to match(/This is a new service/) }
+end


### PR DESCRIPTION
Adds a feedback banner pointing to the Google form.

<img width="688" alt="Screenshot 2020-09-09 at 14 36 47" src="https://user-images.githubusercontent.com/29867726/92606063-6faa1100-f2aa-11ea-9509-70ed8023a0b5.png">

