### PR TITLE
Strip query params from document/blocked URIs

### DIFF
--- a/config/initializers/instrumentation.rb
+++ b/config/initializers/instrumentation.rb
@@ -63,7 +63,10 @@ ActiveSupport::Notifications.subscribe "tta.csp_violation" do |*args|
 
   labels = { blocked_uri: nil, document_uri: nil, violated_directive: nil }
   labels.merge!(report.slice(*labels.keys))
+
   labels[:violated_directive] = labels[:violated_directive].split.first if labels[:violated_directive]
+  labels[:blocked_uri] = labels[:blocked_uri].split("?").first if labels[:blocked_uri]
+  labels[:document_uri] = labels[:document_uri].split("?").first if labels[:document_uri]
 
   metric = prometheus.get(:tta_csp_violations_total)
   metric.increment(labels: labels)

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe "Instrumentation" do
       {
         "csp-report" =>
         {
-          "blocked-uri" => "blocked-uri",
-          "document-uri" => "document-uri",
+          "blocked-uri" => "http://document-uri.com/script.js?param=test",
+          "document-uri" => "http://document-uri.com?param=test",
           "violated-directive": "violated-directive extra-info",
         },
       }
@@ -75,8 +75,8 @@ RSpec.describe "Instrumentation" do
       metric = registry.get(:tta_csp_violations_total)
       expect(metric).to receive(:increment).with(labels:
         {
-          blocked_uri: "blocked-uri",
-          document_uri: "document-uri",
+          blocked_uri: "http://document-uri.com/script.js",
+          document_uri: "http://document-uri.com",
           violated_directive: "violated-directive",
         }).once
     end


### PR DESCRIPTION
We are getting a lot of similar CSP violations where the blocked/document URIs only differ by their query string parameters, for example:

```
https://t.co/i/adsct?type=javascript&version=1.1.0&p_id=Twitter&p_user_id=0&txn_id=o0wo4&events=%5B%5B%22pageview%22%2Cnull%5D%5D&tw_sale_amount=0&tw_order_quantity=0&tw_iframe_status=0&tw_document_href=https%3A%2F%2Fbeta-getintoteaching.education.gov.uk%2Fsteps-to-become-a-teacher

https://t.co/i/adsct?type=javascript&version=1.1.0&p_id=Twitter&p_user_id=0&txn_id=o0wo4&events=%5B%5B%22pageview%22%2Cnull%5D%5D&tw_sale_amount=0&tw_order_quantity=0&tw_iframe_status=0&tw_document_href=https%3A%2F%2Fbeta-getintoteaching.education.gov.uk%2Fsteps-to-become-a-teacher%23step-4
```

If we truncate the query parameters it will let us aggregate on the domain/path and provide a better insight into the CSP violations. The full violation details are still available to explore in Kibana.
