### PR TITLE
Prevent error when skipping ahead to review answers step

### DIFF
--- a/app/models/teacher_training_adviser/steps/uk_callback.rb
+++ b/app/models/teacher_training_adviser/steps/uk_callback.rb
@@ -14,8 +14,8 @@ module TeacherTrainingAdviser::Steps
 
     def reviewable_answers
       {
-        "callback_date" => phone_call_scheduled_at.to_date,
-        "callback_time" => phone_call_scheduled_at.to_time, # rubocop:disable Rails/Date
+        "callback_date" => phone_call_scheduled_at&.to_date,
+        "callback_time" => phone_call_scheduled_at&.to_time, # rubocop:disable Rails/Date
       }
     end
 

--- a/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
@@ -61,5 +61,11 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
         "callback_time" => date_time.to_time, # rubocop:disable Rails/Date
       })
     }
+
+    context "when the phone_call_scheduled_at is nil" do
+      let(:date_time) { nil }
+
+      it { is_expected.to eq({ "callback_date" => nil, "callback_time" => nil }) }
+    end
   end
 end


### PR DESCRIPTION
### JIRA ticket number

[Trello-518](https://trello.com/c/oaWXG1mL/518-fix-sentry-issue-in-tta)
[Sentry](https://sentry.io/organizations/dfe-bat/issues/2006318159/?project=5276960&referrer=slack)

### Context

If a user proceeds through the TTA sign up as a candidate with an equivalent degree that is located in the UK, but then manually enters the URL for the review answers page before completing the `UkCallback` step an error would be thrown as the `phone_call_scheduled_at` is `nil` and we try and call `to_date` on it.

### Changes proposed in this pull request

- Prevent error when skipping ahead to review answers step

Update to use the safe navigation operator on `phone_call_scheduled_at`.

### Guidance to review

