### PR TITLE
Clean up HaveADegree step

### DIFF
--- a/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
@@ -15,7 +15,7 @@ module TeacherTrainingAdviser::Steps
     def skipped?
       not_studying_or_have_a_degree = [
         TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying],
-        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree],
+        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes],
       ].none?(@store["degree_options"])
 
       not_studying_or_have_a_degree

--- a/app/models/teacher_training_adviser/steps/gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_science.rb
@@ -19,7 +19,7 @@ module TeacherTrainingAdviser::Steps
         @store["planning_to_retake_gcse_maths_and_english_id"] == TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
       not_studying_or_have_a_degree = [
         TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying],
-        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree],
+        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes],
       ].none?(@store["degree_options"])
 
       returning_teacher || phase_is_secondary || no_gcse_maths_science || not_studying_or_have_a_degree

--- a/app/models/teacher_training_adviser/steps/have_a_degree.rb
+++ b/app/models/teacher_training_adviser/steps/have_a_degree.rb
@@ -4,10 +4,23 @@ module TeacherTrainingAdviser::Steps
     attribute :degree_status_id, :integer
     attribute :degree_type_id, :integer
 
-    DEGREE_OPTIONS = { degree: "degree", no: "no", studying: "studying", equivalent: "equivalent" }.freeze
-    STUDYING = -1 # degree_status_id will be overriden on subsequent step.
-    DEGREE_STATUS_OPTIONS = { yes: 222_750_000, no: 222_750_004, studying: STUDYING, first_year: 222_750_003, second_year: 222_750_002, final_year: 222_750_001, equivalent: 222_750_005 }.freeze
-    DEGREE_TYPE = { degree: 222_750_000, equivalent: 222_750_005 }.freeze
+    DEGREE_OPTIONS = {
+      yes: "yes",
+      no: "no",
+      studying: "studying",
+      equivalent: "equivalent",
+    }.freeze
+
+    DEGREE_STATUS_OPTIONS = {
+      has_degree: 222_750_000,
+      no_degree: 222_750_004,
+      studying: -1, # degree_status_id is set on the subsequent step.
+    }.freeze
+
+    DEGREE_TYPE_OPTIONS = {
+      has_degree: 222_750_000,
+      has_degree_equivalent: 222_750_005,
+    }.freeze
 
     validates :degree_options, inclusion: { in: DEGREE_OPTIONS.values }
 
@@ -32,20 +45,20 @@ module TeacherTrainingAdviser::Steps
     def set_degree_status
       self.degree_status_id = case degree_options
                               when DEGREE_OPTIONS[:no]
-                                DEGREE_STATUS_OPTIONS[:no]
+                                DEGREE_STATUS_OPTIONS[:no_degree]
                               when DEGREE_OPTIONS[:studying]
                                 DEGREE_STATUS_OPTIONS[:studying]
                               else
-                                DEGREE_STATUS_OPTIONS[:yes]
+                                DEGREE_STATUS_OPTIONS[:has_degree]
                               end
     end
 
     def set_degree_type
       self.degree_type_id = case degree_options
                             when DEGREE_OPTIONS[:equivalent]
-                              DEGREE_TYPE[:equivalent]
+                              DEGREE_TYPE_OPTIONS[:has_degree_equivalent]
                             else
-                              DEGREE_TYPE[:degree]
+                              DEGREE_TYPE_OPTIONS[:has_degree]
                             end
     end
   end

--- a/app/models/teacher_training_adviser/steps/what_degree_class.rb
+++ b/app/models/teacher_training_adviser/steps/what_degree_class.rb
@@ -19,7 +19,7 @@ module TeacherTrainingAdviser::Steps
       returning_teacher = @store["returning_to_teaching"]
       not_studying_or_have_a_degree = [
         TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying],
-        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree],
+        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes],
       ].none?(@store["degree_options"])
 
       returning_teacher || not_studying_or_have_a_degree

--- a/app/models/teacher_training_adviser/steps/what_subject_degree.rb
+++ b/app/models/teacher_training_adviser/steps/what_subject_degree.rb
@@ -14,7 +14,7 @@ module TeacherTrainingAdviser::Steps
       returning_teacher = @store["returning_to_teaching"]
       not_studying_or_have_a_degree = [
         TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying],
-        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree],
+        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes],
       ].none?(@store["degree_options"])
 
       returning_teacher || not_studying_or_have_a_degree

--- a/app/views/teacher_training_adviser/steps/_have_a_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_have_a_degree.html.erb
@@ -1,7 +1,7 @@
 <% options = f.object.class::DEGREE_OPTIONS %>
 <%= f.govuk_radio_buttons_fieldset(:degree_options, legend: { text: 'Do you have a degree?'},
   hint_text: "To use this service your bachelor's degree or predicted grade needs to be a 2:2 class honours or above." ) do %>
