### PR TITLE
Custom error for invalid date of birth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem "govuk_design_system_formbuilder"
 
 gem "secure_headers"
 
+gem "validates_timeliness"
+
 gem "dotenv-rails"
 
 # redis for session store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,12 +295,15 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.0.1)
     thread_safe (0.3.6)
+    timeliness (0.4.4)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
     unicode_utils (1.4.0)
+    validates_timeliness (4.1.1)
+      timeliness (>= 0.3.10, < 1)
     vcr (6.0.0)
     web-console (4.0.4)
       actionview (>= 6.0.0)
@@ -353,6 +356,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
+  validates_timeliness
   vcr
   web-console (>= 3.3.0)
   webdrivers (~> 4.3)

--- a/spec/models/teacher_training_adviser/steps/date_of_birth_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/date_of_birth_spec.rb
@@ -8,24 +8,22 @@ RSpec.describe TeacherTrainingAdviser::Steps::DateOfBirth do
 
   context "attributes" do
     it { is_expected.to respond_to :date_of_birth }
-    it { is_expected.to respond_to "date_of_birth(3i)" }
-    it { is_expected.to respond_to "date_of_birth(2i)" }
-    it { is_expected.to respond_to "date_of_birth(1i)" }
   end
 
-  describe "date_of_birth" do
+  describe "#date_of_birth" do
     it { is_expected.to_not allow_value(nil).for :date_of_birth }
     it { is_expected.to_not allow_value(Date.new(1900, 1, 1)).for :date_of_birth }
     it { is_expected.to_not allow_value(1.year.from_now).for :date_of_birth }
+    it { is_expected.to_not allow_value(13.years.ago).for :date_of_birth }
     it { is_expected.to allow_value(18.years.ago).for :date_of_birth }
-  end
 
-  it "maps individual components to date_of_birth" do
-    subject.send("date_of_birth(1i)=", 2001)
-    subject.send("date_of_birth(2i)=", 4)
-    subject.send("date_of_birth(3i)=", 20)
-    subject.valid?
-    expect(subject.date_of_birth).to eq(Date.new(2001, 4, 20))
+    context "when validating" do
+      it "adds a custom error when an invalid date is entered" do
+        subject.date_of_birth = { 3 => -1, 2 => -1, 1 => -1 }
+        expect(subject).to_not be_valid
+        expect(subject.errors[:date_of_birth]).to include("You did not enter a valid date of birth")
+      end
+    end
   end
 
   describe "#reviewable_answers" do


### PR DESCRIPTION
### JIRA ticket number

[GITPB-593](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?assignee=5e997e0e6b01320c41b6d21c&selectedIssue=GITPB-593)

### Context

When a user enters an invalid date of birth we show them the same error as if they hadn't entered a value at all (and we also clear the date of birth field), which is confusing for users. Instead, we should show them a different error message that informs them they have entered an invalid date of birth.

### Changes proposed in this pull request

- Custom error for invalid date of birth

Previously when an invalid `date_of_birth` was set we were showing the validation error associated with the `presence` validation (as we rescue and `nil` the `date_of_birth` if it can't be parsed as a `Date`).

Instead, this commit will add a custom error message when we rescue from an invalid date format and inform the user that they did not enter a valid date of birth.

Clean up `DateOfBirth` model, specifically around attribute assignment in `date_of_birth`.

### Guidance to review

We're constrained by the GOV.UK form builder somewhat here, so it's not possible (or at least simple) to add a more specific error message and retain the form values after the page reloads.

![Screenshot 2020-09-14 at 08 16 37](https://user-images.githubusercontent.com/29867726/93055977-a9409a80-f663-11ea-99b9-cb707064a615.png)
