### PR TITLE
Remove 'No Preference' from WhatSubjectDegree step

### DIFF
--- a/app/models/teacher_training_adviser/steps/what_subject_degree.rb
+++ b/app/models/teacher_training_adviser/steps/what_subject_degree.rb
@@ -2,12 +2,16 @@ module TeacherTrainingAdviser::Steps
   class WhatSubjectDegree < Wizard::Step
     extend ApiOptions
 
+    OMIT_SUBJECT_IDS = [
+      "bc68e0c1-7212-e911-a974-000d3a206976", # No Preference
+    ].freeze
+
     attribute :degree_subject, :string
 
     validates :degree_subject, presence: true
 
     def self.options
-      generate_api_options(:get_teaching_subjects)
+      generate_api_options(:get_teaching_subjects, OMIT_SUBJECT_IDS)
     end
 
     def skipped?

--- a/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::WhatSubjectDegree do
   include_context "wizard step"
   it_behaves_like "a wizard step"
-  it_behaves_like "a wizard step that exposes API types as options", :get_teaching_subjects
+  it_behaves_like "a wizard step that exposes API types as options",
+                  :get_teaching_subjects, described_class::OMIT_SUBJECT_IDS
 
   context "attributes" do
     it { is_expected.to respond_to :degree_subject }


### PR DESCRIPTION
We don't want to display the 'No Preference' option for teaching subjects in the `WhatSubjectDegree` step, as it doesn't make sense as an answer.