### PR TITLE
Update copy for overseas candidate callback

### DIFF
--- a/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
@@ -1,7 +1,7 @@
 <%= f.govuk_fieldset legend: { text: 'You told us you have an equivalent degree and live overseas' } do %>
 
-<p class="govuk-body">You need to book a callback with us. We will contact you once your call is booked. If you use an international phone number there may be a short delay in one of us contacting you. </p>
-<p class="govuk-body">You must have the details of your overseas qualifications when we contact you.</p>
+<p>We will need to call you to discuss your qualifications. You must have the details of your overseas qualifications when we contact you. There may be a short delay in us contacting you if you’re providing an international phone number.</p> 
+<p>In the meantime, if you need to speak to us you can, by using Freephone <%= link_to("0800 389 2501", "tel://08003892501") %> between 8am - 8pm Monday to Friday.</p>
 
 <%= f.govuk_phone_field :telephone, width: 20,
   label: { text: 'Contact telephone number' } %>


### PR DESCRIPTION
They are no longer booking a callback slot, so the copy has been updated to reflect that.

