### PR TITLE
Raise errors in specs for deprecation warnings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,4 +101,7 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  # Raise errors for deprecation warnings
+  config.raise_errors_for_deprecations!
 end


### PR DESCRIPTION
### Context

We want to prevent deprecation warnings creeping into the codebase

### Changes proposed in this pull request

1. Enable the RSpec option to raise errors when it encounters a deprecation warning



