### PR TITLE
Remove No Preference from subject taught list

### DIFF
--- a/app/models/teacher_training_adviser/steps/subject_taught.rb
+++ b/app/models/teacher_training_adviser/steps/subject_taught.rb
@@ -2,12 +2,16 @@ module TeacherTrainingAdviser::Steps
   class SubjectTaught < Wizard::Step
     extend ApiOptions
 
+    NO_PREFERENCE_ID = "bc68e0c1-7212-e911-a974-000d3a206976".freeze
+
     attribute :subject_taught_id, :string
 
     validates :subject_taught_id, types: { method: :get_teaching_subjects }
 
     def self.options
-      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects)
+      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects).reject do |_, value|
+        value == NO_PREFERENCE_ID
+      end
     end
 
     def skipped?

--- a/app/views/teacher_training_adviser/steps/_subject_taught.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_taught.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_collection_select :subject_taught_id,
-  GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects,
-  :id,
-  :value,
+  f.object.class.options,
+  :last,
+  :first,
   label: { text: "Which main subject did you previously teach?", tag: "h1", size: "m" }
 %>

--- a/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
@@ -3,9 +3,24 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::SubjectTaught do
   include_context "wizard step"
   it_behaves_like "a wizard step"
+  it_behaves_like "a wizard step that exposes API types as options", :get_teaching_subjects
 
   context "attributes" do
     it { is_expected.to respond_to :subject_taught_id }
+  end
+
+  describe ".options" do
+    it "does not return the No Preference option" do
+      types = [
+        GetIntoTeachingApiClient::TypeEntity.new(id: "1", value: "one"),
+        GetIntoTeachingApiClient::TypeEntity.new(id: described_class::NO_PREFERENCE_ID, value: "two"),
+      ]
+
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_teaching_subjects) { types }
+
+      expect(described_class.options.values).to_not include(described_class::NO_PREFERENCE_ID)
+    end
   end
 
   describe "#subject_taught_id" do


### PR DESCRIPTION
We should not allow 'no preference' as an option for previous subject taught.

