### PR TITLE
Render 404 on Wizard::UnknownStep

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,17 @@ class ApplicationController < ActionController::Base
   before_action :http_basic_authenticate
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :session_expired
+  rescue_from ActionController::RoutingError, with: :render_not_found
+
+  def raise_not_found
+    raise ActionController::RoutingError, "Not Found"
+  end
 
 private
+
+  def render_not_found
+    render template: "errors/not_found", status: :not_found
+  end
 
   def http_basic_authenticate
     return true if ENV["HTTPAUTH_USERNAME"].blank?

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -39,6 +39,8 @@ private
 
   def load_wizard
     @wizard = wizard_class.new(wizard_store, params[:id])
+  rescue Wizard::UnknownStep
+    raise_not_found
   end
 
   def load_current_step

--- a/spec/requests/sign_up_spec.rb
+++ b/spec/requests/sign_up_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe TeacherTrainingAdviser::StepsController do
     before { get step_path }
     subject { response }
     it { is_expected.to have_http_status :success }
+
+    context "with an invalid step" do
+      let(:step_path) { teacher_training_adviser_step_path(:invalid) }
+
+      it { is_expected.to have_http_status :not_found }
+    end
   end
 
   describe "#update" do


### PR DESCRIPTION
We currently fail with a 500 error if the wizard is initialised with an unknown step; this happens if the user enters a bad URL, so it would make more sense to return a 404 in this scenario.
