### PR TITLE
Prometheus metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem "dotenv-rails"
 # redis for session store
 gem "redis"
 
+gem "prometheus-client"
+
 gem "country_select", "~> 4.0"
 
 # api client

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
+    prometheus-client (2.1.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -343,6 +344,7 @@ DEPENDENCIES
   get_into_teaching_api_client_faraday!
   govuk_design_system_formbuilder
   listen (>= 3.0.5, < 3.3)
+  prometheus-client
   pry-byebug
   puma (~> 4.3)
   rails (~> 6.0.3)

--- a/config.ru
+++ b/config.ru
@@ -2,4 +2,11 @@
 
 require_relative 'config/environment'
 
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
+use Rack::Deflater
+use Prometheus::Middleware::Collector
+use Prometheus::Middleware::Exporter
+
 run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,9 +15,22 @@ require "action_view/railtie"
 # require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
+require "prometheus/client/data_stores/direct_file_store"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+
+PROMETHEUS_DIR = "/tmp/prometheus".freeze
+
+# Needs to clear before initializing.
+Dir["#{PROMETHEUS_DIR}/*.bin"].each do |file_path|
+  File.unlink(file_path)
+end
+
+# The DirectFileStore is the only way to aggregate metrics across processes.
+file_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: PROMETHEUS_DIR)
+Prometheus::Client.config.data_store = file_store
 
 module GetIntoTeachingRegister
   class Application < Rails::Application

--- a/config/initializers/instrumentation.rb
+++ b/config/initializers/instrumentation.rb
@@ -1,0 +1,56 @@
+ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  payload = event.payload.symbolize_keys.reject { |_, v| v.nil? }
+
+  prometheus = Prometheus::Client.registry
+
+  labels = { path: nil, method: nil, status: nil }
+  labels.merge!(payload.slice(*labels.keys))
+
+  metric = prometheus.get(:requests_total)
+  metric.increment(labels: labels)
+
+  metric = prometheus.get(:request_duration_ms)
+  metric.observe(event.duration, labels: labels)
+
+  if payload.key?(:view_runtime)
+    metric = prometheus.get(:request_view_runtime_ms)
+    metric.observe(payload[:view_runtime], labels: labels)
+  end
+end
+
+ActiveSupport::Notifications.subscribe "render_template.action_view" do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+
+  prometheus = Prometheus::Client.registry
+
+  labels = { identifier: nil }
+  labels.merge!(event.payload.symbolize_keys.slice(*labels.keys))
+
+  metric = prometheus.get(:render_view_ms)
+  metric.observe(event.duration, labels: labels)
+end
+
+ActiveSupport::Notifications.subscribe "render_partial.action_view" do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+
+  prometheus = Prometheus::Client.registry
+
+  labels = { identifier: nil }
+  labels.merge!(event.payload.symbolize_keys.slice(*labels.keys))
+
+  metric = prometheus.get(:render_partial_ms)
+  metric.observe(event.duration, labels: labels)
+end
+
+ActiveSupport::Notifications.subscribe "cache_read.active_support" do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+
+  prometheus = Prometheus::Client.registry
+
+  labels = { key: nil, hit: nil }
+  labels.merge!(event.payload.symbolize_keys.slice(*labels.keys))
+
+  metric = prometheus.get(:cache_read_total)
+  metric.increment(labels: labels)
+end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,1 @@
+require "prometheus/metrics"

--- a/lib/prometheus/metrics.rb
+++ b/lib/prometheus/metrics.rb
@@ -1,0 +1,41 @@
+module Prometheus
+  module Metrics
+    prometheus = Prometheus::Client.registry
+
+    prometheus.counter(
+      :requests_total,
+      docstring: "A counter of requests",
+      labels: %i[path method status],
+    )
+
+    prometheus.histogram(
+      :request_duration_ms,
+      docstring: "A histogram of request durations",
+      labels: %i[path method status],
+    )
+
+    prometheus.histogram(
+      :request_view_runtime_ms,
+      docstring: "A histogram of request view runtimes",
+      labels: %i[path method status],
+    )
+
+    prometheus.histogram(
+      :render_view_ms,
+      docstring: "A histogram of view rendering times",
+      labels: %i[identifier],
+    )
+
+    prometheus.histogram(
+      :render_partial_ms,
+      docstring: "A histogram of partial rendering times",
+      labels: %i[identifier],
+    )
+
+    prometheus.counter(
+      :cache_read_total,
+      docstring: "A counter of cache reads",
+      labels: %i[key hit],
+    )
+  end
+end