-  <%= f.govuk_radio_button :degree_options, options[:degree],  label: { text: t("have_a_degree.degree_options.degree") }, link_errors: true %>
+  <%= f.govuk_radio_button :degree_options, options[:yes],  label: { text: t("have_a_degree.degree_options.yes") }, link_errors: true %>
   <%= f.govuk_radio_button :degree_options, options[:no], label: { text: t("have_a_degree.degree_options.no") } %>
   <%= f.govuk_radio_button :degree_options, options[:studying], label: { text: t("have_a_degree.degree_options.studying") } %>
   <%= f.govuk_radio_button :degree_options, options[:equivalent], label: { text: t("have_a_degree.degree_options.equivalent") } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,7 +37,7 @@ telephone_errors: &telephone_errors
 en:
   have_a_degree:
     degree_options:
-      degree: "Yes"
+      yes: "Yes"
       no: "No"
       studying: "I'm studying for a degree"
       equivalent: "I have an equivalent qualification from another country"

--- a/spec/models/teacher_training_adviser/steps/gcse_maths_english_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/gcse_maths_english_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::GcseMathsEnglish do
     it "returns false if degree_options is studying/degree" do
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
       expect(subject).to_not be_skipped
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       expect(subject).to_not be_skipped
     end
 

--- a/spec/models/teacher_training_adviser/steps/gcse_science_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/gcse_science_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::GcseScience do
       wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:primary]
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
       expect(subject).to_not be_skipped
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       expect(subject).to_not be_skipped
     end
 

--- a/spec/models/teacher_training_adviser/steps/have_a_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/have_a_degree_spec.rb
@@ -17,27 +17,27 @@ RSpec.describe TeacherTrainingAdviser::Steps::HaveADegree do
 
   describe "#degree_option=" do
     it "sets the correct degree_status_id/degree_type_id for value of degree" do
-      subject.degree_options = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
-      expect(subject.degree_status_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_STATUS_OPTIONS[:yes])
-      expect(subject.degree_type_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_TYPE[:degree])
+      subject.degree_options = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
+      expect(subject.degree_status_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_STATUS_OPTIONS[:has_degree])
+      expect(subject.degree_type_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_TYPE_OPTIONS[:has_degree])
     end
 
     it "sets the correct degree_status_id/degree_type_id when no" do
       subject.degree_options = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:no]
-      expect(subject.degree_status_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_STATUS_OPTIONS[:no])
-      expect(subject.degree_type_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_TYPE[:degree])
+      expect(subject.degree_status_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_STATUS_OPTIONS[:no_degree])
+      expect(subject.degree_type_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_TYPE_OPTIONS[:has_degree])
     end
 
     it "sets the correct degree_status_id/degree_type_id when studying" do
       subject.degree_options = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
       expect(subject.degree_status_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_STATUS_OPTIONS[:studying])
-      expect(subject.degree_type_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_TYPE[:degree])
+      expect(subject.degree_type_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_TYPE_OPTIONS[:has_degree])
     end
 
     it "sets the correct degree_status_id/degree_type_id when equivalent" do
       subject.degree_options = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
-      expect(subject.degree_status_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_STATUS_OPTIONS[:yes])
-      expect(subject.degree_type_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_TYPE[:equivalent])
+      expect(subject.degree_status_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_STATUS_OPTIONS[:has_degree])
+      expect(subject.degree_type_id).to eq(TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_TYPE_OPTIONS[:has_degree_equivalent])
     end
   end
 

--- a/spec/models/teacher_training_adviser/steps/no_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/no_degree_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::NoDegree do
     end
 
     it "returns true if degree_options is not no" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTimeZone do
     end
 
     it "returns true if degree_options is not equivalent" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
       wizardstore["returning_to_teaching"] = false
       expect(subject).to be_skipped

--- a/spec/models/teacher_training_adviser/steps/stage_of_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/stage_of_degree_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StageOfDegree do
     end
 
     it "returns true if degree_options is not studying" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       expect(subject).to be_skipped
     end
 

--- a/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
     end
 
     it "returns true if degree_options is not equivalent" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
       wizardstore["returning_to_teaching"] = false
       expect(subject).to be_skipped

--- a/spec/models/teacher_training_adviser/steps/what_degree_class_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/what_degree_class_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::WhatDegreeClass do
     it "returns false if degree_options is studying/degree" do
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
       expect(subject).to_not be_skipped
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       expect(subject).to_not be_skipped
     end
 
@@ -47,7 +47,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::WhatDegreeClass do
     end
 
     it "returns false if degree_options is not studying" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       expect(subject).to_not be_studying
     end
   end

--- a/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::WhatSubjectDegree do
     it "returns false if degree_options is studying/degree" do
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
       expect(subject).to_not be_skipped
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:degree]
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       expect(subject).to_not be_skipped
     end
 


### PR DESCRIPTION
Improve naming of options to better match what is shown to the user.

Remove unused constants.

Remove redundant validation check for date being in the past; this is covered on the specs for the `years` method/inclusion validation.