### PR TITLE
Added a save button to the Cookie Preferences page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,4 +60,12 @@ module ApplicationHelper
   def link_to_git_site(text = "Get into Teaching", attributes = {})
     link_to text, (ENV["GIT_URL"].presence || "/url-not-set"), attributes
   end
+
+  def internal_referer
+    referer = request.referer
+    internal = referer.to_s.include?(root_url)
+    return nil unless internal
+
+    referer
+  end
 end

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -1,6 +1,6 @@
 <main class="govuk-main-wrapper no-margin" id="main-content" role="main">
   <div class="govuk-width-container">
-    <%= back_link %>
+    <%= back_link internal_referer || root_path %>
 
     <h1>Cookies on Get into Teaching</h1>
 
@@ -81,7 +81,7 @@
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input id="cookies-non-functional-no" class="govuk-radios__input" type="radio" value="0" name="cookies-non-functional"  data-action="cookie-preferences#toggle" />
+                <input id="cookies-non-functional-no" class="govuk-radios__input" type="radio" value="0" name="cookies-non-functional" data-action="cookie-preferences#toggle" />
                 <label for="cookies-non-functional-no" class="govuk-label govuk-radios__label">
                   No
                 </label>
@@ -161,12 +161,29 @@
 
               <p>They always need to be on.</p>
 
-              <p>
-                <%= link_to "Find out more", cookies_path %>
-                about cookies on this service
-              </p>
+
             </div>
           </fieldset>
+
+          <p class="save-with-confirmation">
+            <button type="button"
+              data-action="cookie-preferences#save"
+              class="govuk-button">
+              Save
+            </button>
+
+            <span data-target="cookie-preferences.flash" class="save-with-confirmation__message">
+              Your cookie preferences have been saved
+            </span>
+
+            <br />
+            <%= link_to "Back to page", internal_referer || root_path, class: "govuk-button govuk-button--secondary" %>
+          </p>
+
+          <p>
+            <%= link_to "Find out more", cookies_path %>
+            about cookies on this service
+          </p>
         </div>
       </form>
 

--- a/app/webpacker/controllers/cookie_preferences_controller.js
+++ b/app/webpacker/controllers/cookie_preferences_controller.js
@@ -6,7 +6,6 @@ export default class extends Controller {
 
   connect() {
     this.cookiePreferences = new CookiePreferences ;
-    this.cookiePreferences.writeCookie(this.cookiePreferences.all) ;
     this.assignRadios() ;
   }
 
@@ -23,9 +22,27 @@ export default class extends Controller {
   }
 
   toggle(event) {
-    const category = event.target.name.toString().replace(/^cookies-/, '')
-    const value = event.target.value ;
+    this.data.set('save-state', 'unsaved')
+  }
 
-    this.cookiePreferences.setCategory(category, value) ;
+  save(event) {
+    event.preventDefault() ;
+
+    for (const categoryFieldset of this.categoryTargets) {
+      const category = categoryFieldset.getAttribute('data-category')
+      const field = categoryFieldset.querySelector('input[type="radio"]:checked')
+
+      if (field) {
+        this.cookiePreferences.setCategory(category, field.value)
+      }
+    }
+
+    this.data.set('save-state', 'saving')
+    window.setTimeout(this.finishSave.bind(this), 300)
+  }
+
+  finishSave() {
+    if (this.data.get('save-state') == 'saving')
+      this.data.set('save-state', 'saved')
   }
 }

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -104,6 +104,23 @@ $govuk-global-styles: true;
   }
 }
 
+[data-controller="cookie-preferences"] {
+  .save-with-confirmation button {
+    vertical-align: baseline;
+    @include govuk-responsive-margin(2, "bottom");
+    @include govuk-responsive-margin(2, "right");
+  }
 
+  .save-with-confirmation__message {
+    display: none;
+    vertical-align: baseline;
+    color: govuk-colour("green") ;
+    @include govuk-responsive-margin(5, "bottom");
+  }
+
+  &[data-cookie-preferences-save-state="saved"] .save-with-confirmation__message {
+    display: inline-block ;
+  }
+}
 
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -156,6 +156,28 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe "#internal_referer" do
+    it "returns nil if the referrer is not set" do
+      helper.request = double("request", referer: nil)
+      expect(helper.internal_referer).to be_nil
+    end
+
+    it "returns nil if the referrer is empty" do
+      helper.request = double("request", referer: " ")
+      expect(helper.internal_referer).to be_nil
+    end
+
+    it "returns nil if the referrer is external" do
+      helper.request = double("request", referer: " ")
+      expect(helper.internal_referer).to be_nil
+    end
+
+    it "returns the referrer if internal" do
+      helper.request = double("request", referer: root_url)
+      expect(helper.internal_referer).to eql(root_url)
+    end
+  end
+
   class StubModel
     include ActiveModel::Model
   end


### PR DESCRIPTION
### Context

The cookie preferences should require the user to save their preferences rather than auto-saving changes

### Changes proposed in this pull request

1. Add a save buttom
2. Added a back link which will trigger a page reload
3. Replaced existing back link with one which will reload the page



