### PR TITLE
Prefix metrics with "tta_"

### DIFF
--- a/config/initializers/instrumentation.rb
+++ b/config/initializers/instrumentation.rb
@@ -7,14 +7,14 @@ ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*a
   labels = { path: nil, method: nil, status: nil }
   labels.merge!(payload.slice(*labels.keys))
 
-  metric = prometheus.get(:requests_total)
+  metric = prometheus.get(:tta_requests_total)
   metric.increment(labels: labels)
 
-  metric = prometheus.get(:request_duration_ms)
+  metric = prometheus.get(:tta_request_duration_ms)
   metric.observe(event.duration, labels: labels)
 
   if payload.key?(:view_runtime)
-    metric = prometheus.get(:request_view_runtime_ms)
+    metric = prometheus.get(:tta_request_view_runtime_ms)
     metric.observe(payload[:view_runtime], labels: labels)
   end
 end
@@ -27,7 +27,7 @@ ActiveSupport::Notifications.subscribe "render_template.action_view" do |*args|
   labels = { identifier: nil }
   labels.merge!(event.payload.symbolize_keys.slice(*labels.keys))
 
-  metric = prometheus.get(:render_view_ms)
+  metric = prometheus.get(:tta_render_view_ms)
   metric.observe(event.duration, labels: labels)
 end
 
@@ -39,7 +39,7 @@ ActiveSupport::Notifications.subscribe "render_partial.action_view" do |*args|
   labels = { identifier: nil }
   labels.merge!(event.payload.symbolize_keys.slice(*labels.keys))
 
-  metric = prometheus.get(:render_partial_ms)
+  metric = prometheus.get(:tta_render_partial_ms)
   metric.observe(event.duration, labels: labels)
 end
 
@@ -51,6 +51,6 @@ ActiveSupport::Notifications.subscribe "cache_read.active_support" do |*args|
   labels = { key: nil, hit: nil }
   labels.merge!(event.payload.symbolize_keys.slice(*labels.keys))
 
-  metric = prometheus.get(:cache_read_total)
+  metric = prometheus.get(:tta_cache_read_total)
   metric.increment(labels: labels)
 end

--- a/lib/prometheus/metrics.rb
+++ b/lib/prometheus/metrics.rb
@@ -3,37 +3,37 @@ module Prometheus
     prometheus = Prometheus::Client.registry
 
     prometheus.counter(
-      :requests_total,
+      :tta_requests_total,
       docstring: "A counter of requests",
       labels: %i[path method status],
     )
 
     prometheus.histogram(
-      :request_duration_ms,
+      :tta_request_duration_ms,
       docstring: "A histogram of request durations",
       labels: %i[path method status],
     )
 
     prometheus.histogram(
-      :request_view_runtime_ms,
+      :tta_request_view_runtime_ms,
       docstring: "A histogram of request view runtimes",
       labels: %i[path method status],
     )
 
     prometheus.histogram(
-      :render_view_ms,
+      :tta_render_view_ms,
       docstring: "A histogram of view rendering times",
       labels: %i[identifier],
     )
 
     prometheus.histogram(
-      :render_partial_ms,
+      :tta_render_partial_ms,
       docstring: "A histogram of partial rendering times",
       labels: %i[identifier],
     )
 
     prometheus.counter(
-      :cache_read_total,
+      :tta_cache_read_total,
       docstring: "A counter of cache reads",
       labels: %i[key hit],
     )

--- a/spec/lib/metrics_spec.rb
+++ b/spec/lib/metrics_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Prometheus::Metrics do
   let(:registry) { Prometheus::Client.registry }
 
   describe "request_total" do
-    subject { registry.get(:requests_total) }
+    subject { registry.get(:tta_requests_total) }
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of requests") }
@@ -12,7 +12,7 @@ RSpec.describe Prometheus::Metrics do
   end
 
   describe "request_duration_ms" do
-    subject { registry.get(:request_duration_ms) }
+    subject { registry.get(:tta_request_duration_ms) }
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of request durations") }
@@ -20,7 +20,7 @@ RSpec.describe Prometheus::Metrics do
   end
 
   describe "request_view_runtime_ms" do
-    subject { registry.get(:request_view_runtime_ms) }
+    subject { registry.get(:tta_request_view_runtime_ms) }
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of request view runtimes") }
@@ -28,7 +28,7 @@ RSpec.describe Prometheus::Metrics do
   end
 
   describe "render_view_ms" do
-    subject { registry.get(:render_view_ms) }
+    subject { registry.get(:tta_render_view_ms) }
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of view rendering times") }
@@ -36,7 +36,7 @@ RSpec.describe Prometheus::Metrics do
   end
 
   describe "render_partial_ms" do
-    subject { registry.get(:render_partial_ms) }
+    subject { registry.get(:tta_render_partial_ms) }
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of partial rendering times") }
@@ -44,7 +44,7 @@ RSpec.describe Prometheus::Metrics do
   end
 
   describe "cache_read_total" do
-    subject { registry.get(:cache_read_total) }
+    subject { registry.get(:tta_cache_read_total) }
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of cache reads") }

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -7,17 +7,17 @@ RSpec.describe "Instrumentation" do
     after { get cookies_path }
 
     it "increments the :requests_total metric" do
-      metric = registry.get(:requests_total)
+      metric = registry.get(:tta_requests_total)
       expect(metric).to receive(:increment).with(labels: { path: "/cookies", method: "GET", status: 200 }).once
     end
 
     it "observes the :request_duration_ms metric" do
-      metric = registry.get(:request_duration_ms)
+      metric = registry.get(:tta_request_duration_ms)
       expect(metric).to receive(:observe).with(instance_of(Float), labels: { path: "/cookies", method: "GET", status: 200 }).once
     end
 
     it "observes the :request_view_runtime_ms metric" do
-      metric = registry.get(:request_view_runtime_ms)
+      metric = registry.get(:tta_request_view_runtime_ms)
       expect(metric).to receive(:observe).with(instance_of(Float), labels: { path: "/cookies", method: "GET", status: 200 }).once
     end
   end
@@ -26,7 +26,7 @@ RSpec.describe "Instrumentation" do
     after { get cookie_preference_path }
 
     it "observes the :render_view_ms metric" do
-      metric = registry.get(:render_view_ms)
+      metric = registry.get(:tta_render_view_ms)
       expect(metric).to receive(:observe).with(instance_of(Float), labels: {
         identifier: Rails.root.join("app/views/cookie_preferences/show.html.erb").to_s,
       }).once
@@ -37,7 +37,7 @@ RSpec.describe "Instrumentation" do
     after { get root_path }
 
     it "observes the :render_view_ms metric" do
-      metric = registry.get(:render_partial_ms)
+      metric = registry.get(:tta_render_partial_ms)
       allow(metric).to receive(:observe)
       expect(metric).to receive(:observe).with(instance_of(Float), labels: {
         identifier: Rails.root.join("app/views/layouts/_footer.html.erb").to_s,
@@ -49,7 +49,7 @@ RSpec.describe "Instrumentation" do
     after { get privacy_policy_path }
 
     it "observes the :cache_read_total metric" do
-      metric = registry.get(:cache_read_total)
+      metric = registry.get(:tta_cache_read_total)
       expect(metric).to receive(:increment).with(labels: {
         key: instance_of(String),
         hit: false,


### PR DESCRIPTION
As we only have one Prometheus server scraping all apps we need to differentiate the metric names; adding "tta_" as the prefix to these metrics will enable us to find them in Grafana more easily and avoid clashes with other apps.

