### PR TITLE
Remove API calls from view partials

### DIFF
--- a/app/models/concerns/api_options.rb
+++ b/app/models/concerns/api_options.rb
@@ -1,5 +1,11 @@
 module ApiOptions
-  def generate_api_options(api_call)
-    api_call.reduce({}) { |options, type| options.update(type.value => type.id.to_s) }
+  def generate_api_options(types_method_call, omit_ids = [])
+    api = GetIntoTeachingApiClient::TypesApi.new
+
+    types = api.send(types_method_call).reject do |type|
+      omit_ids.include?(type.id)
+    end
+
+    types.reduce({}) { |options, type| options.update(type.value => type.id.to_s) }
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_country.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_country.rb
@@ -6,15 +6,13 @@ module TeacherTrainingAdviser::Steps
 
     validates :country_id, types: { method: :get_country_types }
 
-    IGNORE_COUNTRY_IDS = [
+    OMIT_COUNTRY_IDS = [
       "76f5c2e6-74f9-e811-a97a-000d3a2760f2", # Unknown
       "72f5c2e6-74f9-e811-a97a-000d3a2760f2", # United Kingdom
     ].freeze
 
     def self.options
-      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_country_types).reject do |_, id|
-        IGNORE_COUNTRY_IDS.include?(id)
-      end
+      generate_api_options(:get_country_types, OMIT_COUNTRY_IDS)
     end
 
     def skipped?

--- a/app/models/teacher_training_adviser/steps/stage_of_degree.rb
+++ b/app/models/teacher_training_adviser/steps/stage_of_degree.rb
@@ -20,7 +20,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def self.options
-      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_qualification_degree_status)
+      generate_api_options(:get_qualification_degree_status)
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -1,17 +1,12 @@
 module TeacherTrainingAdviser::Steps
   class StartTeacherTraining < Wizard::Step
-    extend ApiOptions
-
     attribute :initial_teacher_training_year_id, :integer
 
     validates :initial_teacher_training_year_id, types: { method: :get_candidate_initial_teacher_training_years, message: "You must select an option from the list" }
-    validate :date_cannot_be_in_the_past, unless: :dont_know
+    validate :date_cannot_be_in_the_past, unless: :not_sure?
 
     NUMBER_OF_YEARS = 3
-
-    def self.options
-      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_candidate_initial_teacher_training_years)
-    end
+    NOT_SURE_ID = 12_917
 
     def reviewable_answers
       super.tap do |answers|
@@ -19,7 +14,6 @@ module TeacherTrainingAdviser::Steps
       end
     end
 
-    # sets year range for view, this must be within api range!
     def year_range
       years = GetIntoTeachingApiClient::TypesApi.new.get_candidate_initial_teacher_training_years
       years.select { |year| year.id.to_i == 12_917 || year.value.to_i.between?(first_year, first_year + (NUMBER_OF_YEARS - 1)) }
@@ -31,8 +25,8 @@ module TeacherTrainingAdviser::Steps
       end
     end
 
-    def dont_know
-      initial_teacher_training_year_id == self.class.options["Not sure"].to_i
+    def not_sure?
+      initial_teacher_training_year_id == NOT_SURE_ID
     end
 
     def skipped?

--- a/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
@@ -6,15 +6,13 @@ module TeacherTrainingAdviser::Steps
 
     validates :preferred_teaching_subject_id, types: { method: :get_teaching_subjects, message: "Please select a subject" }
 
-    IGNORED_SUBJECT_IDS = [
+    OMIT_SUBJECT_IDS = [
       "bc2655a1-2afa-e811-a981-000d3a276620", # Other
       "bc68e0c1-7212-e911-a974-000d3a206976", # No Preference
     ].freeze
 
     def self.options
-      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects).reject do |_, id|
-        IGNORED_SUBJECT_IDS.include?(id)
-      end
+      generate_api_options(:get_teaching_subjects, OMIT_SUBJECT_IDS)
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
+++ b/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
@@ -7,7 +7,7 @@ module TeacherTrainingAdviser::Steps
     validates :preferred_teaching_subject_id, types: { method: :get_teaching_subjects, message: "Please select maths, physics or modern foreign language" }
 
     def self.options
