### PR TITLE
Remove unknown country from options

### DIFF
--- a/app/models/teacher_training_adviser/steps/overseas_country.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_country.rb
@@ -6,8 +6,15 @@ module TeacherTrainingAdviser::Steps
 
     validates :country_id, types: { method: :get_country_types }
 
+    IGNORE_COUNTRY_IDS = [
+      "76f5c2e6-74f9-e811-a97a-000d3a2760f2", # Unknown
+      "72f5c2e6-74f9-e811-a97a-000d3a2760f2", # United Kingdom
+    ].freeze
+
     def self.options
-      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_country_types)
+      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_country_types).reject do |_, id|
+        IGNORE_COUNTRY_IDS.include?(id)
+      end
     end
 
     def skipped?

--- a/app/views/teacher_training_adviser/steps/_overseas_country.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_country.html.erb
@@ -1,9 +1,6 @@
-<% countries = GetIntoTeachingApiClient::TypesApi.new.get_country_types.sort_by { |k| k.value } %>
-<% countries.delete_if { |k| k.value == "United Kingdom" } %>
-
 <%= f.govuk_collection_select :country_id,
-  countries,
-  :id,
-  :value,
+  f.object.class.options,
+  :last,
+  :first,
   label: { text: "Which country do you live in?", tag: "h1", size: "m" }
 %>

--- a/spec/models/teacher_training_adviser/steps/overseas_country_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_country_spec.rb
@@ -9,6 +9,23 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasCountry do
     it { is_expected.to respond_to :country_id }
   end
 
+  describe ".options" do
+    it "does not return the ignored countries" do
+      types = [
+        GetIntoTeachingApiClient::TypeEntity.new(id: "1", value: "one"),
+      ]
+
+      types += described_class::IGNORE_COUNTRY_IDS.map do |id|
+        GetIntoTeachingApiClient::TypeEntity.new(id: id, value: "ignored")
+      end
+
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_country_types) { types }
+
+      expect(described_class.options.values).to contain_exactly("1")
+    end
+  end
+
   describe "country_id" do
     it "allows a valid country id" do
       country = GetIntoTeachingApiClient::TypeEntity.new(id: "abc-123")


### PR DESCRIPTION
The CRM contains an 'Unknown' country type - we don't want to display this to users in the overseas country step.

Refactors the logic to remove the United Kingdom country from the view into the model.
