### PR TITLE
Fix missing translation for HaveADegree step

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,8 +37,8 @@ telephone_errors: &telephone_errors
 en:
   have_a_degree:
     degree_options:
-      yes: "Yes"
-      no: "No"
+      "yes": "Yes"
+      "no": "No"
       studying: "I'm studying for a degree"
       equivalent: "I have an equivalent qualification from another country"
   answers:


### PR DESCRIPTION
Yaml was translating yes/no keys into `true` and `false`, which mean the translation key `have_a_degree.degree_options.yes` was not matching. By wrapping it in quotes YAML respects the yes/no key values.