-      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects)
+      generate_api_options(:get_teaching_subjects)
     end
 
     def skipped?

--- a/app/models/teacher_training_adviser/steps/subject_taught.rb
+++ b/app/models/teacher_training_adviser/steps/subject_taught.rb
@@ -2,16 +2,16 @@ module TeacherTrainingAdviser::Steps
   class SubjectTaught < Wizard::Step
     extend ApiOptions
 
-    NO_PREFERENCE_ID = "bc68e0c1-7212-e911-a974-000d3a206976".freeze
+    OMIT_SUBJECT_IDS = [
+      "bc68e0c1-7212-e911-a974-000d3a206976", # No Preference
+    ].freeze
 
     attribute :subject_taught_id, :string
 
     validates :subject_taught_id, types: { method: :get_teaching_subjects }
 
     def self.options
-      generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects).reject do |_, value|
-        value == NO_PREFERENCE_ID
-      end
+      generate_api_options(:get_teaching_subjects, OMIT_SUBJECT_IDS)
     end
 
     def skipped?

--- a/app/models/teacher_training_adviser/steps/what_degree_class.rb
+++ b/app/models/teacher_training_adviser/steps/what_degree_class.rb
@@ -2,15 +2,18 @@ module TeacherTrainingAdviser::Steps
   class WhatDegreeClass < Wizard::Step
     extend ApiOptions
 
+    OMIT_GRADE_IDS = [
+      "222750004", # Third class or below
+      "222750005", # Unknown
+    ].freeze
+
     attribute :uk_degree_grade_id, :integer
 
     def self.options
-      result = generate_api_options(GetIntoTeachingApiClient::TypesApi.new.get_qualification_uk_degree_grades)
-      # remove third class and grade unknown from options
-      result.reject { |_k, v| %w[222750004 222750005].include? v }
+      generate_api_options(:get_qualification_uk_degree_grades, OMIT_GRADE_IDS)
     end
 
-    validates :uk_degree_grade_id, inclusion: { in: TeacherTrainingAdviser::Steps::WhatDegreeClass.options.map { |_k, v| v.to_i }, message: "Select an option from the list" }
+    validates :uk_degree_grade_id, inclusion: { in: options.values.map(&:to_i), message: "Select an option from the list" }
 
     def skipped?
       returning_teacher = @store["returning_to_teaching"]

--- a/app/models/teacher_training_adviser/steps/what_subject_degree.rb
+++ b/app/models/teacher_training_adviser/steps/what_subject_degree.rb
@@ -1,8 +1,14 @@
 module TeacherTrainingAdviser::Steps
   class WhatSubjectDegree < Wizard::Step
+    extend ApiOptions
+
     attribute :degree_subject, :string
 
     validates :degree_subject, presence: true
+
+    def self.options
+      generate_api_options(:get_teaching_subjects)
+    end
 
     def skipped?
       returning_teacher = @store["returning_to_teaching"]

--- a/app/views/teacher_training_adviser/steps/_gcse_maths_english.html.erb
+++ b/app/views/teacher_training_adviser/steps/_gcse_maths_english.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_radio_buttons_fieldset(:has_gcse_maths_and_english_id, legend: { text: 'Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?' }, inline: true ) do %>
-  <%= f.govuk_radio_button :has_gcse_maths_and_english_id, TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:yes], label: { text: 'Yes' }, link_errors: true %>
-  <%= f.govuk_radio_button :has_gcse_maths_and_english_id, TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no], label: { text: 'No' } %>
+  <%= f.govuk_radio_button :has_gcse_maths_and_english_id, f.object.class::OPTIONS[:yes], label: { text: 'Yes' }, link_errors: true %>
+  <%= f.govuk_radio_button :has_gcse_maths_and_english_id, f.object.class::OPTIONS[:no], label: { text: 'No' } %>
 <% end %>
 <details class="govuk-details" data-module="govuk-details">
   <summary class="govuk-details__summary">

