### PR TITLE
Clean up step skipped? logic

### DIFF
--- a/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
@@ -13,7 +13,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      @wizard.all_skipped?(WhatSubjectDegree.key)
+      other_step(:what_subject_degree).skipped?
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
@@ -13,12 +13,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      not_studying_or_have_a_degree = [
-        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying],
-        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes],
-      ].none?(@store["degree_options"])
-
-      not_studying_or_have_a_degree
+      @wizard.all_skipped?(WhatSubjectDegree.key)
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_science.rb
@@ -13,11 +13,12 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      gcse_maths_english_skipped = @wizard.all_skipped?(GcseMathsEnglish.key)
-      preferred_education_phase_id = @wizard.find(StageInterestedTeaching.key).preferred_education_phase_id
+      gcse_maths_english_step = other_step(:gcse_maths_english)
+      gcse_maths_english_skipped = gcse_maths_english_step.skipped?
+      preferred_education_phase_id = other_step(:stage_interested_teaching).preferred_education_phase_id
       phase_is_secondary = preferred_education_phase_id == StageInterestedTeaching::OPTIONS[:secondary]
-      has_gcse_maths_and_english_id = @wizard.find(GcseMathsEnglish.key).has_gcse_maths_and_english_id
-      planning_to_retake_gcse_maths_and_english_id = @wizard.find(RetakeGcseMathsEnglish.key).planning_to_retake_gcse_maths_and_english_id
+      has_gcse_maths_and_english_id = gcse_maths_english_step.has_gcse_maths_and_english_id
+      planning_to_retake_gcse_maths_and_english_id = other_step(:retake_gcse_maths_english).planning_to_retake_gcse_maths_and_english_id
       no_gcse_maths_english = has_gcse_maths_and_english_id == GcseMathsEnglish::OPTIONS[:no] &&
         planning_to_retake_gcse_maths_and_english_id == RetakeGcseMathsEnglish::OPTIONS[:no]
 

--- a/app/models/teacher_training_adviser/steps/gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_science.rb
@@ -18,10 +18,10 @@ module TeacherTrainingAdviser::Steps
       phase_is_secondary = preferred_education_phase_id == StageInterestedTeaching::OPTIONS[:secondary]
       has_gcse_maths_and_english_id = @wizard.find(GcseMathsEnglish.key).has_gcse_maths_and_english_id
       planning_to_retake_gcse_maths_and_english_id = @wizard.find(RetakeGcseMathsEnglish.key).planning_to_retake_gcse_maths_and_english_id
-      no_gcse_maths_science = has_gcse_maths_and_english_id == GcseMathsEnglish::OPTIONS[:no] &&
+      no_gcse_maths_english = has_gcse_maths_and_english_id == GcseMathsEnglish::OPTIONS[:no] &&
         planning_to_retake_gcse_maths_and_english_id == RetakeGcseMathsEnglish::OPTIONS[:no]
 
-      gcse_maths_english_skipped || no_gcse_maths_science || phase_is_secondary
+      gcse_maths_english_skipped || no_gcse_maths_english || phase_is_secondary
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_science.rb
@@ -13,16 +13,15 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-      phase_is_secondary = @store["preferred_education_phase_id"] == TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
-      no_gcse_maths_science = @store["has_gcse_maths_and_english_id"] == TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no] &&
-        @store["planning_to_retake_gcse_maths_and_english_id"] == TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
-      not_studying_or_have_a_degree = [
-        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying],
-        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes],
-      ].none?(@store["degree_options"])
+      gcse_maths_english_skipped = @wizard.all_skipped?(GcseMathsEnglish.key)
+      preferred_education_phase_id = @wizard.find(StageInterestedTeaching.key).preferred_education_phase_id
+      phase_is_secondary = preferred_education_phase_id == StageInterestedTeaching::OPTIONS[:secondary]
+      has_gcse_maths_and_english_id = @wizard.find(GcseMathsEnglish.key).has_gcse_maths_and_english_id
+      planning_to_retake_gcse_maths_and_english_id = @wizard.find(RetakeGcseMathsEnglish.key).planning_to_retake_gcse_maths_and_english_id
+      no_gcse_maths_science = has_gcse_maths_and_english_id == GcseMathsEnglish::OPTIONS[:no] &&
+        planning_to_retake_gcse_maths_and_english_id == RetakeGcseMathsEnglish::OPTIONS[:no]
 
-      returning_teacher || phase_is_secondary || no_gcse_maths_science || not_studying_or_have_a_degree
+      gcse_maths_english_skipped || no_gcse_maths_science || phase_is_secondary
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/has_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/has_teacher_id.rb
@@ -11,7 +11,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      !@wizard.find(ReturningTeacher.key).returning_to_teaching
+      !other_step(:returning_teacher).returning_to_teaching
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/has_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/has_teacher_id.rb
@@ -11,9 +11,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-
-      !returning_teacher
+      !@wizard.find(ReturningTeacher.key).returning_to_teaching
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/have_a_degree.rb
+++ b/app/models/teacher_training_adviser/steps/have_a_degree.rb
@@ -37,9 +37,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-
-      returning_teacher
+      @wizard.find(ReturningTeacher.key).returning_to_teaching
     end
 
     def set_degree_status

--- a/app/models/teacher_training_adviser/steps/have_a_degree.rb
+++ b/app/models/teacher_training_adviser/steps/have_a_degree.rb
@@ -37,7 +37,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      @wizard.find(ReturningTeacher.key).returning_to_teaching
+      other_step(:returning_teacher).returning_to_teaching
     end
 
     def set_degree_status