--- a/spec/lib/metrics_spec.rb
+++ b/spec/lib/metrics_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Prometheus::Metrics do
+  let(:registry) { Prometheus::Client.registry }
+
+  describe "request_total" do
+    subject { registry.get(:requests_total) }
+
+    it { is_expected.not_to be_nil }
+    it { is_expected.to have_attributes(docstring: "A counter of requests") }
+    it { expect { subject.get(labels: %i[path method status]) }.to_not raise_error }
+  end
+
+  describe "request_duration_ms" do
+    subject { registry.get(:request_duration_ms) }
+
+    it { is_expected.not_to be_nil }
+    it { is_expected.to have_attributes(docstring: "A histogram of request durations") }
+    it { expect { subject.get(labels: %i[path method status]) }.to_not raise_error }
+  end
+
+  describe "request_view_runtime_ms" do
+    subject { registry.get(:request_view_runtime_ms) }
+
+    it { is_expected.not_to be_nil }
+    it { is_expected.to have_attributes(docstring: "A histogram of request view runtimes") }
+    it { expect { subject.get(labels: %i[path method status]) }.to_not raise_error }
+  end
+
+  describe "render_view_ms" do
+    subject { registry.get(:render_view_ms) }
+
+    it { is_expected.not_to be_nil }
+    it { is_expected.to have_attributes(docstring: "A histogram of view rendering times") }
+    it { expect { subject.get(labels: %i[identifier]) }.to_not raise_error }
+  end
+
+  describe "render_partial_ms" do
+    subject { registry.get(:render_partial_ms) }
+
+    it { is_expected.not_to be_nil }
+    it { is_expected.to have_attributes(docstring: "A histogram of partial rendering times") }
+    it { expect { subject.get(labels: %i[identifier]) }.to_not raise_error }
+  end
+
+  describe "cache_read_total" do
+    subject { registry.get(:cache_read_total) }
+
+    it { is_expected.not_to be_nil }
+    it { is_expected.to have_attributes(docstring: "A counter of cache reads") }
+    it { expect { subject.get(labels: %i[key hit]) }.to_not raise_error }
+  end
+end

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe "Instrumentation" do
+  let(:registry) { Prometheus::Client.registry }
+
+  describe "process_action.action_controller" do
+    after { get cookies_path }
+
+    it "increments the :requests_total metric" do
+      metric = registry.get(:requests_total)
+      expect(metric).to receive(:increment).with(labels: { path: "/cookies", method: "GET", status: 200 }).once
+    end
+
+    it "observes the :request_duration_ms metric" do
+      metric = registry.get(:request_duration_ms)
+      expect(metric).to receive(:observe).with(instance_of(Float), labels: { path: "/cookies", method: "GET", status: 200 }).once
+    end
+
+    it "observes the :request_view_runtime_ms metric" do
+      metric = registry.get(:request_view_runtime_ms)
+      expect(metric).to receive(:observe).with(instance_of(Float), labels: { path: "/cookies", method: "GET", status: 200 }).once
+    end
+  end
+
+  describe "render_template.action_view" do
+    after { get cookie_preference_path }
+
+    it "observes the :render_view_ms metric" do
+      metric = registry.get(:render_view_ms)
+      expect(metric).to receive(:observe).with(instance_of(Float), labels: {
+        identifier: Rails.root.join("app/views/cookie_preferences/show.html.erb").to_s,
+      }).once
+    end
+  end
+
+  describe "render_partial.action_view" do
+    after { get root_path }
+
+    it "observes the :render_view_ms metric" do
+      metric = registry.get(:render_partial_ms)
+      allow(metric).to receive(:observe)
+      expect(metric).to receive(:observe).with(instance_of(Float), labels: {
+        identifier: Rails.root.join("app/views/layouts/_footer.html.erb").to_s,
+      }).once
+    end
+  end
+
+  describe "cache_read.active_support" do
+    after { get privacy_policy_path }
+
+    it "observes the :cache_read_total metric" do
+      metric = registry.get(:cache_read_total)
+      expect(metric).to receive(:increment).with(labels: {
+        key: instance_of(String),
+        hit: false,
+      }).twice
+    end
+  end
+end


### PR DESCRIPTION
- Add Prometheus::Client

Add the Prometheus::Client for aggregating and exporting metrics on the /metrics endpoint.

Configured to use DirectFileStore as this supports Puma forking additional processes (by default metrics will be summed together; if we use a gauge metric this may not be desirable). The DirectFileStore is the recommended approach for applications with pre-fork servers/multi-processors, but there are caveats:

When scraped by Prometheus the store reads all the files into memory (one file per metric per process), which can bump up the memory usage a fair amount. I don't anticipate this being an issue for us yet/soon given the amount of metrics we're collecting is small.

The metric files need to be cleared out each time the application starts to avoid a new instance exporting metrics from a previous one; I've done this programatically on start but since we're dockerized it probably won't matter anyway.

A large number of files can be created; there's no real solution for this one in the client library. If we're on the way to running out of disk space we should be alerted by infrastructure monitoring, but I imagine worst-case scenario is the container runs out of memory, blows up and a new one spins up to take it's place. It would only result in a problem if it happens on all instances at the same time - if we're worried about that then we could schedule periodic restarts of the instances to keep the usage low.

- Add ActiveSupport::Notifications instrumentation

Add metrics for recording notifications exposed from ActiveSupport, such as request durations, view rendering runtimes and cache reads.
