### PR TITLE
Fix SonarCloud integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,8 +115,14 @@ jobs:
 
       - name: Lint Ruby
         run: |-
-          docker run -t --rm -e RAILS_ENV=test ${{ steps.sha.outputs.local }} \
-            rubocop app config db lib spec Gemfile --format clang
+          docker run -t --rm -v ${PWD}/out:/app/out -e RAILS_ENV=test ${{ steps.sha.outputs.local }} \
+            rubocop app config db lib spec Gemfile --format json --out=/app/out/rubocop-result.json
+
+      - name:  Keep Rubocop output
+        uses: actions/upload-artifact@v2
+        with:
+          name: Rubocop_results
+          path: ${{ github.workspace }}/rubocop-result.json
 
       - name: Run Brakeman static security scanner
         run: |-
@@ -132,6 +138,7 @@ jobs:
            -Dsonar.projectKey=get-teacher-training-adviser-service
            -Dsonar.testExecutionReportPaths=${PWD}/out/test-report.xml
            -Dsonar.ruby.coverage.reportPaths=${PWD}/coverage/.resultset.json
+           -Dsonar.ruby.rubocop.reportPaths=${PWD}/out/rubocop-result.json
 
       - name: Slack Notification
         if: failure()

--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ group :development, :test do
   # Testing framework
   gem "rspec-rails", "~> 4.0.0"
   gem "rspec-sonarqube-formatter", "~> 1.4"
-  gem "simplecov", "<= 0.20"
+  gem "simplecov", "~> 0.17.1"
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", "~> 3.32"
   # Factory builder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,10 +278,11 @@ GEM
       faraday (>= 1.0)
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
-    simplecov (0.19.1)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.3)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     sixarm_ruby_unaccent (1.2.0)
     sort_alphabetical (1.1.0)
       unicode_utils (>= 1.2.2)
@@ -358,7 +359,7 @@ DEPENDENCIES
   secure_headers
   sentry-raven
   shoulda-matchers
-  simplecov (<= 0.20)
+  simplecov (~> 0.17.1)
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,5 @@ sonar.tests=./spec
 sonar.exclusions=app/assets/**/*,app/webpacker/**/*,**/fake_endpoints.rb
 sonar.ruby.coverage.framework=RSpec
 sonar.coverage.exclusions=config/**/*
+sonar.ruby.rubocop.reportPath=rubocop-result.json
+sonar.ruby.coverage.reportPaths=coverage/.resultset.json


### PR DESCRIPTION
- Update SonarCloud to know where Rubocop results are
- Direct SonarCloud to simplecov output
- Revert SimpleCov version for SonarCloud compatibility

Lift & shift of https://github.com/DFE-Digital/get-into-teaching-app/pull/532