### PR TITLE
GITPB-585 Disable canonical links for now

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <title><%= prefix_title(@page_title) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%= canonical_tag %>
+    <%#= canonical_tag %>
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
     <%= tag :meta, property: 'og:image', content: asset_pack_path('media/images/govuk-opengraph-image.png') %>
     <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>


### PR DESCRIPTION
They are not actually needed for private beta but are currently wrong so may
cause a problem in the future if they end up indexed now

Once we know all the urls these can be corrected properly
