### PR TITLE
Disable rate limiting in production-like environments

### DIFF
--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -3,4 +3,6 @@ require File.expand_path("production.rb", __dir__)
 
 Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-test.london.cloudapps.digital"
+
+  Rack::Attack.enabled = false
 end

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -3,4 +3,6 @@ require File.expand_path("production.rb", __dir__)
 
 Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
+
+  Rack::Attack.enabled = false
 end

--- a/config/environments/userresearch.rb
+++ b/config/environments/userresearch.rb
@@ -3,4 +3,6 @@ require File.expand_path("production.rb", __dir__)
 
 Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
+
+  Rack::Attack.enabled = false
 end


### PR DESCRIPTION
We want to disable rate limiting in production-like environments (but not production) so that the integration tests can be ran successfully.