--- a/app/views/teacher_training_adviser/steps/_gcse_science.html.erb
+++ b/app/views/teacher_training_adviser/steps/_gcse_science.html.erb
@@ -1,4 +1,4 @@
 <%= f.govuk_radio_buttons_fieldset(:has_gcse_science_id, legend: { text: 'Do you have grade 4 (C) or above in GCSE science, or equivalent?'}, inline: true ) do %>
-  <%= f.govuk_radio_button :has_gcse_science_id, TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:yes], label: { text: 'Yes' }, link_errors: true %>
-  <%= f.govuk_radio_button :has_gcse_science_id, TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:no], label: { text: 'No' } %>
+  <%= f.govuk_radio_button :has_gcse_science_id, f.object.class::OPTIONS[:yes], label: { text: 'Yes' }, link_errors: true %>
+  <%= f.govuk_radio_button :has_gcse_science_id, f.object.class::OPTIONS[:no], label: { text: 'No' } %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_have_a_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_have_a_degree.html.erb
@@ -1,7 +1,8 @@
+<% options = f.object.class::DEGREE_OPTIONS %>
 <%= f.govuk_radio_buttons_fieldset(:degree_options, legend: { text: 'Do you have a degree?'},
   hint_text: "To use this service your bachelor's degree or predicted grade needs to be a 2:2 class honours or above." ) do %>
-  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree],  label: { text: t("have_a_degree.degree_options.degree") }, link_errors: true %>
-  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:no], label: { text: t("have_a_degree.degree_options.no") } %>
-  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying], label: { text: t("have_a_degree.degree_options.studying") } %>
-  <%= f.govuk_radio_button :degree_options, TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent], label: { text: t("have_a_degree.degree_options.equivalent") } %>
+  <%= f.govuk_radio_button :degree_options, options[:degree],  label: { text: t("have_a_degree.degree_options.degree") }, link_errors: true %>
+  <%= f.govuk_radio_button :degree_options, options[:no], label: { text: t("have_a_degree.degree_options.no") } %>
+  <%= f.govuk_radio_button :degree_options, options[:studying], label: { text: t("have_a_degree.degree_options.studying") } %>
+  <%= f.govuk_radio_button :degree_options, options[:equivalent], label: { text: t("have_a_degree.degree_options.equivalent") } %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_retake_gcse_maths_english.html.erb
+++ b/app/views/teacher_training_adviser/steps/_retake_gcse_maths_english.html.erb
@@ -1,4 +1,4 @@
 <%= f.govuk_radio_buttons_fieldset(:planning_to_retake_gcse_maths_and_english_id, legend: { text: 'Are you planning to retake either English or maths (or both) GCSEs, or equivalent?'}, inline: true ) do %>
-  <%= f.govuk_radio_button :planning_to_retake_gcse_maths_and_english_id, TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:yes], label: { text: 'Yes' }, link_errors: true %>
-  <%= f.govuk_radio_button :planning_to_retake_gcse_maths_and_english_id, TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no], label: { text: 'No' } %>
+  <%= f.govuk_radio_button :planning_to_retake_gcse_maths_and_english_id, f.object.class::OPTIONS[:yes], label: { text: 'Yes' }, link_errors: true %>
+  <%= f.govuk_radio_button :planning_to_retake_gcse_maths_and_english_id, f.object.class::OPTIONS[:no], label: { text: 'No' } %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_retake_gcse_science.html.erb
+++ b/app/views/teacher_training_adviser/steps/_retake_gcse_science.html.erb
@@ -1,4 +1,4 @@
 <%= f.govuk_radio_buttons_fieldset(:planning_to_retake_gcse_science_id, legend: { text: 'Are you planning to retake your science GCSE?'}, inline: true ) do %>
