### PR TITLE
Rate limit transactions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,11 +19,11 @@ private
   end
 
   def render_too_many_requests
-    render template: "errors/too_many_requests", status: :too_many_requests
+    render template: "errors/too_many_requests", status: :too_many_requests, layout: "application"
   end
 
   def render_not_found
-    render template: "errors/not_found", status: :not_found
+    render template: "errors/not_found", status: :not_found, layout: "application"
   end
 
   def http_basic_authenticate

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,12 +4,23 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :session_expired
   rescue_from ActionController::RoutingError, with: :render_not_found
+  rescue_from GetIntoTeachingApiClient::ApiError, with: :handle_api_error
 
   def raise_not_found
     raise ActionController::RoutingError, "Not Found"
   end
 
 private
+
+  def handle_api_error(error)
+    render_too_many_requests && return if error.code == 429
+
+    raise
+  end
+
+  def render_too_many_requests
+    render template: "errors/too_many_requests", status: :too_many_requests
+  end
 
   def render_not_found
     render template: "errors/not_found", status: :not_found

--- a/app/models/wizard/issue_verification_code.rb
+++ b/app/models/wizard/issue_verification_code.rb
@@ -10,7 +10,9 @@ module Wizard
           request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(request_attributes)
           GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
           @store["authenticate"] = true
-        rescue GetIntoTeachingApiClient::ApiError
+        rescue GetIntoTeachingApiClient::ApiError => e
+          raise if e.code == 429
+
           # Existing candidate not found or CRM is currently unavailable.
           @store["authenticate"] = false
         end

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -1,0 +1,7 @@
+<main class="govuk-main-wrapper" id="main-content" role="main">
+  <div class="govuk-width-container">
+    <h1 class="govuk-heading-xl">Too many requests</h1>
+    <p>You have tried to access a page too often in a short space of time.</p>
+    <p>You can go <%= link_to("back", :back) %> and try to access the page again in 1 minute.</p>
+  </div>
+</main>

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,36 @@
-class Rack::Attack
-  # Throttle /csp_reports requests by IP (5rpm)
-  throttle("req/ip", limit: 5, period: 1.minute) do |req|
-    req.ip if req.path == "/csp_reports"
+module Rack
+  class Attack
+    # Throttle /csp_reports requests by IP (5rpm)
+    throttle("csp_reports req/ip", limit: 5, period: 1.minute) do |req|
+      req.ip if req.path == "/csp_reports"
+    end
+
+    # Throttle requests that issue a verification code by IP (5rpm)
+    throttle("issue_verification_code req/ip", limit: 5, period: 1.minute) do |req|
+      req.ip if (req.patch? || req.put?) && req.path == "/teacher_training_adviser/sign_up/identity"
+    end
+
+    # Throttle requests that resend a verification code by IP (5rpm)
+    throttle("resend_verification_code req/ip", limit: 5, period: 1.minute) do |req|
+      path_resends_verification_code = %r{/*./resend_verification}.match?(req.path)
+
+      req.ip if req.get? && path_resends_verification_code
+    end
+
+    # Throttle teacher training adviser sign ups by IP (5rpm)
+    throttle("teacher_training_adviser_sign_up req/ip", limit: 5, period: 1.minute) do |req|
+      req.ip if (req.patch? || req.put?) && req.path == "/teacher_training_adviser/sign_up/accept_privacy_policy"
+    end
+  end
+
+  Rack::Attack.throttled_response = lambda do |env|
+    accept_html = env["HTTP_ACCEPT"].include?("text/html")
+    return [429, {}, "Rate limit exceeded"] unless accept_html
+
+    html = ApplicationController.render(
+      template: "errors/too_many_requests",
+    )
+
+    [429, { "Content-Type" => "text/html; charset=utf-8" }, [html]]
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -29,6 +29,7 @@ module Rack
 
     html = ApplicationController.render(
       template: "errors/too_many_requests",
+      layout: "application",
     )
 
     [429, { "Content-Type" => "text/html; charset=utf-8" }, [html]]

--- a/spec/support/shared_examples/rate_limiting_support.rb
+++ b/spec/support/shared_examples/rate_limiting_support.rb
@@ -1,0 +1,32 @@
+RSpec.shared_examples "an IP-based rate limited endpoint" do |desc, limit, period|
+  describe desc do
+    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+    before do
+      allow(Rack::Attack.cache).to receive(:store) { memory_store }
+      request_count.times { perform_request }
+    end
+
+    subject { response.status }
+
+    context "when fewer than rate limit" do
+      let(:request_count) { limit - 1 }
+
+      it { is_expected.to_not eq(429) }
+    end
+
+    context "when more than rate limit" do
+      let(:request_count) { limit + 1 }
+
+      it { is_expected.to eq(429) }
+
+      context "when time restriction has passed" do
+        it "allows another request" do
+          travel period + 1.second
+          perform_request
+          expect(response.status).to_not eq(429)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/wizard_support.rb
+++ b/spec/support/shared_examples/wizard_support.rb
@@ -95,6 +95,17 @@ RSpec.shared_examples "an issue verification code wizard step" do
         expect(wizardstore["authenticate"]).to be_falsy
       end
     end
+
+    context "when the API rate limits the request" do
+      let(:too_many_requests_error) { GetIntoTeachingApiClient::ApiError.new(code: 429) }
+
+      it "will re-raise the ApiError (to be rescued by the ApplicationController)" do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request)
+          .and_raise(too_many_requests_error)
+        expect { subject.save! }.to raise_error(too_many_requests_error)
+        expect(wizardstore["authenticate"]).to be_nil
+      end
+    end
   end
 end
 


### PR DESCRIPTION
### JIRA ticket number

[Trello-352](https://trello.com/c/MjWfjLi7/352-set-rate-limiting-on-api)

### Context

The API is rate limited to 30 requests/client API key/minute for transactional/vulnerable endpoints (both apps currently share the same API key, but this will change in the future).

We want to apply per-user/IP rate limiting in the front end applications as well, to add more granular control over submissions. The rate limits initially will be 5 requests/IP/minute - this should be plenty for now, but may need tweaking as we roll out to more users (or to take into account advertising 'spikes' in traffic).

When a user encounters a rate limit we want to display a 429 error page similar to the existing 404/500 error pages.

If the user encounters an API rate limit we want to display the same page.

### Changes proposed in this pull request

- Rate limit transaction endpoints

The transaction endpoints are rate limited to 30 requests per minute by the API. We want to enforce the rate limiting client-side per user/ip as well to a maximum of 5 requests/IP/minute.

If a user encounters a rate limit, instead of returning a standard 429 and text response we instead render a 'Too many requests' error page, similar to the existing 404 and 500 error pages.

- Rescue ApiError and render 429 error page

Whilst the app itself is rate limited the API also has rate limiting. In the unlikely event that the client rate limits don't trigger and instead the API's rate limiting is enforced we want to display the same 429 error page to the user.

Raise `ApiError` up to the `ApplicationController` when the `code` is 429. The `ApplicationController` will then rescue the error and render the error page.

### Guidance to review

<img width="1218" alt="Screenshot 2020-10-30 at 09 03 12" src="https://user-images.githubusercontent.com/29867726/97680541-bfc57880-1a8e-11eb-96f6-a8640c9d8a0b.png">
