### PR TITLE
Remove usage of html_safe

### DIFF
--- a/app/helpers/text_format_helper.rb
+++ b/app/helpers/text_format_helper.rb
@@ -7,6 +7,6 @@ module TextFormatHelper
   end
 
   def safe_html_format(html)
-    sanitize html, tags: %w[strong a ul li p b span], attributes: %w[href class]
+    sanitize html, tags: %w[strong a ul li p b span br], attributes: %w[href class]
   end
 end

--- a/app/views/wizard/steps/_authenticate.html.erb
+++ b/app/views/wizard/steps/_authenticate.html.erb
@@ -6,4 +6,4 @@
 
 <%= f.govuk_text_field :timed_one_time_password, 
 label: { text: "Enter the verification code sent to #{email}" }, 
-hint_text: hint_text.html_safe %>
+hint_text: safe_html_format(hint_text) %>

--- a/spec/helpers/text_format_helper_spec.rb
+++ b/spec/helpers/text_format_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe TextFormatHelper, type: :helper do
     subject { safe_html_format html }
 
     context "with allowed HTML" do
-      let(:html) { "<p><strong>hello</strong> <a href=\"http://test.com\">world</a></p><ul><li>test</li></ul>" }
+      let(:html) { "<p><strong>hello</strong><br><a href=\"http://test.com\">world</a></p><ul><li>test</li></ul>" }
       it { is_expected.to eql html }
     end
 


### PR DESCRIPTION
Avoids use of `html_safe` by running through `sanitize` with a whitelist of allowed tags.
