### PR TITLE
Fix for typo's on cookie preferences page

### DIFF
--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -150,12 +150,12 @@
 
               <ul>
                 <li>
-                  your progress through a form (for example a licence
+                  remember your progress through a form (for example a licence
                   application)
                 </li>
                 <li>
-                  the notifications you've seen so we do not show them to you
-                  again
+                  remember the notifications you've seen so we do not show them
+                  to you again
                 </li>
               </ul>
 


### PR DESCRIPTION
### Context

There are a couple of missing words on the cookie preferences page

### Changes proposed in this pull request

1. Add in the missing words



