### PR TITLE
Minor bug fixes after error message refactoring

### DIFF
--- a/app/views/teacher_training_adviser/steps/_what_subject_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_what_subject_degree.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_collection_select :degree_subject,
   f.object.class.options,
-  :last,
+  :first,
   :first,
   label: { text: "What subject is your degree?", tag: "h1", size: "m" },
   hint_text: "If your subject is not listed choose the option that is nearest to your degree."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,7 +132,7 @@ en:
         teacher_training_adviser/steps/uk_address:
           attributes:
             address_line1:
-              blank: Enter the first line of your address"
+              blank: Enter the first line of your address
             address_city:
               blank: "Enter your town or city"
             address_postcode:


### PR DESCRIPTION
- Correct typo in error message

- Use entity value for both option value and name

On the `WhatSubjectDegree` step we send the text value of the subject instead of the GUID (which is unique to this step - the field expects a text value instead of ID).