### PR TITLE
Send CSP violations to Sentry

### DIFF
--- a/.env.preprod
+++ b/.env.preprod
@@ -1,2 +1,3 @@
 # Add public environment variables here for the Pre Prod environment
+SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276960/security/?sentry_key=b89dc4f42ee945fdbc2196e59c72d3a4"
 

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 # Add public environment variables here for the Production environment
+SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276960/security/?sentry_key=fc7ea359642d4030a50bbe811ee8ee1d"

--- a/.env.rolling
+++ b/.env.rolling
@@ -1,1 +1,2 @@
 # Add public environment variables here for the Rolling environment
+SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276960/security/?sentry_key=71eaa99a3b1f4fe7941d51ed9d4e146a"

--- a/.env.userresearch
+++ b/.env.userresearch
@@ -1,4 +1,4 @@
 # Add public environment variables here for the User Research environment
 GOOGLE_TAG_MANAGER_ID=GTM-MF9JLJ2
 HOTJAR_ID=1871524
-
+SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276960/security/?sentry_key=44d4f9ff84c9430990794acac74f386b"

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -22,6 +22,7 @@ SecureHeaders::Configuration.default do |config|
     style_src: %w['self' 'unsafe-inline'],
     worker_src: %w['self'],
     upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
+    report_uri: [ENV["SENTRY_CSP_REPORT_URI"]],
   }
 end
 # rubocop:enable Lint/PercentStringArray


### PR DESCRIPTION
### JIRA ticket number

[GITPB-706](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?assignee=5e997e0e6b01320c41b6d21c&selectedIssue=GITPB-706)

### Context

If a CSP violation is triggered we want to report the violation to Sentry so that we will be notified/alerted.

### Changes proposed in this pull request

- Send CSP violations to Sentry
- Rename `initializers/csp` to `initializers/secure_headers` as this file does more than just the CSP.

### Guidance to review