-  <%= f.govuk_radio_button :planning_to_retake_gcse_science_id, TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:yes], label: { text: 'Yes' }, link_errors: true %>
-  <%= f.govuk_radio_button :planning_to_retake_gcse_science_id, TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:no], label: { text: 'No' } %>
+  <%= f.govuk_radio_button :planning_to_retake_gcse_science_id, f.object.class::OPTIONS[:yes], label: { text: 'Yes' }, link_errors: true %>
+  <%= f.govuk_radio_button :planning_to_retake_gcse_science_id, f.object.class::OPTIONS[:no], label: { text: 'No' } %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_stage_interested_teaching.html.erb
+++ b/app/views/teacher_training_adviser/steps/_stage_interested_teaching.html.erb
@@ -1,5 +1,5 @@
 <%= f.govuk_radio_buttons_fieldset(:preferred_education_phase_id, legend: { text: 'Which stage are you interested in teaching?'},
 hint_text: "Select a stage even if you're not sure yet, as this will not affect the sign up process.", inline: true ) do %>
-  <%= f.govuk_radio_button :preferred_education_phase_id, TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:primary], label: { text: 'Primary' }, link_errors: true %>
-  <%= f.govuk_radio_button :preferred_education_phase_id, TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary], label: { text: 'Secondary' } %>
+  <%= f.govuk_radio_button :preferred_education_phase_id, f.object.class::OPTIONS[:primary], label: { text: 'Primary' }, link_errors: true %>
+  <%= f.govuk_radio_button :preferred_education_phase_id, f.object.class::OPTIONS[:secondary], label: { text: 'Secondary' } %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_stage_of_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_stage_of_degree.html.erb
@@ -1,6 +1,7 @@
+<% options = f.object.class::options %>
 <%= f.govuk_radio_buttons_fieldset(:degree_status_id, legend: { text: 'In which year are you studying?'} ) do %>
-  <%= f.govuk_radio_button :degree_status_id, TeacherTrainingAdviser::Steps::StageOfDegree::options["Final year"], label: { text: 'Final year' }, link_errors: true %>
-  <%= f.govuk_radio_button :degree_status_id, TeacherTrainingAdviser::Steps::StageOfDegree::options["Second year"], label: { text: 'Second year' } %>
-  <%= f.govuk_radio_button :degree_status_id, TeacherTrainingAdviser::Steps::StageOfDegree::options["First year"], label: { text: "First year" } %>
-  <%= f.govuk_radio_button :degree_status_id, TeacherTrainingAdviser::Steps::StageOfDegree::options["Other"], label: { text: 'Other' } %>
+  <%= f.govuk_radio_button :degree_status_id, options["Final year"], label: { text: 'Final year' }, link_errors: true %>
+  <%= f.govuk_radio_button :degree_status_id, options["Second year"], label: { text: 'Second year' } %>
+  <%= f.govuk_radio_button :degree_status_id, options["First year"], label: { text: "First year" } %>
+  <%= f.govuk_radio_button :degree_status_id, options["Other"], label: { text: 'Other' } %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_subject_like_to_teach.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_like_to_teach.html.erb
@@ -1,7 +1,8 @@
+<% options = f.object.class::options %>
 <%= f.govuk_radio_buttons_fieldset(:preferred_teaching_subject_id, legend: { text: 'Which subject would you like to teach if you return to teaching?' } ) do %>
-  <%= f.govuk_radio_button :preferred_teaching_subject_id, TeacherTrainingAdviser::Steps::SubjectLikeToTeach::options["Maths"], label: { text: 'Maths' }, link_errors: true %>
-  <%= f.govuk_radio_button :preferred_teaching_subject_id, TeacherTrainingAdviser::Steps::SubjectLikeToTeach::options["Physics"], label: { text: 'Physics' } %>
-  <%= f.govuk_radio_button :preferred_teaching_subject_id, TeacherTrainingAdviser::Steps::SubjectLikeToTeach::options["Languages (other)"], label: { text: 'Modern foreign language' } %>
+  <%= f.govuk_radio_button :preferred_teaching_subject_id, options["Maths"], label: { text: 'Maths' }, link_errors: true %>
+  <%= f.govuk_radio_button :preferred_teaching_subject_id, options["Physics"], label: { text: 'Physics' } %>
+  <%= f.govuk_radio_button :preferred_teaching_subject_id, options["Languages (other)"], label: { text: 'Modern foreign language' } %>
 <% end %>
 
 <details class="govuk-details" data-module="govuk-details">

