### PR TITLE
Created internal routes for Prometheus

### DIFF
--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -21,9 +21,7 @@ resource "cloudfoundry_app" "adviser_application" {
         route = routes.value["id"]
       }
     }
-    routes {
-        route = cloudfoundry_route.adviser_route.id
-    }    
+
     environment = {
        HTTPAUTH_PASSWORD = var.HTTPAUTH_PASSWORD
        HTTPAUTH_USERNAME = var.HTTPAUTH_USERNAME
@@ -33,14 +31,3 @@ resource "cloudfoundry_app" "adviser_application" {
     }    
 }
 
-resource "cloudfoundry_route" "adviser_route" {
-    domain = data.cloudfoundry_domain.cloudapps.id
-    space = data.cloudfoundry_space.space.id
-    hostname =  var.paas_adviser_route_name
-}
-
-data "cloudfoundry_route" "app_route_internet" {
-    count = var.additional_routes
-    domain = data.cloudfoundry_domain.internet.id
-    hostname = var.paas_additional_route_name
-}

--- a/terraform/paas/domain.tf
+++ b/terraform/paas/domain.tf
@@ -5,3 +5,7 @@ data "cloudfoundry_domain" "cloudapps" {
 data "cloudfoundry_domain" "internet" {
     name = "education.gov.uk"
 }
+
+data "cloudfoundry_domain" "internal" {
+    name = "apps.internal"
+}

--- a/terraform/paas/routes.tf
+++ b/terraform/paas/routes.tf
@@ -1,0 +1,23 @@
+resource "cloudfoundry_route" "adviser_route" {
+    domain = data.cloudfoundry_domain.cloudapps.id
+    hostname =  var.paas_adviser_route_name
+    space = data.cloudfoundry_space.space.id
+    target {
+          app = cloudfoundry_app.adviser_application.id
+    }
+
+}
+resource "cloudfoundry_route" "app_route_internal" {
+    domain = data.cloudfoundry_domain.internal.id
+    hostname =  "${var.paas_adviser_route_name}-internal"
+    space = data.cloudfoundry_space.space.id
+    target {
+          app = cloudfoundry_app.adviser_application.id
+    }
+}
+
+data "cloudfoundry_route" "app_route_internet" {
+    count = var.additional_routes
+    domain = data.cloudfoundry_domain.internet.id
+    hostname = var.paas_additional_route_name
+}

--- a/terraform/paas/test.env.tfvars
+++ b/terraform/paas/test.env.tfvars
@@ -2,7 +2,7 @@ paas_space="get-into-teaching-test"
 paas_adviser_application_name="get-teacher-training-adviser-service-test"
 paas_adviser_route_name="get-teacher-training-adviser-service-test"
 paas_redis_1_name="get-into-teaching-test-redis-svc"
-paas_additional_route_name="beta-adviser-getintoteaching"
+paas_additional_route_name="staging-adviser-getintoteaching"
 logging=1
 additional_routes=0
 


### PR DESCRIPTION
To enable Prometheus to scrape the metrics from each node of the adviser, internal routes are required.

The routes have had to be removed from the application.routes method and moved to routes.application.  Since there were now more resources it made sense to put routes into its own terraform file. (routes.tf)