--- a/app/models/teacher_training_adviser/steps/no_degree.rb
+++ b/app/models/teacher_training_adviser/steps/no_degree.rb
@@ -5,9 +5,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      has_degree = @store["degree_options"] != TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:no]
-
-      has_degree
+      @wizard.find(HaveADegree.key).degree_options != HaveADegree::DEGREE_OPTIONS[:no]
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/no_degree.rb
+++ b/app/models/teacher_training_adviser/steps/no_degree.rb
@@ -5,7 +5,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      @wizard.find(HaveADegree.key).degree_options != HaveADegree::DEGREE_OPTIONS[:no]
+      other_step(:have_a_degree).degree_options != HaveADegree::DEGREE_OPTIONS[:no]
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_country.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_country.rb
@@ -16,9 +16,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      in_uk = @store["uk_or_overseas"] == TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
-
-      in_uk
+      @wizard.find(UkOrOverseas.key).uk_or_overseas == UkOrOverseas::OPTIONS[:uk]
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/overseas_country.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_country.rb
@@ -16,7 +16,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      @wizard.find(UkOrOverseas.key).uk_or_overseas == UkOrOverseas::OPTIONS[:uk]
+      other_step(:uk_or_overseas).uk_or_overseas == UkOrOverseas::OPTIONS[:uk]
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/overseas_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_telephone.rb
@@ -13,10 +13,11 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      equivalent_degree = @store["degree_options"] == "equivalent"
-      in_uk = @store["uk_or_overseas"] == TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+      overseas_country_skippped = @wizard.all_skipped?(OverseasCountry.key)
+      degree_options = @wizard.find(HaveADegree.key).degree_options
+      equivalent_degree = degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]
 
-      equivalent_degree || in_uk
+      overseas_country_skippped || equivalent_degree
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_telephone.rb
@@ -13,8 +13,8 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      overseas_country_skippped = @wizard.all_skipped?(OverseasCountry.key)
-      degree_options = @wizard.find(HaveADegree.key).degree_options
+      overseas_country_skippped = other_step(:overseas_country).skipped?
+      degree_options = other_step(:have_a_degree).degree_options
       equivalent_degree = degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]
 
       overseas_country_skippped || equivalent_degree

--- a/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
@@ -11,11 +11,11 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-      not_equivalent_degree = @store["degree_options"] != TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
-      not_overseas = @store["uk_or_overseas"] != TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+      overseas_country_skipped = @wizard.all_skipped?(OverseasCountry.key)
+      degree_options = @wizard.find(HaveADegree.key).degree_options
+      equivalent_degree = degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]
 
-      returning_teacher || not_equivalent_degree || not_overseas
+      overseas_country_skipped || !equivalent_degree
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
@@ -11,8 +11,8 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      overseas_country_skipped = @wizard.all_skipped?(OverseasCountry.key)
-      degree_options = @wizard.find(HaveADegree.key).degree_options
+      overseas_country_skipped = other_step(:overseas_country).skipped?
+      degree_options = other_step(:have_a_degree).degree_options
       equivalent_degree = degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]
 
       overseas_country_skipped || !equivalent_degree

--- a/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
@@ -3,8 +3,9 @@ module TeacherTrainingAdviser::Steps
     attribute :teacher_id, :string
 
     def skipped?
-      has_teacher_id_skipped = @wizard.all_skipped?(HasTeacherId.key)
-      has_id = @wizard.find(HasTeacherId.key).has_id
+      has_teacher_id_step = other_step(:has_teacher_id)
+      has_teacher_id_skipped = has_teacher_id_step.skipped?
+      has_id = has_teacher_id_step.has_id
 
       has_teacher_id_skipped || !has_id
     end

--- a/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
@@ -3,10 +3,10 @@ module TeacherTrainingAdviser::Steps
     attribute :teacher_id, :string
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-      has_id = @store["has_id"] == true
+      has_teacher_id_skipped = @wizard.all_skipped?(HasTeacherId.key)
+      has_id = @wizard.find(HasTeacherId.key).has_id
 
-      !returning_teacher || !has_id
+      has_teacher_id_skipped || !has_id
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/qualification_required.rb
+++ b/app/models/teacher_training_adviser/steps/qualification_required.rb
@@ -5,21 +5,15 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      equivalent_degree = @store["degree_options"] == "equivalent"
-      returning_teacher = @store["returning_to_teaching"]
-      has_gcse_maths_english = @store["has_gcse_maths_and_english_id"] != TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
-      retaking_gcse_maths_english = @store["planning_to_retake_gcse_maths_and_english_id"] != TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
-      phase_is_primary = @store["preferred_education_phase_id"] == TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:primary]
-      phase_is_secondary = @store["preferred_education_phase_id"] == TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
-      has_gcse_science = @store["has_gcse_science_id"] != TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:no]
-      retaking_gcse_science = @store["planning_to_retake_gcse_science_id"] != TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:no]
-      has_or_retaking_gcse_maths_english = has_gcse_maths_english || retaking_gcse_maths_english
-      has_or_retaking_gcse_science = has_gcse_science || retaking_gcse_science
+      retake_gcse_maths_english_skipped = @wizard.all_skipped?(RetakeGcseMathsEnglish.key)
+      retake_gcse_science_skipped = @wizard.all_skipped?(RetakeGcseScience.key)
+      planning_to_retake_gcse_maths_and_english_id = @wizard.find(RetakeGcseMathsEnglish.key).planning_to_retake_gcse_maths_and_english_id
+      planning_to_retake_gcse_science_id = @wizard.find(RetakeGcseScience.key).planning_to_retake_gcse_science_id
+      retaking_gcse_maths_english = planning_to_retake_gcse_maths_and_english_id != TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
+      retaking_gcse_science = planning_to_retake_gcse_science_id != TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:no]
 
