### PR TITLE
Feature/689/logit integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,5 +84,12 @@ group :test do
   gem "webdrivers", "~> 4.3"
 end
 
+group :rolling, :preprod, :userresearch, :production do
+  # loading the Gem monkey patches rails logger
+  # only load in prod-like environments when we actually need it
+  gem "amazing_print"
+  gem "rails_semantic_logger"
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    amazing_print (1.2.1)
     ast (2.4.1)
     bindex (0.8.1)
     bootsnap (1.4.7)
@@ -194,6 +195,10 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_semantic_logger (4.4.4)
+      rack
+      railties (>= 3.2)
+      semantic_logger (~> 4.4)
     railties (6.0.3.3)
       actionpack (= 6.0.3.3)
       activesupport (= 6.0.3.3)
@@ -271,6 +276,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    semantic_logger (4.7.2)
+      concurrent-ruby (~> 1.0)
     semantic_range (2.3.0)
     sentry-raven (3.0.0)
       faraday (>= 1.0)
@@ -332,6 +339,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  amazing_print
   bootsnap (>= 1.1.0)
   brakeman
   byebug
@@ -348,6 +356,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 4.3)
   rails (~> 6.0.3)
+  rails_semantic_logger
   redis
   rspec-rails (~> 4.0.0)
   rspec-sonarqube-formatter (~> 1.3)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -67,16 +67,6 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false
@@ -113,4 +103,21 @@ Rails.application.configure do
                        same_site: :lax,
                        expire_after: 1.day,
                        secure: true
+
+  # Configure Semantic Logging for production environments
+  # This cannot be conditionally loaded so we use it all the time in production
+  # like environments.
+  #
+  # The rails_semantic_logger gem overwrites the log initializer code and by
+  # this point its too late to monkey patch that
+  STDOUT.sync = true
+  SemanticLogger.application = ENV["SEMANTIC_LOGGER_APP"].presence || "Get into Teaching App"
+  config.rails_semantic_logger.started = false
+  config.rails_semantic_logger.processing = false
+  config.rails_semantic_logger.format = :json
+  config.rails_semantic_logger.add_file_appender = false
+  config.semantic_logger.add_appender \
+    io: STDOUT,
+    level: Rails.application.config.log_level,
+    formatter: config.rails_semantic_logger.format
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,3 +36,10 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+on_worker_boot do
+  if defined? SemanticLogger
+    # Re-open appenders after forking the process
+    SemanticLogger.reopen
+  end
+end


### PR DESCRIPTION
### JIRA ticket number

GITPB-689

### Context

We should be generating logs which are useful to LogIt - initially that means single line logs, or logs where the multiple parts of a request can be grouped togther

### Changes proposed in this pull request

1. Make STDOUT logs synchronous
2. Only load Semantic logging if either SEMANTIC_LOGGING or CF_INSTANCE_GUID are set
3. Make puma reopen the log output when if it forks a worker if running with semantic logging

### Notes

1. I've tested to make sure param filtering is honoured - visiting `http://localhost:3000/?first_name=Joe` shows as `[FILTERED]`



