### PR TITLE
Fixed the default colour of all links

### DIFF
--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -8,6 +8,7 @@
 
 $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
+$govuk-global-styles: true;
 
 @import "~govuk-frontend/govuk/all";
 


### PR DESCRIPTION
### Context

All links in the site are currently in the wrong colour. This is because they lack the `govuk-link` class

### Changes proposed in this pull request

1. Set the `govuk-global-styles` variable to true - this merges in the `.govuk-link` class to the default `a` tag and `.govuk-body-m` class to the `p` tag