### PR TITLE
Remove current year after 17th September

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,7 +55,4 @@ module ApplicationHelper
       safe_html_format("Change <span class='visually-hidden'> #{step.key.humanize(capitalize: false)}</span>")
     end
   end
-
-  
-
 end

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -22,7 +22,7 @@ module TeacherTrainingAdviser::Steps
     # sets year range for view, this must be within api range!
     def year_range
       years = GetIntoTeachingApiClient::TypesApi.new.get_candidate_initial_teacher_training_years
-      years.select { |year| year.id.to_i == 12_917 || year.value.to_i.between?(Time.zone.today.year, Time.zone.today.next_year(NUMBER_OF_YEARS).year) }
+      years.select { |year| year.id.to_i == 12_917 || year.value.to_i.between?(first_year, first_year + (NUMBER_OF_YEARS - 1)) }
     end
 
     def date_cannot_be_in_the_past
@@ -39,6 +39,15 @@ module TeacherTrainingAdviser::Steps
       returning_teacher = @store["returning_to_teaching"]
 
       returning_teacher
+    end
+
+  private
+
+    def first_year
+      # After 17th September you can no longer start teacher training for that year.
+      current_year = Time.zone.today.year
+      include_current_year = Time.zone.today < Date.new(current_year, 9, 18)
+      include_current_year ? current_year : current_year + 1
     end
   end
 end

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -37,8 +37,24 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
 
     let(:years) { subject.year_range }
 
-    it "returns 'Not sure', and the current year plus next 3 years" do
-      expect(years.map(&:value)).to eq(["Not sure", 2020, 2021, 2022, 2023])
+    context "when its on or before 17th September of the current year" do
+      around do |example|
+        travel_to(Date.new(2020, 9, 17)) { example.run }
+      end
+
+      it "returns 'Not sure', and the current year plus next 2 years" do
+        expect(years.map(&:value)).to eq(["Not sure", 2020, 2021, 2022])
+      end
+    end
+
+    context "when its after 17th September of the current year" do
+      around do |example|
+        travel_to(Date.new(2020, 9, 18)) { example.run }
+      end
+
+      it "returns 'Not sure', and the next 3 years" do
+        expect(years.map(&:value)).to eq(["Not sure", 2021, 2022, 2023])
+      end
     end
   end
 


### PR DESCRIPTION
Once it has passed the 17th September it is no longer possible to apply for teacher training for the current year.