--- a/app/views/teacher_training_adviser/steps/_what_degree_class.html.erb
+++ b/app/views/teacher_training_adviser/steps/_what_degree_class.html.erb
@@ -6,11 +6,9 @@ else
 end
 %>
 
-<div class="govuk-form-group">
-  <%= f.label :uk_degree_grade_id, text, class: "govuk-label govuk-label--m" %>
-  <%= f.select :uk_degree_grade_id,
-    options_for_select(TeacherTrainingAdviser::Steps::WhatDegreeClass.options, selected: f.object.uk_degree_grade_id),
-    {},
-    { class: "govuk-select" }
-  %>
-</div>
+<%= f.govuk_collection_select :uk_degree_grade_id,
+  f.object.class.options,
+  :last,
+  :first,
+  label: { text: text, tag: "h1", size: "m" }
+%>

--- a/app/views/teacher_training_adviser/steps/_what_subject_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_what_subject_degree.html.erb
@@ -1,7 +1,7 @@
 <%= f.govuk_collection_select :degree_subject,
-  GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects,
-  :value,
-  :value,
+  f.object.class.options,
+  :last,
+  :first,
   label: { text: "What subject is your degree?", tag: "h1", size: "m" },
   hint_text: "If your subject is not listed choose the option that is nearest to your degree."
 %>

--- a/spec/models/teacher_training_adviser/steps/overseas_country_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_country_spec.rb
@@ -3,27 +3,11 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::OverseasCountry do
   include_context "wizard step"
   it_behaves_like "a wizard step"
-  it_behaves_like "a wizard step that exposes API types as options", :get_country_types
+  it_behaves_like "a wizard step that exposes API types as options",
+                  :get_country_types, described_class::OMIT_COUNTRY_IDS
 
   context "attributes" do
     it { is_expected.to respond_to :country_id }
-  end
-
-  describe ".options" do
-    it "does not return the ignored countries" do
-      types = [
-        GetIntoTeachingApiClient::TypeEntity.new(id: "1", value: "one"),
-      ]
-
-      types += described_class::IGNORE_COUNTRY_IDS.map do |id|
-        GetIntoTeachingApiClient::TypeEntity.new(id: id, value: "ignored")
-      end
-
-      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
-        receive(:get_country_types) { types }
-
-      expect(described_class.options.values).to contain_exactly("1")
-    end
   end
 
   describe "country_id" do

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
   include_context "wizard step"
   it_behaves_like "a wizard step"
-  it_behaves_like "a wizard step that exposes API types as options", :get_candidate_initial_teacher_training_years
 
   context "attributes" do
     it { is_expected.to respond_to :initial_teacher_training_year_id }
@@ -58,15 +57,15 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
     end
   end
 
-  describe "#dont_know" do
+  describe "#not_sure?" do
     it "returns true if the set year is 'Dont know'" do
-      subject.initial_teacher_training_year_id = TeacherTrainingAdviser::Steps::StartTeacherTraining.options["Not sure"]
-      expect(subject.dont_know).to be_truthy
+      subject.initial_teacher_training_year_id = TeacherTrainingAdviser::Steps::StartTeacherTraining::NOT_SURE_ID
+      expect(subject.not_sure?).to be_truthy
     end
 
     it "returns false if the set year is not 'Dont know'" do
       subject.initial_teacher_training_year_id = -1
-      expect(subject.dont_know).to be_falsy
+      expect(subject.not_sure?).to be_falsy
     end
   end
 

--- a/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
@@ -3,27 +3,11 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::SubjectInterestedTeaching do
   include_context "wizard step"
   it_behaves_like "a wizard step"
-  it_behaves_like "a wizard step that exposes API types as options", :get_teaching_subjects
+  it_behaves_like "a wizard step that exposes API types as options",
+                  :get_teaching_subjects, described_class::OMIT_SUBJECT_IDS
 
   context "attributes" do
     it { is_expected.to respond_to :preferred_teaching_subject_id }
