### PR TITLE
Redirect to identity step on resend_verification bad request

### DIFF
--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -33,6 +33,10 @@ module WizardSteps
     request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(camelized_identity_data)
     GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
     redirect_to authenticate_path(verification_resent: true)
+  rescue GetIntoTeachingApiClient::ApiError => e
+    redirect_to teacher_training_adviser_step_path(:identity) and return if e.code == 400
+
+    raise
   end
 
 private

--- a/spec/requests/sign_up_spec.rb
+++ b/spec/requests/sign_up_spec.rb
@@ -117,5 +117,17 @@ RSpec.describe TeacherTrainingAdviser::StepsController do
       it { is_expected.to match(/Too many requests/) }
       it { is_expected.to match(/You have tried to access a page too often/) }
     end
+
+    context "when the API returns 400 bad request" do
+      let(:bad_request_error) { GetIntoTeachingApiClient::ApiError.new(code: 400) }
+
+      subject! do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token).and_raise(bad_request_error)
+        get resend_verification_teacher_training_adviser_steps_path
+      end
+
+      it { is_expected.to redirect_to(teacher_training_adviser_step_path(:identity)) }
+    end
   end
 end


### PR DESCRIPTION
If a candidate's session expires (so they sit on the authenticate step overnight, for instance) then they hit the link to resend their verification code the app attempts to make an invalid request to the API (email, first and last name are nil). This currently results in a 500 error for the user. Instead, we rescue this condition and redirect to the identity step so that they can re-authenticate.

Fixes https://sentry.io/organizations/dfe-bat/issues/2010050592/?project=5276960&referrer=slack