### PR TITLE
API requires the teaching subject set for primary applicants

### DIFF
--- a/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
@@ -6,6 +6,7 @@ module TeacherTrainingAdviser::Steps
 
     validates :preferred_education_phase_id, types: { method: :get_candidate_preferred_education_phases }
 
+    PRIMARY_SUBJECT_ID = "b02655a1-2afa-e811-a981-000d3a276620".freeze
     OPTIONS = { primary: 222_750_000, secondary: 222_750_001 }.freeze
 
     def reviewable_answers
@@ -18,6 +19,14 @@ module TeacherTrainingAdviser::Steps
       returning_teacher = @store["returning_to_teaching"]
 
       returning_teacher
+    end
+
+    def export
+      if preferred_education_phase_id == OPTIONS[:primary] && !skipped?
+        super.merge("preferred_teaching_subject_id" => PRIMARY_SUBJECT_ID)
+      else
+        super
+      end
     end
   end
 end

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Sign up for a teacher training adviser", type: :feature do
+  PRIMARY_SUBJECT_ID = "b02655a1-2afa-e811-a981-000d3a276620".freeze
   EDUCATION_PHASE_PRIMARY = 222_750_000
   EDUCATION_PHASE_SECONDARY = 222_750_001
   DEGREE_STATUS_HAS_DEGREE = 222_750_000
@@ -219,6 +220,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
         degree_type_id: DEGREE_TYPE_DEGREE,
         initial_teacher_training_year_id: TEACHER_TRAINING_YEAR_2022,
         preferred_education_phase_id: EDUCATION_PHASE_PRIMARY,
+        preferred_teaching_subject_id: PRIMARY_SUBJECT_ID,
         has_gcse_maths_and_english_id: HAS_GCSE,
         has_gcse_science_id: HAS_GCSE,
         degree_subject: "Maths",


### PR DESCRIPTION
### JIRA ticket number

N/a

### Context

We should be including the primary teaching subject as the preferred teaching subject id when submitting primary stage applicants to the API

### Changes proposed in this pull request

1. This includes the expected primary subject in the export hash from the teaching stage. This only occurs if the teaching stage is skipped.

### Guidance to review

I've since thought of a better way of doing this but this approach is reliable and I can shift things around later on.