-      equivalent_degree ||
-        returning_teacher ||
-        (phase_is_secondary && has_or_retaking_gcse_maths_english) ||
-        (phase_is_primary && has_or_retaking_gcse_maths_english && has_or_retaking_gcse_science)
+      (retake_gcse_maths_english_skipped || retaking_gcse_maths_english) &&
+        (retake_gcse_science_skipped || retaking_gcse_science)
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/qualification_required.rb
+++ b/app/models/teacher_training_adviser/steps/qualification_required.rb
@@ -5,10 +5,12 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      retake_gcse_maths_english_skipped = @wizard.all_skipped?(RetakeGcseMathsEnglish.key)
-      retake_gcse_science_skipped = @wizard.all_skipped?(RetakeGcseScience.key)
-      planning_to_retake_gcse_maths_and_english_id = @wizard.find(RetakeGcseMathsEnglish.key).planning_to_retake_gcse_maths_and_english_id
-      planning_to_retake_gcse_science_id = @wizard.find(RetakeGcseScience.key).planning_to_retake_gcse_science_id
+      retake_gcse_maths_english_step = other_step(:retake_gcse_maths_english)
+      retake_gcse_science_step = other_step(:retake_gcse_science)
+      retake_gcse_maths_english_skipped = retake_gcse_maths_english_step.skipped?
+      retake_gcse_science_skipped = retake_gcse_science_step.skipped?
+      planning_to_retake_gcse_maths_and_english_id = retake_gcse_maths_english_step.planning_to_retake_gcse_maths_and_english_id
+      planning_to_retake_gcse_science_id = retake_gcse_science_step.planning_to_retake_gcse_science_id
       retaking_gcse_maths_english = planning_to_retake_gcse_maths_and_english_id != TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
       retaking_gcse_science = planning_to_retake_gcse_science_id != TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:no]
 

--- a/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
@@ -14,11 +14,11 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-      equivalent_degree = @store["degree_options"] == TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
-      has_gcse_maths_english = @store["has_gcse_maths_and_english_id"] != TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
+      gcse_maths_english_skipped = @wizard.all_skipped?(GcseMathsEnglish.key)
+      has_gcse_maths_and_english_id = @wizard.find(GcseMathsEnglish.key).has_gcse_maths_and_english_id
+      has_gcse_maths_english = has_gcse_maths_and_english_id != GcseMathsEnglish::OPTIONS[:no]
 
-      returning_teacher || equivalent_degree || has_gcse_maths_english
+      gcse_maths_english_skipped || has_gcse_maths_english
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
@@ -14,8 +14,9 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      gcse_maths_english_skipped = @wizard.all_skipped?(GcseMathsEnglish.key)
-      has_gcse_maths_and_english_id = @wizard.find(GcseMathsEnglish.key).has_gcse_maths_and_english_id
+      gcse_maths_english_step = other_step(:gcse_maths_english)
+      gcse_maths_english_skipped = gcse_maths_english_step.skipped?
+      has_gcse_maths_and_english_id = gcse_maths_english_step.has_gcse_maths_and_english_id
       has_gcse_maths_english = has_gcse_maths_and_english_id != GcseMathsEnglish::OPTIONS[:no]
 
       gcse_maths_english_skipped || has_gcse_maths_english

--- a/app/models/teacher_training_adviser/steps/retake_gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_science.rb
@@ -14,8 +14,9 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      gcse_science_skipped = @wizard.all_skipped?(GcseScience.key)
-      has_gcse_science_id = @wizard.find(GcseScience.key).has_gcse_science_id
+      gcse_science_step = other_step(:gcse_science)
+      gcse_science_skipped = gcse_science_step.skipped?
+      has_gcse_science_id = gcse_science_step.has_gcse_science_id
       has_gcse_science = has_gcse_science_id != GcseMathsEnglish::OPTIONS[:no]
 
       gcse_science_skipped || has_gcse_science

--- a/app/models/teacher_training_adviser/steps/retake_gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_science.rb
@@ -14,13 +14,11 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-      equivalent_degree = @store["degree_options"] == TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
-      phase_is_secondary = @store["preferred_education_phase_id"] == TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
-      has_gcse_science = @store["has_gcse_science_id"] != TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:no]
-      not_retaking_gcse_maths_english = @store["planning_to_retake_gcse_maths_and_english_id"] == TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
+      gcse_science_skipped = @wizard.all_skipped?(GcseScience.key)
+      has_gcse_science_id = @wizard.find(GcseScience.key).has_gcse_science_id
+      has_gcse_science = has_gcse_science_id != GcseMathsEnglish::OPTIONS[:no]
 
-      returning_teacher || equivalent_degree || phase_is_secondary || has_gcse_science || not_retaking_gcse_maths_english
+      gcse_science_skipped || has_gcse_science
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
@@ -16,7 +16,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      @wizard.all_skipped?(HaveADegree.key)
+      other_step(:have_a_degree).skipped?
     end
 
     def export

--- a/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
@@ -16,9 +16,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-
-      returning_teacher
+      @wizard.all_skipped?(HaveADegree.key)
     end
 
     def export

--- a/app/models/teacher_training_adviser/steps/stage_of_degree.rb
+++ b/app/models/teacher_training_adviser/steps/stage_of_degree.rb
@@ -7,10 +7,10 @@ module TeacherTrainingAdviser::Steps
     validates :degree_status_id, types: { method: :get_qualification_degree_status }
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-      studying = @store["degree_options"] == TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
+      studying = @wizard.find(HaveADegree.key).degree_options == HaveADegree::DEGREE_OPTIONS[:studying]
+      have_a_degree_skipped = @wizard.all_skipped?(HaveADegree.key)
 
-      returning_teacher || !studying
+      have_a_degree_skipped || !studying
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/stage_of_degree.rb
+++ b/app/models/teacher_training_adviser/steps/stage_of_degree.rb
@@ -7,8 +7,9 @@ module TeacherTrainingAdviser::Steps
     validates :degree_status_id, types: { method: :get_qualification_degree_status }
 
     def skipped?
-      studying = @wizard.find(HaveADegree.key).degree_options == HaveADegree::DEGREE_OPTIONS[:studying]
-      have_a_degree_skipped = @wizard.all_skipped?(HaveADegree.key)
+      have_a_degree_step = other_step(:have_a_degree)
+      studying = have_a_degree_step.degree_options == HaveADegree::DEGREE_OPTIONS[:studying]
+      have_a_degree_skipped = have_a_degree_step.skipped?
 
       have_a_degree_skipped || !studying
     end

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -23,9 +23,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-
-      returning_teacher
+      @wizard.find(ReturningTeacher.key).returning_to_teaching
     end
 
   private

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -23,7 +23,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      @wizard.find(ReturningTeacher.key).returning_to_teaching
+      other_step(:returning_teacher).returning_to_teaching
     end
 
   private

