### PR TITLE
Fix webpacker deprecation warning

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -11,7 +11,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: ['node_modules/govuk-frontend/govuk']
+  additional_paths: ['node_modules/govuk-frontend/govuk']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@rails/webpacker": "^5.1.1",
+    "@rails/webpacker": "^5.2.1",
     "govuk-frontend": "^3.6.0",
     "js-cookie": "^2.2.1",
     "rails-ujs": "^5.2.4",


### PR DESCRIPTION
Webpacker is throwing a deprecation warning as `resolved_paths` has now been replaced with `additional_paths`.
