### PR TITLE
Fix the text colour after accepting cookies from the banner

### DIFF
--- a/app/views/shared/_cookie_banner.html.erb
+++ b/app/views/shared/_cookie_banner.html.erb
@@ -32,11 +32,13 @@
   <div id="cookie-banner-flash" class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        We've updated your cookie settings. You can
+        <p>We've updated your cookie settings.</p>
 
-        <%= link_to 'change your cookie settings', cookie_preference_path %>
-
-        at any time.
+        <p>
+          You can
+          <%= link_to 'change your cookie settings', cookie_preference_path %>
+          at any time.
+        </p>
       </div>
 
       <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
### Context

Currently the confirmation text shown, after accepting cookies in the banner, is white which is hard to see against the blue background.

### Changes proposed in this pull request

1. Use <p> tags so it shows in black