--- a/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
@@ -22,10 +22,11 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-      phase_is_not_secondary = @store["preferred_education_phase_id"] != TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
+      stage_interested_teaching_skipped = @wizard.all_skipped?(StageInterestedTeaching.key)
+      preferred_education_phase_id = @wizard.find(StageInterestedTeaching.key).preferred_education_phase_id
+      phase_is_not_secondary = preferred_education_phase_id != StageInterestedTeaching::OPTIONS[:secondary]
 
-      returning_teacher || phase_is_not_secondary
+      stage_interested_teaching_skipped || phase_is_not_secondary
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
@@ -22,8 +22,9 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      stage_interested_teaching_skipped = @wizard.all_skipped?(StageInterestedTeaching.key)
-      preferred_education_phase_id = @wizard.find(StageInterestedTeaching.key).preferred_education_phase_id
+      stage_interested_teaching_step = other_step(:stage_interested_teaching)
+      stage_interested_teaching_skipped = stage_interested_teaching_step.skipped?
+      preferred_education_phase_id = stage_interested_teaching_step.preferred_education_phase_id
       phase_is_not_secondary = preferred_education_phase_id != StageInterestedTeaching::OPTIONS[:secondary]
 
       stage_interested_teaching_skipped || phase_is_not_secondary

--- a/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
+++ b/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
@@ -25,7 +25,7 @@ module TeacherTrainingAdviser::Steps
     validates :preferred_teaching_subject_id, inclusion: { in: sanitized_options.values }
 
     def skipped?
-      !@wizard.find(ReturningTeacher.key).returning_to_teaching
+      !other_step(:returning_teacher).returning_to_teaching
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
+++ b/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
@@ -25,9 +25,7 @@ module TeacherTrainingAdviser::Steps
     validates :preferred_teaching_subject_id, inclusion: { in: sanitized_options.values }
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-
-      !returning_teacher
+      !@wizard.find(ReturningTeacher.key).returning_to_teaching
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/subject_not_found.rb
+++ b/app/models/teacher_training_adviser/steps/subject_not_found.rb
@@ -5,8 +5,9 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-      subject_not_found = @store["preferred_teaching_subject_id"] == TeacherTrainingAdviser::Steps::SubjectLikeToTeach::OTHER_SUBJECT_ID
+      returning_teacher = other_step(:returning_teacher).returning_to_teaching
+      preferred_teaching_subject_id = other_step(:subject_interested_teaching).preferred_teaching_subject_id
+      subject_not_found = preferred_teaching_subject_id == TeacherTrainingAdviser::Steps::SubjectLikeToTeach::OTHER_SUBJECT_ID
 
       !(returning_teacher && subject_not_found)
     end

--- a/app/models/teacher_training_adviser/steps/subject_taught.rb
+++ b/app/models/teacher_training_adviser/steps/subject_taught.rb
@@ -15,9 +15,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-
-      !returning_teacher
+      !@wizard.find(ReturningTeacher.key).returning_to_teaching
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/subject_taught.rb
+++ b/app/models/teacher_training_adviser/steps/subject_taught.rb
@@ -15,7 +15,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      !@wizard.find(ReturningTeacher.key).returning_to_teaching
+      !other_step(:returning_teacher).returning_to_teaching
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/uk_address.rb
+++ b/app/models/teacher_training_adviser/steps/uk_address.rb
@@ -17,9 +17,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      overseas = @store["uk_or_overseas"] != TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
-
-      overseas
+      @wizard.find(UkOrOverseas.key).uk_or_overseas != UkOrOverseas::OPTIONS[:uk]
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/uk_address.rb
+++ b/app/models/teacher_training_adviser/steps/uk_address.rb
@@ -17,7 +17,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      @wizard.find(UkOrOverseas.key).uk_or_overseas != UkOrOverseas::OPTIONS[:uk]
+      other_step(:uk_or_overseas).uk_or_overseas != UkOrOverseas::OPTIONS[:uk]
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/uk_callback.rb
+++ b/app/models/teacher_training_adviser/steps/uk_callback.rb
@@ -20,8 +20,8 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      uk_address_skipped = @wizard.all_skipped?(UkAddress.key)
-      degree_options = @wizard.find(HaveADegree.key).degree_options
+      uk_address_skipped = other_step(:uk_address).skipped?
+      degree_options = other_step(:have_a_degree).degree_options
       equivalent_degree = degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]
 
       uk_address_skipped || !equivalent_degree

--- a/app/models/teacher_training_adviser/steps/uk_callback.rb
+++ b/app/models/teacher_training_adviser/steps/uk_callback.rb
@@ -20,11 +20,11 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      overseas = @store["uk_or_overseas"] != TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
-      not_equivalent_degree = @store["degree_options"] != TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
-      returning_teacher = @store["returning_to_teaching"]
+      uk_address_skipped = @wizard.all_skipped?(UkAddress.key)
+      degree_options = @wizard.find(HaveADegree.key).degree_options
+      equivalent_degree = degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]
 
-      overseas || not_equivalent_degree || returning_teacher
+      uk_address_skipped || !equivalent_degree
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/uk_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/uk_telephone.rb
@@ -13,8 +13,8 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      uk_address_skipped = @wizard.all_skipped?(UkAddress.key)
-      degree_options = @wizard.find(HaveADegree.key).degree_options
+      uk_address_skipped = other_step(:uk_address).skipped?
+      degree_options = other_step(:have_a_degree).degree_options
       equivalent_degree = degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]
 
       uk_address_skipped || equivalent_degree

--- a/app/models/teacher_training_adviser/steps/uk_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/uk_telephone.rb
@@ -13,10 +13,11 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      equivalent_degree = @store["degree_options"] == "equivalent"
-      overseas = @store["uk_or_overseas"] == TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+      uk_address_skipped = @wizard.all_skipped?(UkAddress.key)
+      degree_options = @wizard.find(HaveADegree.key).degree_options
+      equivalent_degree = degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]
 
