### PR TITLE
Rename service to Get an adviser

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,9 +21,9 @@ module ApplicationHelper
 
   def prefix_title(title)
     if title
-      "Sign up to get an adviser: #{title}"
+      "Get an adviser: #{title}"
     else
-      "Sign up to get an adviser"
+      "Get an adviser"
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,7 +41,7 @@
           <% end %>
         </div>
         <div class="govuk-header__content">
-          <%= link_to "Sign up to get an adviser", "/", class: "govuk-header__link govuk-header__link--service-name" %>
+          <%= link_to "Get an adviser", "/", class: "govuk-header__link govuk-header__link--service-name" %>
         </div>
       </div>
     </header>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Sign up to get an adviser</h1>
+        <h1 class="govuk-heading-l">Get an adviser</h1>
 
         <p class="govuk-body">This service is for those who want to train to be a teacher in England.</p>
 

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -3,6 +3,6 @@ require "rails_helper"
 RSpec.feature "View pages", type: :feature do
   scenario "Navigates to home page" do
     visit "/home"
-    expect(page).to have_text("Sign up to get an adviser\n")
+    expect(page).to have_text("Get an adviser\n")
   end
 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe PagesController, type: :request do
     context "for known page" do
       before { get "/home" }
       it { is_expected.to have_http_status :success }
-      it { expect(response.body).to match "Sign up to get an adviser" }
+      it { expect(response.body).to match "Get an adviser" }
     end
 
     context "for unknown page" do


### PR DESCRIPTION
### JIRA ticket number

[GITPB-661](https://dfedigital.atlassian.net/browse/GITPB-661)

### Context

It has been decided the service will be called 'Get an adviser' - we need to change all references to reflect this.

### Changes proposed in this pull request

- Rename service to Get an adviser

### Guidance to review

