### PR TITLE
Add test coverage for reviewing incomplete steps

### DIFF
--- a/spec/requests/review_answers_spec.rb
+++ b/spec/requests/review_answers_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "Review answers", type: :request do
+  let(:model) { TeacherTrainingAdviser::Steps::ReviewAnswers }
+  let(:step_path) { teacher_training_adviser_step_path model.key }
+
+  context "when reviewing all steps without any steps being completed" do
+    subject do
+      TeacherTrainingAdviser::Wizard.steps.each do |step|
+        allow_any_instance_of(step).to receive(:skipped?) { false }
+      end
+
+      get step_path
+      response
+    end
+
+    it { is_expected.to have_http_status :success }
+  end
+end


### PR DESCRIPTION
A user is able to skip straight to the review answers page manually by entering the correct URL without actually completing any steps. This is expected behaviour, however we need to ensure the steps can handle this scenario and don't assume they have been answered when their `reviewable_answers` method is called.

Add test to simulate rendering all wizard steps for review as unanswered.