-      equivalent_degree || overseas
+      uk_address_skipped || equivalent_degree
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/what_degree_class.rb
+++ b/app/models/teacher_training_adviser/steps/what_degree_class.rb
@@ -16,17 +16,11 @@ module TeacherTrainingAdviser::Steps
     validates :uk_degree_grade_id, inclusion: { in: options.values.map(&:to_i) }
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
-      not_studying_or_have_a_degree = [
-        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying],
-        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes],
-      ].none?(@store["degree_options"])
-
-      returning_teacher || not_studying_or_have_a_degree
+      @wizard.all_skipped?(WhatSubjectDegree.key)
     end
 
     def studying?
-      @store["degree_options"] == TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
+      @wizard.find(HaveADegree.key).degree_options == HaveADegree::DEGREE_OPTIONS[:studying]
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/what_degree_class.rb
+++ b/app/models/teacher_training_adviser/steps/what_degree_class.rb
@@ -16,11 +16,11 @@ module TeacherTrainingAdviser::Steps
     validates :uk_degree_grade_id, inclusion: { in: options.values.map(&:to_i) }
 
     def skipped?
-      @wizard.all_skipped?(WhatSubjectDegree.key)
+      other_step(:what_subject_degree).skipped?
     end
 
     def studying?
-      @wizard.find(HaveADegree.key).degree_options == HaveADegree::DEGREE_OPTIONS[:studying]
+      other_step(:have_a_degree).degree_options == HaveADegree::DEGREE_OPTIONS[:studying]
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/what_subject_degree.rb
+++ b/app/models/teacher_training_adviser/steps/what_subject_degree.rb
@@ -15,13 +15,14 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      returning_teacher = @store["returning_to_teaching"]
+      have_a_degree_skipped = @wizard.all_skipped?(HaveADegree.key)
+      degree_options = @wizard.find(HaveADegree.key).degree_options
       not_studying_or_have_a_degree = [
-        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying],
-        TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes],
-      ].none?(@store["degree_options"])
+        HaveADegree::DEGREE_OPTIONS[:studying],
+        HaveADegree::DEGREE_OPTIONS[:yes],
+      ].none?(degree_options)
 
-      returning_teacher || not_studying_or_have_a_degree
+      have_a_degree_skipped || not_studying_or_have_a_degree
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/what_subject_degree.rb
+++ b/app/models/teacher_training_adviser/steps/what_subject_degree.rb
@@ -15,8 +15,9 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      have_a_degree_skipped = @wizard.all_skipped?(HaveADegree.key)
-      degree_options = @wizard.find(HaveADegree.key).degree_options
+      have_a_degree_step = other_step(:have_a_degree)
+      have_a_degree_skipped = have_a_degree_step.skipped?
+      degree_options = have_a_degree_step.degree_options
       not_studying_or_have_a_degree = [
         HaveADegree::DEGREE_OPTIONS[:studying],
         HaveADegree::DEGREE_OPTIONS[:yes],

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -97,6 +97,10 @@ module Wizard
       all_steps.map(&:export).reduce({}, :merge)
     end
 
+    def all_skipped?(*keys)
+      keys.all? { |key| find(key).skipped? }
+    end
+
     def reviewable_answers_by_step
       all_steps.reject(&:skipped?).each_with_object({}) do |step, hash|
         hash[step.class] = step.reviewable_answers

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -97,10 +97,6 @@ module Wizard
       all_steps.map(&:export).reduce({}, :merge)
     end
 
-    def all_skipped?(*keys)
-      keys.all? { |key| find(key).skipped? }
-    end
-
     def reviewable_answers_by_step
       all_steps.reject(&:skipped?).each_with_object({}) do |step, hash|
         hash[step.class] = step.reviewable_answers

--- a/app/models/wizard/step.rb
+++ b/app/models/wizard/step.rb
@@ -48,6 +48,11 @@ module Wizard
       false
     end
 
+    def other_step(key_or_class)
+      key = key_or_class.respond_to?(:key) ? key_or_class.key : key_or_class.to_s
+      @wizard.find(key)
+    end
+
     def export
       return {} if skipped?
 

--- a/spec/models/teacher_training_adviser/steps/gcse_maths_english_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/gcse_maths_english_spec.rb
@@ -14,20 +14,13 @@ RSpec.describe TeacherTrainingAdviser::Steps::GcseMathsEnglish do
   end
 
   describe "#skipped?" do
-    it "returns false if degree_options is studying/degree" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
-      expect(subject).to_not be_skipped
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
+    it "returns false if WhatSubjectDegree step was shown" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::WhatSubjectDegree).to receive(:skipped?) { false }
       expect(subject).to_not be_skipped
     end
 
-    it "returns true if degree_options is not studying/degree" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
+    it "returns true if WhatSubjectDegree step was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::WhatSubjectDegree).to receive(:skipped?) { true }
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/gcse_science_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/gcse_science_spec.rb
@@ -14,32 +14,26 @@ RSpec.describe TeacherTrainingAdviser::Steps::GcseScience do
   end
 
   describe "#skipped?" do
-    it "returns false if degree_options is studying/degree and preferred_education_phase_id primary" do
+    it "returns false if GcseMathsEnglish was shown, they have a GCSE maths/english and phase is primary" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::GcseMathsEnglish).to receive(:skipped?) { false }
+      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:yes]
       wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:primary]
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
-      expect(subject).to_not be_skipped
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       expect(subject).to_not be_skipped
     end
 
