### PR TITLE
Error pages were showing aligned to the left side of the screen

### DIFF
--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,8 +1,6 @@
-<div class="govuk-main-wrapper">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">We're sorry, but something went wrong.</h1>
-      <p class="govuk-body">If you are the application owner check the logs for more information.</p>
-    </div>
+<main class="govuk-main-wrapper" id="main-content" role="main">
+  <div class="govuk-width-container">
+    <h1 class="govuk-heading-xl">We're sorry, but something went wrong.</h1>
+    <p class="govuk-body">If you are the application owner check the logs for more information.</p>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,9 +1,7 @@
-<div class="govuk-main-wrapper">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">The page you were looking for doesn't exist.</h1>
-      <p class="govuk-body">You may have mistyped the address or the page may have moved.</p>
-      <p class="govuk-body">If you are the application owner check the logs for more information.</p>
-    </div>
+<main class="govuk-main-wrapper" id="main-content" role="main">
+  <div class="govuk-width-container">
+    <h1 class="govuk-heading-xl">The page you were looking for doesn't exist.</h1>
+    <p class="govuk-body">You may have mistyped the address or the page may have moved.</p>
+    <p class="govuk-body">If you are the application owner check the logs for more information.</p>
   </div>
-</div>
+</main>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,9 +1,7 @@
-<div class="govuk-main-wrapper">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>
-      <p class="govuk-body">Maybe you tried to change something you didn't have access to.</p>
-      <p class="govuk-body">If you are the application owner check the logs for more information.</p>
-    </div>
+<main class="govuk-main-wrapper" id="main-content" role="main">
+  <div class="govuk-width-container">
+    <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>
+    <p class="govuk-body">Maybe you tried to change something you didn't have access to.</p>
+    <p class="govuk-body">If you are the application owner check the logs for more information.</p>
   </div>
 </div>


### PR DESCRIPTION
### Context

Error pages (404, 500, etc) were not showing within the fixed width central column of the site

### Changes proposed in this pull request

1. Added container class
2. Removed 2/3rds width restriction



