### PR TITLE
Configure security headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem "canonical-rails"
 
 gem "govuk_design_system_formbuilder"
 
+gem "secure_headers"
+
 gem "dotenv-rails"
 
 # redis for session store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,7 @@ GEM
       sass (~> 3.5, >= 3.5.5)
     scss_lint-govuk (0.2.0)
       scss_lint
+    secure_headers (6.3.1)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -345,6 +346,7 @@ DEPENDENCIES
   rspec-sonarqube-formatter (~> 1.3)
   rubocop-govuk
   scss_lint-govuk
+  secure_headers
   sentry-raven
   shoulda-matchers
   simplecov (<= 0.17)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,10 +19,6 @@
   </head>
 
   <%= analytics_body_tag class: "govuk-template__body govuk-body" do %>
-    <script>
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
-
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
     <header class="govuk-header" role="banner" data-module="govuk-header">

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -5,6 +5,9 @@ import Rails from "rails-ujs";
 import Turbolinks from "turbolinks";
 import { initAll } from "govuk-frontend";
 
+// Required by GOV.UK front-end
+document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+
 Rails.start();
 Turbolinks.start();
 initAll();

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,5 +111,6 @@ Rails.application.configure do
   config.session_store :cache_store,
                        key: "_dfe_session",
                        same_site: :lax,
-                       expire_after: 1.day
+                       expire_after: 1.day,
+                       secure: true
 end

--- a/config/initializers/csp.rb
+++ b/config/initializers/csp.rb
@@ -1,0 +1,27 @@
+# rubocop:disable Lint/PercentStringArray
+SecureHeaders::Configuration.default do |config|
+  config.x_frame_options = "DENY"
+  config.x_content_type_options = "nosniff"
+  config.x_xss_protection = "1; mode=block"
+  config.x_download_options = "noopen"
+  config.x_permitted_cross_domain_policies = "none"
+  config.referrer_policy = %w[origin-when-cross-origin strict-origin-when-cross-origin]
+  config.csp = {
+    default_src: %w['none'],
+    base_uri: %w['self'],
+    block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
+    child_src: %w['self'],
+    connect_src: %w['self'],
+    font_src: %w['self'],
+    form_action: %w['self'],
+    frame_ancestors: %w['none'],
+    img_src: %w['self'],
+    manifest_src: %w['self'],
+    media_src: %w['self'],
+    script_src: %w['self' *.facebook.net *.googletagmanager.com *.hotjar.com *.pinimg.com *.sc-static.net],
+    style_src: %w['self' 'unsafe-inline'],
+    worker_src: %w['self'],
+    upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
+  }
+end
+# rubocop:enable Lint/PercentStringArray


### PR DESCRIPTION
### JIRA ticket number

[GITPB-678](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?selectedIssue=GITPB-678)

### Context

We want to make sure all cookies have the `secure` flag and an appropriate CSP is configured, along with other security headers flagged in the PEN test (x-content-type, x-xss-protection, x-frame-options).

### Changes proposed in this pull request

- Enable secure cookies in production

- Configure CSP headers

Adds `SecureHeaders` gem for easily configuring CSP headers (Rails has this built in but the gem will prevent unsupported headers being sent if the browser doesn't support them, avoiding potential errors in dev).

CSP is basically locked down to self with inline styles allowed. Allows scripts from tracking pixel domains.

- Remove inline Javascript

It causes a CSP violation, so moving it into the main application.js.

### Guidance to review