-    it "returns true if degree_options is not studying/degree" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+    it "returns true if GcseMathsEnglish was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::GcseMathsEnglish).to receive(:skipped?) { true }
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if they neither have or are planning to retake GCSE maths and english" do
+      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
+      wizardstore["planning_to_retake_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
       expect(subject).to be_skipped
     end
 
     it "returns true if preferred_education_phase_id is secondary" do
       wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if has_gcse_maths_and_english_id and planning_to_retake_gcse_maths_and_english_id are no" do
-      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
-      wizardstore["planning_to_retake_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
@@ -17,18 +17,19 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTelephone do
   end
 
   describe "#skipped?" do
-    it "returns false if uk_or_overseas is Overseas" do
-      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+    it "returns false if OverseasCountry was shown and they don't have an equivalent degree" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::OverseasCountry).to receive(:skipped?) { false }
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       expect(subject).to_not be_skipped
     end
 
-    it "returns true if uk_or_overseas is UK" do
-      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+    it "returns true if OverseasCountry was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::OverseasCountry).to receive(:skipped?) { true }
       expect(subject).to be_skipped
     end
 
-    it "returns true if degree_options is equivalent is true" do
-      wizardstore["degree_options"] = "equivalent"
+    it "returns true if degree_options is equivalent" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
@@ -11,31 +11,19 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTimeZone do
   end
 
   describe "#skipped?" do
-    it "returns false if degree_options is equivalent and uk_or_overseas is overseas" do
+    it "returns false if OverseasCountry was shown and they have an equivalent degree" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::OverseasCountry).to receive(:skipped?) { false }
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
-      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
-      wizardstore["returning_to_teaching"] = false
       expect(subject).to_not be_skipped
+    end
+
+    it "returns true if OverseasCountry was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::OverseasCountry).to receive(:skipped?) { true }
+      expect(subject).to be_skipped
     end
 
     it "returns true if degree_options is not equivalent" do
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
-      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
-      wizardstore["returning_to_teaching"] = false
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if uk_or_overseas is not overseas" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
-      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
-      wizardstore["returning_to_teaching"] = false
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if returning_to_teaching is true" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
-      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
-      wizardstore["returning_to_teaching"] = true
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/previous_teacher_id_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/previous_teacher_id_spec.rb
@@ -9,26 +9,19 @@ RSpec.describe TeacherTrainingAdviser::Steps::PreviousTeacherId do
   end
 
   describe "#skipped?" do
-    it "returns false if returning_to_teaching is true and has_id is true" do
-      wizardstore["returning_to_teaching"] = true
+    it "returns false if HasTeacherId was shown and they selected yes" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HasTeacherId).to receive(:skipped?) { false }
       wizardstore["has_id"] = true
       expect(subject).to_not be_skipped
     end
 
+    it "returns true if HasTeacherId was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HasTeacherId).to receive(:skipped?) { true }
+      expect(subject).to be_skipped
+    end
+
     it "returns true if has_id is false" do
-      wizardstore["returning_to_teaching"] = true
       wizardstore["has_id"] = false
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if returning_to_teaching is false" do
-      wizardstore["returning_to_teaching"] = false
-      wizardstore["has_id"] = true
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if returning_to_teaching is false" do
-      wizardstore["uk_or_overseas"] = false
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/qualification_required_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/qualification_required_spec.rb
@@ -7,48 +7,36 @@ RSpec.describe TeacherTrainingAdviser::Steps::QualificationRequired do
   it { is_expected.to_not be_can_proceed }
 
   describe "#skipped?" do
-    it "returns false if RetakeGcseMathsEnglish step shown and they are not retaking" do
+    it "returns false if RetakeGcseMathsEnglish was shown and they selected no" do
       expect_any_instance_of(TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish).to receive(:skipped?) { false }
       wizardstore["planning_to_retake_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
       expect(subject).to_not be_skipped
     end
 
-    it "returns false if RetakeGcseScience step shown and they are not retaking" do
+    it "returns false if RetakeGcseScience was shown and they selected no" do
       expect_any_instance_of(TeacherTrainingAdviser::Steps::RetakeGcseScience).to receive(:skipped?) { false }
       wizardstore["planning_to_retake_gcse_science_id"] = TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:no]
       expect(subject).to_not be_skipped
     end
 
-    it "returns true if degree_options is equivalent is true" do
-      wizardstore["degree_options"] = "equivalent"
+    it "returns true if RetakeGcseMathsEnglish was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish).to receive(:skipped?) { true }
       expect(subject).to be_skipped
     end
 
-    it "returns true if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if preferred_education_phase_id is primary and has gcse maths/english" do
-      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
-      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:yes]
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if preferred_education_phase_id is primary and retaking gcse maths/english" do
-      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
+    it "returns true if RetakeGcseMathsEnglish was shown and they selected yes" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish).to receive(:skipped?) { false }
       wizardstore["planning_to_retake_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:yes]
       expect(subject).to be_skipped
     end
 
-    it "returns true if preferred_education_phase_id is secondary and has gcse science" do
-      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
-      wizardstore["has_gcse_science_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:yes]
+    it "returns true if RetakeGcseScience was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::RetakeGcseScience).to receive(:skipped?) { true }
       expect(subject).to be_skipped
     end
 
-    it "returns true if preferred_education_phase_id is secondary and retaking gcse science" do
-      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
+    it "returns true if RetakeGcseScience was shown and they selected yes" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::RetakeGcseScience).to receive(:skipped?) { false }
       wizardstore["planning_to_retake_gcse_science_id"] = TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:yes]
       expect(subject).to be_skipped
     end

--- a/spec/models/teacher_training_adviser/steps/qualification_required_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/qualification_required_spec.rb
@@ -7,18 +7,15 @@ RSpec.describe TeacherTrainingAdviser::Steps::QualificationRequired do
   it { is_expected.to_not be_can_proceed }
 
   describe "#skipped?" do
-    it "returns false if has gcse maths/english, primary, doesn't have or retaking gcse science" do
-      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:primary]
-      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:yes]
-      wizardstore["has_gcse_science_id"] = TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:no]
-      wizardstore["planning_to_retake_gcse_science_id"] = TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:no]
+    it "returns false if RetakeGcseMathsEnglish step shown and they are not retaking" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish).to receive(:skipped?) { false }
+      wizardstore["planning_to_retake_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
       expect(subject).to_not be_skipped
     end
 
-    it "returns false if does not have or planning to retake gcse maths/english, secondary" do
-      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
-      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
-      wizardstore["planning_to_retake_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
+    it "returns false if RetakeGcseScience step shown and they are not retaking" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::RetakeGcseScience).to receive(:skipped?) { false }
+      wizardstore["planning_to_retake_gcse_science_id"] = TeacherTrainingAdviser::Steps::RetakeGcseScience::OPTIONS[:no]
       expect(subject).to_not be_skipped
     end
 

--- a/spec/models/teacher_training_adviser/steps/retake_gcse_maths_english_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/retake_gcse_maths_english_spec.rb
@@ -14,25 +14,21 @@ RSpec.describe TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish do
   end
 
   describe "#skipped?" do
-    it "returns false if has_gcse_maths_and_english_id is no" do
-      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
+    it "returns false if GcseMathsEnglish step was shown and has_gcse_maths_and_english_id is no" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::GcseMathsEnglish).to receive(:skipped?) { false }
+      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:no]
       expect(subject).to_not be_skipped
     end
 
