### PR TITLE
Bypass password for healthchecks

### DIFF
--- a/app/controllers/healthchecks_controller.rb
+++ b/app/controllers/healthchecks_controller.rb
@@ -1,4 +1,6 @@
 class HealthchecksController < ApplicationController
+  skip_before_action :http_basic_authenticate
+
   def show
     @healthcheck = Healthcheck.new
     render json: @healthcheck

--- a/spec/features/password_protection_spec.rb
+++ b/spec/features/password_protection_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.feature "Password protection", type: :feature do
   before do
-    allow_any_instance_of(Healthcheck).to receive(:test_api).and_return true
     allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with("HTTPAUTH_USERNAME") { username }
     allow(ENV).to receive(:[]).with("HTTPAUTH_PASSWORD") { password }


### PR DESCRIPTION
We don't need to password protect the healthcheck endpoints

