### PR TITLE
Renamed Workflow

### DIFF
--- a/.github/workflows/new_deploy.yml
+++ b/.github/workflows/new_deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Deploy to PaaS
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Trial workflow needs to be correct name in master or it cannot be picked up by the preceding workflow, even though it isn't running on the master branch

### Trello card
[Continuous Deployment](https://trello.com/c/UQrm3g59/516-continuous-deployment)

### Context
Workflow needs to exist in master for the system to even consider working on branches

### Guidance to review
This is a single file that should not effect anything, it isn't fully working but because of how github works, it is a place holder.

