### PR TITLE
Feature/asterisk

### DIFF
--- a/app/views/teacher_training_adviser/steps/_uk_address.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_address.html.erb
@@ -1,10 +1,10 @@
 <%= f.govuk_fieldset legend: { text: 'What is your address?' } do %>
   <%= f.govuk_text_field :address_line1, width: 20,
-    label: { text: 'Address line 1 *' } %>
+    label: { text: 'Address line 1' } %>
   <%= f.govuk_text_field :address_line2, width: 20,
-    label: { text: 'Address line 2' } %>
+    label: { text: 'Address line 2 (optional)' } %>
   <%= f.govuk_text_field :address_city, width: 20,
-    label: { text: 'Town or City *' } %>
+    label: { text: 'Town or City' } %>
   <%= f.govuk_text_field :address_postcode, width: 20,
-    label: { text: 'Postcode *' } %>
+    label: { text: 'Postcode' } %>
 <% end %>

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -426,13 +426,13 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Continue"
 
       expect(page).to have_text "What is your address?"
-      expect(find_field("Address line 1 *").value).to eq("7 Main Street")
-      expect(find_field("Town or City *").value).to eq("Manchester")
-      expect(find_field("Postcode *").value).to eq("TE7 1NG")
+      expect(find_field("Address line 1").value).to eq("7 Main Street")
+      expect(find_field("Town or City").value).to eq("Manchester")
+      expect(find_field("Postcode").value).to eq("TE7 1NG")
       click_on "Continue"
 
       expect(page).to have_text "You told us you live in the United Kingdom"
-      expect(find_field("Contact telephone number *").value).to eq("123456789")
+      expect(find_field("Contact telephone number").value).to eq("123456789")
       select_first_option "Select your preferred day and time for a callback"
       click_on "Continue"
 
@@ -465,10 +465,10 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
   end
 
   def fill_in_address_step
-    fill_in "Address line 1 *", with: "7"
-    fill_in "Address line 2", with: "Main Street"
-    fill_in "Town or City *", with: "Edinburgh"
-    fill_in "Postcode *", with: "EH12 8JF"
+    fill_in "Address line 1", with: "7"
+    fill_in "Address line 2 (optional)", with: "Main Street"
+    fill_in "Town or City", with: "Edinburgh"
+    fill_in "Postcode", with: "EH12 8JF"
   end
 
   def select_first_option(field_label)


### PR DESCRIPTION
asterisks have been used on the candidates address form and this is not the GDS pattern.
PR removes them and also updates the tests to match
