### PR TITLE
Remove No Preference and Other from SubjectInterestedTeaching step

### DIFF
--- a/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
@@ -6,8 +6,15 @@ module TeacherTrainingAdviser::Steps
 
     validates :preferred_teaching_subject_id, types: { method: :get_teaching_subjects, message: "Please select a subject" }
 
+    IGNORED_SUBJECT_IDS = [
+      "bc2655a1-2afa-e811-a981-000d3a276620", # Other
+      "bc68e0c1-7212-e911-a974-000d3a206976", # No Preference
+    ].freeze
+
     def self.options
-      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects)
+      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects).reject do |_, id|
+        IGNORED_SUBJECT_IDS.include?(id)
+      end
     end
 
     def reviewable_answers

--- a/app/views/teacher_training_adviser/steps/_subject_interested_teaching.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_interested_teaching.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_collection_select :preferred_teaching_subject_id,
-  GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects,
-  :id,
-  :value,
+  f.object.class.options,
+  :last,
+  :first,
   label: { text: "Which subject would you like to teach?", tag: "h1", size: "m" }
 %>

--- a/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
@@ -9,6 +9,23 @@ RSpec.describe TeacherTrainingAdviser::Steps::SubjectInterestedTeaching do
     it { is_expected.to respond_to :preferred_teaching_subject_id }
   end
 
+  describe ".options" do
+    it "does not return the ignored subjects" do
+      types = [
+        GetIntoTeachingApiClient::TypeEntity.new(id: "1", value: "one"),
+      ]
+
+      types += described_class::IGNORED_SUBJECT_IDS.map do |id|
+        GetIntoTeachingApiClient::TypeEntity.new(id: id, value: "ignored")
+      end
+
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_teaching_subjects) { types }
+
+      expect(described_class.options.values).to contain_exactly("1")
+    end
+  end
+
   describe "#preferred_teaching_subject_id" do
     it "allows a valid preferred_teaching_subject_id" do
       subject_type = GetIntoTeachingApiClient::TypeEntity.new(id: "abc-123")


### PR DESCRIPTION
We no longer want to allow the options 'No Preference' and 'Other' to be selected in response to the question "What subject would you like to teach?".
