### PR TITLE
Simplify PolicyValidator

### DIFF
--- a/app/models/teacher_training_adviser/steps/accept_privacy_policy.rb
+++ b/app/models/teacher_training_adviser/steps/accept_privacy_policy.rb
@@ -2,7 +2,7 @@ module TeacherTrainingAdviser::Steps
   class AcceptPrivacyPolicy < Wizard::Step
     attribute :accepted_policy_id, :string
 
-    validates :accepted_policy_id, policy: { method: :get_privacy_policy }
+    validates :accepted_policy_id, policy: true
 
     def reviewable_answers
       {}

--- a/app/validators/policy_validator.rb
+++ b/app/validators/policy_validator.rb
@@ -1,9 +1,9 @@
 class PolicyValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     begin
-      policy = GetIntoTeachingApiClient::PrivacyPoliciesApi.new.send(options[:method], value) if value.present?
+      policy = GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_privacy_policy(value) if value.present?
     rescue GetIntoTeachingApiClient::ApiError => e
-      Rails.logger.error e # how do we handle a Bad Request ?
+      raise unless e.code == 400
     end
 
     unless policy

--- a/spec/models/teacher_training_adviser/steps/accept_privacy_policy_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/accept_privacy_policy_spec.rb
@@ -7,12 +7,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::AcceptPrivacyPolicy do
   it { is_expected.to respond_to :accepted_policy_id }
 
   context "accepted_policy_id" do
-    it "allows a valid privacy policy id" do
-      policy = GetIntoTeachingApiClient::PrivacyPolicy.new(id: "invalid-id")
-      allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
-        receive(:get_privacy_policy).with(policy.id) { policy }
-      expect(subject).to allow_value(policy.id).for :accepted_policy_id
-    end
+    it { is_expected.to allow_value("0a203956-e935-ea11-a813-000d3a44a8e9").for :accepted_policy_id }
     it { is_expected.to_not allow_value("invalid-id").for :accepted_policy_id }
   end
 

--- a/spec/validators/policy_validator_spec.rb
+++ b/spec/validators/policy_validator_spec.rb
@@ -5,7 +5,7 @@ class PolicyValidatable
 
   attr_accessor :policy_id
 
-  validates :policy_id, policy: { method: :get_privacy_policy }
+  validates :policy_id, policy: true
 end
 
 RSpec.describe PolicyValidator, type: :validator do
@@ -22,8 +22,9 @@ RSpec.describe PolicyValidator, type: :validator do
   end
 
   it "is invalid when does not match a policy" do
+    bad_request_error = GetIntoTeachingApiClient::ApiError.new(code: 400)
     expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
-      receive(:get_privacy_policy).with("def-678").and_raise(GetIntoTeachingApiClient::ApiError)
+      receive(:get_privacy_policy).with("def-678").and_raise(bad_request_error)
 
     subject.policy_id = "def-678"
     expect(subject).to be_invalid


### PR DESCRIPTION
We don't need to pass the `method:` into this validator as it always calls `get_privavcy_policy`.

Only rescue on 400/bad request; this indicates the policy entered does not exist in the system. Other errors will bubble up to show the respective error page to the user.