-    it "returns true if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if degree_options is equivalent" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+    it "returns true if GcseMathsEnglish was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::GcseMathsEnglish).to receive(:skipped?) { true }
       expect(subject).to be_skipped
     end
 
     it "returns true if has_gcse_maths_and_english_id is not no" do
       wizardstore["has_gcse_maths_and_english_id"] = nil
       expect(subject).to be_skipped
-      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:yes]
+      wizardstore["has_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::GcseMathsEnglish::OPTIONS[:yes]
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/retake_gcse_science_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/retake_gcse_science_spec.rb
@@ -14,32 +14,18 @@ RSpec.describe TeacherTrainingAdviser::Steps::RetakeGcseScience do
   end
 
   describe "#skipped?" do
-    it "returns false if has_gcse_science_id is no" do
+    it "returns false if GcseScience step was shown and has_gcse_science_id is no" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::GcseScience).to receive(:skipped?) { false }
       wizardstore["has_gcse_science_id"] = TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:no]
       expect(subject).to_not be_skipped
     end
 
-    it "returns true if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
+    it "returns true if GcseScience was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::GcseScience).to receive(:skipped?) { true }
       expect(subject).to be_skipped
     end
 
-    it "returns true if preferred_education_phase_id is secondary" do
-      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if degree_options is equivalent" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if planning_to_retake_gcse_maths_and_english_id is no" do
-      wizardstore["planning_to_retake_gcse_maths_and_english_id"] = TeacherTrainingAdviser::Steps::RetakeGcseMathsEnglish::OPTIONS[:no]
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if has_gcse_science_id is not not no" do
+    it "returns true if has_gcse_science_id is not no" do
       wizardstore["has_gcse_science_id"] = nil
       expect(subject).to be_skipped
       wizardstore["has_gcse_science_id"] = TeacherTrainingAdviser::Steps::GcseScience::OPTIONS[:yes]

--- a/spec/models/teacher_training_adviser/steps/stage_interested_teaching_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/stage_interested_teaching_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe TeacherTrainingAdviser::Steps::StageInterestedTeaching do
   end
 
   describe "#skipped?" do
-    it "returns false if returning_to_teaching is false" do
-      wizardstore["returning_to_teaching"] = false
+    it "returns false if HaveADegree step was shown" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?) { false }
       expect(subject).to_not be_skipped
     end
 
-    it "returns true if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
+    it "returns true if HaveADegree was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?) { true }
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/stage_of_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/stage_of_degree_spec.rb
@@ -21,18 +21,19 @@ RSpec.describe TeacherTrainingAdviser::Steps::StageOfDegree do
   end
 
   describe "#skipped?" do
-    it "returns false if degree_options is studying" do
+    it "returns false if HaveADegree step was shown and they are studying for a degree" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?) { false }
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
       expect(subject).to_not be_skipped
     end
 
-    it "returns true if degree_options is not studying" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
+    it "returns true if HaveADegree was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?) { true }
       expect(subject).to be_skipped
     end
 
-    it "returns true if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
+    it "returns true if not studying for a degree" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
@@ -22,21 +22,19 @@ RSpec.describe TeacherTrainingAdviser::Steps::SubjectInterestedTeaching do
   end
 
   describe "#skipped?" do
-    it "returns false if returning_to_teaching is false and preferred_education_phase_id is secondary" do
-      wizardstore["returning_to_teaching"] = false
+    it "returns false if StageInterestedTeaching step was shown and preferred_education_phase_id is secondary" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::StageInterestedTeaching).to receive(:skipped?) { false }
       wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
       expect(subject).to_not be_skipped
     end
 
-    it "returns true if preferred_education_phase_id is not secondary" do
-      wizardstore["returning_to_teaching"] = false
-      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:primary]
+    it "returns true if StageInterestedTeaching was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::StageInterestedTeaching).to receive(:skipped?) { true }
       expect(subject).to be_skipped
     end
 
-    it "returns true if returning_to_teaching is not false" do
-      wizardstore["returning_to_teaching"] = true
-      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary]
+    it "returns true if education phase is primary" do
+      wizardstore["preferred_education_phase_id"] = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:primary]
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
@@ -22,31 +22,19 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
   end
 
   describe "#skipped?" do
-    it "returns false if degree_options is equivalent and uk_or_overseas is UK" do
+    it "returns false if UkAddress step was shown and degree_options is equivalent" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::UkAddress).to receive(:skipped?) { false }
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
-      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
-      wizardstore["returning_to_teaching"] = false
       expect(subject).to_not be_skipped
+    end
+
+    it "returns true if UkAddress was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::UkAddress).to receive(:skipped?) { true }
+      expect(subject).to be_skipped
     end
 
     it "returns true if degree_options is not equivalent" do
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
-      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
-      wizardstore["returning_to_teaching"] = false
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if uk_or_overseas is not UK" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
-      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
-      wizardstore["returning_to_teaching"] = false
-      expect(subject).to be_skipped
-    end
-
-    it "returns true if returning_to_teaching is true" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
-      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
-      wizardstore["returning_to_teaching"] = true
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/uk_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_telephone_spec.rb
@@ -17,18 +17,19 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkTelephone do
   end
 
   describe "#skipped?" do
