### PR TITLE
Rescue on GetIntoTeachingApiClient::ApiError

### DIFF
--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -8,7 +8,7 @@ class Healthcheck
   def test_api
     GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects
     true
-  rescue Faraday::Error
+  rescue Faraday::Error, GetIntoTeachingApiClient::ApiError
     false
   end
 

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -41,6 +41,15 @@ RSpec.describe Healthcheck do
 
       it { is_expected.to be false }
     end
+
+    context "with an API error" do
+      before do
+        expect_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+          receive(:get_teaching_subjects).and_raise(GetIntoTeachingApiClient::ApiError)
+      end
+
+      it { is_expected.to be false }
+    end
   end
 
   describe "#test_redis" do


### PR DESCRIPTION
The Api Client rescues errors and exposes them as an ApiError, we need to rescue on this as well as the underlying Faraday error.
