### PR TITLE
Replaced usage of deprecated bundler option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV RAILS_ENV=production \
     RAILS_SERVE_STATIC_FILES=true \
     RAILS_LOG_TO_STDOUT=true \
     RACK_TIMEOUT_SERVICE_TIMEOUT=60 \
-    BUNDLE_BUILD__SASSC=--disable-march-tune-native
+    BUNDLE_WITHOUT=development
 
 RUN mkdir /app
 WORKDIR /app
@@ -30,7 +30,7 @@ RUN echo "${APP_SHA}" > /etc/get-teacher-training-adviser-service-sha
 # Install Gems removing artifacts
 COPY .ruby-version Gemfile Gemfile.lock ./
 # hadolint ignore=SC2046
-RUN bundle install --without development --jobs=$(nproc --all) && \
+RUN bundle install --jobs=$(nproc --all) && \
     rm -rf /root/.bundle/cache && \
     rm -rf /usr/local/bundle/cache
 


### PR DESCRIPTION
### JIRA ticket number

https://trello.com/c/O9T3Qco5

### Context

We are using the `--without` bundler option but this has now been deprecated

### Changes proposed in this pull request

1. Switch to using the env var replacement
2. Removed the unused sassc compillation option