-    it "returns false if uk_or_overseas is UK" do
-      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+    it "returns false if UkAddress step was shown and degree_options is not equivalent" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::UkAddress).to receive(:skipped?) { false }
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       expect(subject).to_not be_skipped
     end
 
-    it "returns true if returning_to_teaching is Overseas" do
-      wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+    it "returns true if UkAddress was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::UkAddress).to receive(:skipped?) { true }
       expect(subject).to be_skipped
     end
 
     it "returns true if degree_options is equivalent" do
-      wizardstore["degree_options"] = "equivalent"
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/what_degree_class_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/what_degree_class_spec.rb
@@ -22,33 +22,14 @@ RSpec.describe TeacherTrainingAdviser::Steps::WhatDegreeClass do
   end
 
   describe "#skipped?" do
-    it "returns false if degree_options is studying/degree" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
-      expect(subject).to_not be_skipped
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
+    it "returns false if WhatSubjectDegree step was shown" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::WhatSubjectDegree).to receive(:skipped?) { false }
       expect(subject).to_not be_skipped
     end
 
-    it "returns true if degree_options is not studying/degree" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+    it "returns true if WhatSubjectDegree was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::WhatSubjectDegree).to receive(:skipped?) { true }
       expect(subject).to be_skipped
-    end
-
-    it "returns true if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
-      expect(subject).to be_skipped
-    end
-  end
-
-  describe "#studying?" do
-    it "returns true if degree_options is studying" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
-      expect(subject).to be_studying
-    end
-
-    it "returns false if degree_options is not studying" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
-      expect(subject).to_not be_studying
     end
   end
 

--- a/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
@@ -16,20 +16,25 @@ RSpec.describe TeacherTrainingAdviser::Steps::WhatSubjectDegree do
   end
 
   describe "#skipped?" do
-    it "returns false if degree_options is studying/degree" do
+    it "returns false if HaveADegree step was shown and degree_options is studying" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?) { false }
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
       expect(subject).to_not be_skipped
+    end
+
+    it "returns false if HaveADegree step was shown and degree_options is yes" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?) { false }
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       expect(subject).to_not be_skipped
     end
 
-    it "returns true if degree_options is not studying/degree" do
-      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+    it "returns true if HaveADegree was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?) { true }
       expect(subject).to be_skipped
     end
 
-    it "returns true if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
+    it "returns true if degree_options is not studying/yes" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -210,20 +210,6 @@ RSpec.describe Wizard::Base do
     end
   end
 
-  describe "#all_skipped?" do
-    it "returns true if all steps are skipped" do
-      allow_any_instance_of(TestWizard::Name).to receive(:skipped?) { true }
-      allow_any_instance_of(TestWizard::Age).to receive(:skipped?) { true }
-      expect(wizard).to be_all_skipped(TestWizard::Name.key, TestWizard::Age.key)
-    end
-
-    it "returns false if any of the steps are not skipped" do
-      allow_any_instance_of(TestWizard::Name).to receive(:skipped?) { true }
-      allow_any_instance_of(TestWizard::Age).to receive(:skipped?) { false }
-      expect(wizard).to_not be_all_skipped(TestWizard::Name.key, TestWizard::Age.key)
-    end
-  end
-
   describe "#reviewable_answers_by_step" do
     subject { wizard.reviewable_answers_by_step }
 

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -210,6 +210,20 @@ RSpec.describe Wizard::Base do
     end
   end
 
+  describe "#all_skipped?" do
+    it "returns true if all steps are skipped" do
+      allow_any_instance_of(TestWizard::Name).to receive(:skipped?) { true }
+      allow_any_instance_of(TestWizard::Age).to receive(:skipped?) { true }
+      expect(wizard).to be_all_skipped(TestWizard::Name.key, TestWizard::Age.key)
+    end
+
+    it "returns false if any of the steps are not skipped" do
+      allow_any_instance_of(TestWizard::Name).to receive(:skipped?) { true }
+      allow_any_instance_of(TestWizard::Age).to receive(:skipped?) { false }
+      expect(wizard).to_not be_all_skipped(TestWizard::Name.key, TestWizard::Age.key)
+    end
+  end
+
   describe "#reviewable_answers_by_step" do
     subject { wizard.reviewable_answers_by_step }
 

--- a/spec/models/wizard/step_spec.rb
+++ b/spec/models/wizard/step_spec.rb
@@ -9,8 +9,14 @@ RSpec.describe Wizard::Step do
     validates :name, presence: true
   end
 
+  class StubWizard < Wizard::Base
+    self.steps = [FirstStep].freeze
+  end
+
   let(:attributes) { {} }
-  subject { FirstStep.new nil, wizardstore, attributes }
+  let(:wizard) { StubWizard.new(wizardstore, "first_step") }
+
+  subject { FirstStep.new wizard, wizardstore, attributes }
 
   describe ".key" do
     it { expect(described_class.key).to eql "step" }
@@ -40,6 +46,11 @@ RSpec.describe Wizard::Step do
 
   describe "#can_proceed" do
     it { expect(subject).to be_can_proceed }
+  end
+
+  describe "#other_step" do
+    it { expect(subject.other_step(:first_step)).to be_kind_of(FirstStep) }
+    it { expect(subject.other_step(FirstStep)).to be_kind_of(FirstStep) }
   end
 
   describe "#save!" do

--- a/spec/support/shared_examples/wizard_support.rb
+++ b/spec/support/shared_examples/wizard_support.rb
@@ -6,7 +6,10 @@ end
 RSpec.shared_context "wizard step" do
   include_context "wizard store"
   let(:attributes) { {} }
-  let(:instance) { described_class.new nil, wizardstore, attributes }
+  let(:instance) do
+    wizard = TeacherTrainingAdviser::Wizard.new(wizardstore, described_class.key)
+    described_class.new wizard, wizardstore, attributes
+  end
   subject { instance }
 end
 


### PR DESCRIPTION
- Simplify skipped? methods

Simplifies the `skipped?` logic in steps by allowing them to query the skipped state of previous steps.

The tests have only been refactored where necessary.

- Simplify skipped? tests

As the `skipped?` logic is now more concise the tests can also be made simpler.