-  end
-
-  describe ".options" do
-    it "does not return the ignored subjects" do
-      types = [
-        GetIntoTeachingApiClient::TypeEntity.new(id: "1", value: "one"),
-      ]
-
-      types += described_class::IGNORED_SUBJECT_IDS.map do |id|
-        GetIntoTeachingApiClient::TypeEntity.new(id: id, value: "ignored")
-      end
-
-      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
-        receive(:get_teaching_subjects) { types }
-
-      expect(described_class.options.values).to contain_exactly("1")
-    end
   end
 
   describe "#preferred_teaching_subject_id" do

--- a/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
@@ -3,24 +3,11 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::SubjectTaught do
   include_context "wizard step"
   it_behaves_like "a wizard step"
-  it_behaves_like "a wizard step that exposes API types as options", :get_teaching_subjects
+  it_behaves_like "a wizard step that exposes API types as options",
+                  :get_teaching_subjects, described_class::OMIT_SUBJECT_IDS
 
   context "attributes" do
     it { is_expected.to respond_to :subject_taught_id }
-  end
-
-  describe ".options" do
-    it "does not return the No Preference option" do
-      types = [
-        GetIntoTeachingApiClient::TypeEntity.new(id: "1", value: "one"),
-        GetIntoTeachingApiClient::TypeEntity.new(id: described_class::NO_PREFERENCE_ID, value: "two"),
-      ]
-
-      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
-        receive(:get_teaching_subjects) { types }
-
-      expect(described_class.options.values).to_not include(described_class::NO_PREFERENCE_ID)
-    end
   end
 
   describe "#subject_taught_id" do

--- a/spec/models/teacher_training_adviser/steps/what_degree_class_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/what_degree_class_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::WhatDegreeClass do
   include_context "wizard step"
   it_behaves_like "a wizard step"
-  it_behaves_like "a wizard step that exposes API types as options", :get_qualification_uk_degree_grades
+  it_behaves_like "a wizard step that exposes API types as options",
+                  :get_qualification_uk_degree_grades, described_class::OMIT_GRADE_IDS
 
   context "attributes" do
     it { is_expected.to respond_to :uk_degree_grade_id }
@@ -48,12 +49,6 @@ RSpec.describe TeacherTrainingAdviser::Steps::WhatDegreeClass do
     it "returns false if degree_options is not studying" do
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
       expect(subject).to_not be_studying
-    end
-  end
-
-  describe "#self.options" do
-    it "returns a hash of filtered options" do
-      expect(TeacherTrainingAdviser::Steps::WhatDegreeClass.options).to eq({ "Not applicable" => "222750000", "First class" => "222750001", "2:1" => "222750002", "2:2" => "222750003" })
     end
   end
 

--- a/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::WhatSubjectDegree do
   include_context "wizard step"
   it_behaves_like "a wizard step"
+  it_behaves_like "a wizard step that exposes API types as options", :get_teaching_subjects
 
   context "attributes" do
     it { is_expected.to respond_to :degree_subject }

--- a/spec/support/shared_examples/wizard_support.rb
+++ b/spec/support/shared_examples/wizard_support.rb
@@ -15,7 +15,7 @@ RSpec.shared_examples "a wizard step" do
   it { is_expected.to respond_to :save! }
 end
 
-RSpec.shared_examples "a wizard step that exposes API types as options" do |api_method|
+RSpec.shared_examples "a wizard step that exposes API types as options" do |api_method, omit_ids|
   it { expect(subject.class).to respond_to :options }
 
   it "it exposes API types as options" do
@@ -28,6 +28,17 @@ RSpec.shared_examples "a wizard step that exposes API types as options" do |api_
       receive(api_method) { types }
 
     expect(described_class.options).to eq({ "one" => "1", "two" => "2" })
+  end
+
+  if omit_ids
+    it "omits options with the ids #{omit_ids}" do
+      omitted_types = omit_ids.map { |id| GetIntoTeachingApiClient::TypeEntity.new(id: id, value: "omit-#{id}") }
+
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(api_method) { omitted_types }
+
+      expect(described_class.options).to be_empty
+    end
   end
 end
 


### PR DESCRIPTION
Some of the view partials were calling the API directly; instead we should go through the model.

General tidy up of view partials to make referencing step class consistent.

Minor refactoring of `ApiOptions` to make implementation and tests DRYer.