### PR TITLE
Feature/back link in main

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,9 +60,7 @@
     </div>
 
     <div class="govuk-width-container">
-      <main class="govuk-main-wrapper" id="main-content" role="main">
-        <%= yield %>
-      </main>
+      <%= yield %>
     </div>
 
     <footer class="govuk-footer " role="contentinfo">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,42 +1,34 @@
-<div class="govuk-width-container">
-  <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Get an adviser</h1>
-
-        <p class="govuk-body">This service is for those who want to train to be a teacher in England.</p>
-
-        <p class="govuk-inset-text">To use this service your bachelor&apos;s degree or predicted grade needs to be higher than a 3rd class honours.</p>
-
-        <p class="govuk-body">All our teacher training advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training.</p>
-        <p class="govuk-body">They will help you with the following:</p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <li>finding school experience</li>
-          <li>advice about teaching that is tailored to your needs</li>
-          <li>your application</li>
-          <li>finding national teaching events</li>
-        </ul>
-
-        <p class="govuk-inset-text">If you&apos;re returning to teaching and are qualified to teach maths, physics or languages or you have an overseas qualification, you should use this service to speak to a teacher training adviser.</p>
-
-        <p class="govuk-body">There are teacher training options if you live in:</p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <li><a href="https://teachinscotland.scot">Scotland</a></li>
-          <li><a href="https://www.discoverteaching.wales/routes-into-teaching/">Wales</a></li>
-          <li><a href="https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland">Northern Ireland</a></li>
-        </ul>
-
-        <a href="<%= teacher_training_adviser_step_path(:identity) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
-          Start now
-          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-          </svg>
-        </a>
-
+<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
+  <div class="govuk-width-container">
+    <div class="govuk-main-wrapper">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">Get an adviser</h1>
+          <p class="govuk-body">This service is for those who want to train to be a teacher in England.</p>
+          <p class="govuk-inset-text">To use this service your bachelor&apos;s degree or predicted grade needs to be higher than a 3rd class honours.</p>
+          <p class="govuk-body">All our teacher training advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training.</p>
+          <p class="govuk-body">They will help you with the following:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>finding school experience</li>
+            <li>advice about teaching that is tailored to your needs</li>
+            <li>your application</li>
+            <li>finding national teaching events</li>
+          </ul>
+          <p class="govuk-inset-text">If you&apos;re returning to teaching and are qualified to teach maths, physics or languages or you have an overseas qualification, you should use this service to speak to a teacher training adviser.</p>
+          <p class="govuk-body">There are teacher training options if you live in:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><a href="https://teachinscotland.scot">Scotland</a></li>
+            <li><a href="https://www.discoverteaching.wales/routes-into-teaching/">Wales</a></li>
+            <li><a href="https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland">Northern Ireland</a></li>
+          </ul>
+          <a href="<%= teacher_training_adviser_step_path(:identity) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
+            Start now
+            <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+            </svg>
+          </a>
+        </div>
       </div>
-
     </div>
   </div>
-</div>
+</main>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,5 +1,7 @@
-<div class="content__left">
-  <%= link_to 'Back', 'javascript:history.go(-1);', class: "govuk-back-link hidden", id: "backlink" %>
-  <h2>Privacy Policy</h2>
-  <%= safe_html_format @privacy_policy.text %>
-</div>
+<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
+  <div class="content__left">
+    <%= link_to 'Back', 'javascript:history.go(-1);', class: "govuk-back-link hidden", id: "backlink" %>
+    <h2>Privacy Policy</h2>
+    <%= safe_html_format @privacy_policy.text %>
+  </div>
+</main>

--- a/app/views/pages/session_expired.html.erb
+++ b/app/views/pages/session_expired.html.erb
@@ -1,11 +1,13 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-heading-l">
-      Session expired
+<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-heading-l">
+        Session expired
+      </div>
+      <p>
+        Your session has expired.
+      </p>
+      <%= link_to 'Restart your application', root_path, class: 'govuk-link' %>
     </div>
-    <p>
-      Your session has expired.
-    </p>
-    <%= link_to 'Restart your application', root_path, class: 'govuk-link' %>
   </div>
-</div>
+</main>

--- a/app/views/teacher_training_adviser/steps/_form.html.erb
+++ b/app/views/teacher_training_adviser/steps/_form.html.erb
@@ -2,12 +2,14 @@
   <%= back_link step_path(wizard.previous_key) if wizard.previous_key %>
 </p>
 
-<%= govuk_form_for current_step, url: step_path do |f| %>
-  <%= f.govuk_error_summary %>
+<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
+  <%= govuk_form_for current_step, url: step_path do |f| %>
+    <%= f.govuk_error_summary %>
 
-  <%= render current_step.key, current_step: current_step, f: f %>
+    <%= render current_step.key, current_step: current_step, f: f %>
 
-  <% if wizard.can_proceed? %>
-    <%= f.govuk_submit(wizard.last_step? ? "Complete" : "Continue") %>
+    <% if wizard.can_proceed? %>
+      <%= f.govuk_submit(wizard.last_step? ? "Complete" : "Continue") %>
+    <% end %>
   <% end %>
-<% end %>
+</main>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -18,3 +18,8 @@ $govuk-image-url-function: frontend-image-url;
 .hidden {
   display: none;
 }
+
+.no-margin {
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
The back link on formbuilder wizard steps currently lies within the main tag, which is an accessibility fail

https://trello.com/c/WElJalu3/288-tta-flow-back-link-within-main