### PR TITLE
Improve user experience when SubjectLikeToTeach is not found

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,7 +58,15 @@ module ApplicationHelper
   end
 
   def link_to_git_site(text = "Get into Teaching", attributes = {})
-    link_to text, (ENV["GIT_URL"].presence || "/url-not-set"), attributes
+    link_to text, git_url, attributes
+  end
+
+  def link_to_git_mailing_list(text, attributes = {})
+    link_to text, git_url("mailinglist/signup"), attributes
+  end
+
+  def link_to_git_events(text, attributes = {})
+    link_to text, git_url("events"), attributes
   end
 
   def internal_referer
@@ -67,5 +75,14 @@ module ApplicationHelper
     return nil unless internal
 
     referer
+  end
+
+private
+
+  def git_url(path = "")
+    url = ENV["GIT_URL"].presence
+    return "/url-not-set/#{path}" unless url
+
+    "#{url.chomp('/')}/#{path}"
   end
 end

--- a/app/models/concerns/api_options.rb
+++ b/app/models/concerns/api_options.rb
@@ -1,10 +1,11 @@
 module ApiOptions
-  def generate_api_options(types_method_call, omit_ids = [])
+  def generate_api_options(types_method_call, omit_ids = [], include_ids = [])
     api = GetIntoTeachingApiClient::TypesApi.new
 
-    types = api.send(types_method_call).reject do |type|
-      omit_ids.include?(type.id)
-    end
+    types = api.send(types_method_call)
+
+    types.reject! { |type| omit_ids.include?(type.id) } if omit_ids.present?
+    types.select! { |type| include_ids.include?(type.id) } if include_ids.present?
 
     types.reduce({}) { |options, type| options.update(type.value => type.id.to_s) }
   end

--- a/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
+++ b/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
@@ -4,11 +4,25 @@ module TeacherTrainingAdviser::Steps
 
     attribute :preferred_teaching_subject_id, :string
 
-    validates :preferred_teaching_subject_id, types: { method: :get_teaching_subjects }
+    OTHER_SUBJECT_ID = "-1".freeze
+    INCLUDE_SUBJECT_IDS = [
+      "a42655a1-2afa-e811-a981-000d3a276620", # Maths
+      "ac2655a1-2afa-e811-a981-000d3a276620", # Physics
+      "a22655a1-2afa-e811-a981-000d3a276620", # Languages (other)
+    ].freeze
 
     def self.options
-      generate_api_options(:get_teaching_subjects)
+      generate_api_options(:get_teaching_subjects, nil, INCLUDE_SUBJECT_IDS)
     end
+
+    def self.sanitized_options
+      options.tap do |options|
+        options["Modern foreign language"] = options.delete("Languages (other)")
+        options["Other"] = OTHER_SUBJECT_ID
+      end
+    end
+
+    validates :preferred_teaching_subject_id, inclusion: { in: sanitized_options.values }
 
     def skipped?
       returning_teacher = @store["returning_to_teaching"]

--- a/app/models/teacher_training_adviser/steps/subject_not_found.rb
+++ b/app/models/teacher_training_adviser/steps/subject_not_found.rb
@@ -1,0 +1,14 @@
+module TeacherTrainingAdviser::Steps
+  class SubjectNotFound < Wizard::Step
+    def can_proceed?
+      false
+    end
+
+    def skipped?
+      returning_teacher = @store["returning_to_teaching"]
+      subject_not_found = @store["preferred_teaching_subject_id"] == TeacherTrainingAdviser::Steps::SubjectLikeToTeach::OTHER_SUBJECT_ID
+
+      !(returning_teacher && subject_not_found)
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/wizard.rb
+++ b/app/models/teacher_training_adviser/wizard.rb
@@ -24,6 +24,7 @@ module TeacherTrainingAdviser
       Steps::PreviousTeacherId,
       Steps::SubjectTaught,
       Steps::SubjectLikeToTeach,
+      Steps::SubjectNotFound,
       Steps::DateOfBirth,
       Steps::UkOrOverseas,
       Steps::UkAddress,

--- a/app/views/teacher_training_adviser/steps/_subject_like_to_teach.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_like_to_teach.html.erb
@@ -1,18 +1,6 @@
-<% options = f.object.class::options %>
-<%= f.govuk_radio_buttons_fieldset(:preferred_teaching_subject_id, legend: { text: 'Which subject would you like to teach if you return to teaching?' } ) do %>
-  <%= f.govuk_radio_button :preferred_teaching_subject_id, options["Maths"], label: { text: 'Maths' }, link_errors: true %>
-  <%= f.govuk_radio_button :preferred_teaching_subject_id, options["Physics"], label: { text: 'Physics' } %>
-  <%= f.govuk_radio_button :preferred_teaching_subject_id, options["Languages (other)"], label: { text: 'Modern foreign language' } %>
-<% end %>
-
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      Can't see the subject you would like to teach?
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    If you want to return to teaching with a subject that is not listed above you can get further help by visiting the <a href="https://beta-getintoteaching.education.gov.uk/guidance#9" class="govuk-link">return to teaching guidance</a> page.
-  </div>
-</details>
-
+<%= f.govuk_collection_radio_buttons :preferred_teaching_subject_id,
+  f.object.class.sanitized_options,
+  :last,
+  :first,
+  legend: { text: 'Which subject would you like to teach if you return to teaching?' }
+%> 

--- a/app/views/teacher_training_adviser/steps/_subject_not_found.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_not_found.html.erb
@@ -1,0 +1,13 @@
+<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Get support</h1>
+
+        <p>Our teacher training advisers are here to support those returning to teach maths, physics or languages.</p>
+        <p>
+          We can still offer you support, if you want to teach something else we can <%= link_to_git_mailing_list("send you information via email") %> or you can get advice by <%= link_to_git_mailing_list("attending a return to teaching event") %>.
+        </p>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,7 +157,7 @@ en:
         teacher_training_adviser/steps/subject_like_to_teach:
           attributes:
             preferred_teaching_subject_id:
-              invalid_type: "Please select maths, physics or modern foreign language"
+              inclusion: "Choose a subject or other"
         teacher_training_adviser/steps/subject_interested_teaching:
           attributes:
             preferred_teaching_subject_id:

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -376,6 +376,33 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       expect(page).to have_text "Get the right GCSEs or equivalent qualifications"
       expect(page).to_not have_text "Continue"
     end
+
+    scenario "can't find subject like to teach" do
+      visit teacher_training_adviser_steps_path
+
+      expect(page).to have_text "About you"
+      fill_in_identity_step
+      click_on "Continue"
+
+      expect(page).to have_text "Are you returning to teaching?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have your previous teacher reference number?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Which main subject did you previously teach?"
+      select "Physics"
+      click_on "Continue"
+
+      expect(page).to have_text "Which subject would you like to teach if you return to teaching?"
+      choose "Other"
+      click_on "Continue"
+
+      expect(page).to have_text "Get support"
+      expect(page).to_not have_text "Continue"
+    end
   end
 
   context "an existing candidate" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe ApplicationHelper do
     end
   end
 
-  describe "link_to_git" do
+  describe "#link_to_git" do
     let(:url) { "http://test.url/" }
     subject { link_to_git_site }
 
@@ -145,14 +145,62 @@ RSpec.describe ApplicationHelper do
 
     context "without URL set" do
       before { allow(ENV).to receive(:[]).with("GIT_URL").and_return nil }
-      it { is_expected.to have_css 'a[href="/url-not-set"]' }
+      it { is_expected.to have_css 'a[href="/url-not-set/"]' }
       it { is_expected.to have_css "a", text: "Get into Teaching" }
     end
 
     context "without URL set" do
       before { allow(ENV).to receive(:[]).with("GIT_URL").and_return "" }
-      it { is_expected.to have_css 'a[href="/url-not-set"]' }
+      it { is_expected.to have_css 'a[href="/url-not-set/"]' }
       it { is_expected.to have_css "a", text: "Get into Teaching" }
+    end
+  end
+
+  describe "#link_to_git_mailing_list" do
+    let(:url) { "http://test.url/" }
+    subject { link_to_git_mailing_list("join the mailing list", class: "govuk-link") }
+
+    before { allow(ENV).to receive(:[]).with("GIT_URL") { url } }
+
+    it { is_expected.to have_css "a[href=\"http://test.url/mailinglist/signup\"]" }
+    it { is_expected.to have_css "a.govuk-link", text: "join the mailing list" }
+
+    context "when the GIT_URL is nil" do
+      before { allow(ENV).to receive(:[]).with("GIT_URL") { nil } }
+
+      it { is_expected.to have_css "a[href=\"/url-not-set/mailinglist/signup\"]" }
+      it { is_expected.to have_css "a", text: "join the mailing list" }
+    end
+
+    context "when the GIT_URL is an empty string" do
+      before { allow(ENV).to receive(:[]).with("GIT_URL") { " " } }
+
+      it { is_expected.to have_css "a[href=\"/url-not-set/mailinglist/signup\"]" }
+      it { is_expected.to have_css "a", text: "join the mailing list" }
+    end
+  end
+
+  describe "#link_to_git_events" do
+    let(:url) { "http://test.url/" }
+    subject { link_to_git_events("find an event", class: "govuk-link") }
+
+    before { allow(ENV).to receive(:[]).with("GIT_URL") { url } }
+
+    it { is_expected.to have_css "a[href=\"http://test.url/events\"]" }
+    it { is_expected.to have_css "a.govuk-link", text: "find an event" }
+
+    context "when the GIT_URL is nil" do
+      before { allow(ENV).to receive(:[]).with("GIT_URL") { nil } }
+
+      it { is_expected.to have_css "a[href=\"/url-not-set/events\"]" }
+      it { is_expected.to have_css "a", text: "find an event" }
+    end
+
+    context "when the GIT_URL is an empty string" do
+      before { allow(ENV).to receive(:[]).with("GIT_URL") { " " } }
+
+      it { is_expected.to have_css "a[href=\"/url-not-set/events\"]" }
+      it { is_expected.to have_css "a", text: "find an event" }
     end
   end
 

--- a/spec/models/teacher_training_adviser/steps/subject_like_to_teach_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_like_to_teach_spec.rb
@@ -3,20 +3,36 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::SubjectLikeToTeach do
   include_context "wizard step"
   it_behaves_like "a wizard step"
-  it_behaves_like "a wizard step that exposes API types as options", :get_teaching_subjects
+  it_behaves_like "a wizard step that exposes API types as options",
+                  :get_teaching_subjects, nil, described_class::INCLUDE_SUBJECT_IDS
+
+  let(:valid_id) { described_class::INCLUDE_SUBJECT_IDS.sample }
 
   context "attributes" do
     it { is_expected.to respond_to :preferred_teaching_subject_id }
   end
 
+  describe "#sanitized_options" do
+    before { expect(described_class).to receive(:options) { { "Languages (other)" => "1" } } }
+    subject { described_class.sanitized_options }
+
+    it {
+      is_expected.to eq({
+        "Modern foreign language" => "1",
+        "Other" => "-1",
+      })
+    }
+  end
+
   describe "#preferred_teaching_subject_id" do
     it "allows a valid preferred_teaching_subject_id" do
-      subject_type = GetIntoTeachingApiClient::TypeEntity.new(id: "abc-123")
+      subject_type = GetIntoTeachingApiClient::TypeEntity.new(id: valid_id)
       allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
         receive(:get_teaching_subjects) { [subject_type] }
       expect(subject).to allow_value(subject_type.id).for :preferred_teaching_subject_id
     end
 
+    it { is_expected.to allow_value(described_class::OTHER_SUBJECT_ID).for :preferred_teaching_subject_id }
     it { is_expected.to_not allow_values("", nil, "invalid-id").for :preferred_teaching_subject_id }
   end
 
@@ -34,7 +50,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::SubjectLikeToTeach do
 
   describe "#reviewable_answers" do
     subject { instance.reviewable_answers }
-    let(:type) { GetIntoTeachingApiClient::TypeEntity.new(id: "123", value: "Value") }
+    let(:type) { GetIntoTeachingApiClient::TypeEntity.new(id: valid_id, value: "Value") }
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
         receive(:get_teaching_subjects) { [type] }

--- a/spec/models/teacher_training_adviser/steps/subject_not_found_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_not_found_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe TeacherTrainingAdviser::Steps::SubjectNotFound do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  it { is_expected.to_not be_can_proceed }
+
+  describe "#skipped?" do
+    it "returns false if returning_to_teaching is true and preferred_teaching_subject_id is OTHER_SUBJECT_ID" do
+      wizardstore["returning_to_teaching"] = true
+      wizardstore["preferred_teaching_subject_id"] = TeacherTrainingAdviser::Steps::SubjectLikeToTeach::OTHER_SUBJECT_ID
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns true if returning_teacher is false" do
+      wizardstore["returning_to_teaching"] = false
+      wizardstore["preferred_teaching_subject_id"] = TeacherTrainingAdviser::Steps::SubjectLikeToTeach::OTHER_SUBJECT_ID
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if preferred_teaching_subject_id is not OTHER_SUBJECT_ID" do
+      wizardstore["returning_to_teaching"] = true
+      wizardstore["preferred_teaching_subject_id"] = "abc-123"
+      expect(subject).to be_skipped
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/wizard_spec.rb
+++ b/spec/models/teacher_training_adviser/wizard_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
         TeacherTrainingAdviser::Steps::PreviousTeacherId,
         TeacherTrainingAdviser::Steps::SubjectTaught,
         TeacherTrainingAdviser::Steps::SubjectLikeToTeach,
+        TeacherTrainingAdviser::Steps::SubjectNotFound,
         TeacherTrainingAdviser::Steps::DateOfBirth,
         TeacherTrainingAdviser::Steps::UkOrOverseas,
         TeacherTrainingAdviser::Steps::UkAddress,


### PR DESCRIPTION
### Trello card

[Trello-564](https://trello.com/c/w3emKbaL/564-on-returners-step-5-of-tta-service-amend-cant-see-my-subject-and-include-better-cta)

### Context

We want to improve the visibility of the "Can't see the subject you would like to teach?" prompt by changing it to a radio button. If selected, we should take the candidate to a new page with improved copy and calls to action.

### Changes proposed in this pull request

Add GiT link helpers for events/mailing list

We need to be able to link to the mailing list and events as CTAs, this adds convenience helpers.

- Improve user experience when SubjectLikeToTeach is not found

Change the "Can't see the subject you would like to teach?" prompt to be an extra radio button on the "What subject would you like to teach if you return to teaching?" question.

Add an additional step to handle when the user selects the new radio option (similar to the `QualificationRequired` step).

Tidy up partial for rendering radio buttons.

Improve wording of error message to make sense with the new option value.

Extend the `ApiOptions` helper with support for including only a subset of the types returned from the API.

### Guidance to review

<img width="1239" alt="Screenshot 2020-11-19 at 08 12 26" src="https://user-images.githubusercontent.com/29867726/99639551-a7b69880-2a3f-11eb-8cb7-da164f40afb0.png">
<img width="1293" alt="Screenshot 2020-11-23 at 10 17 44" src="https://user-images.githubusercontent.com/29867726/99950885-2a5b9280-2d75-11eb-826d-ed07127d2a0f.png">
<img width="1239" alt="Screenshot 2020-11-19 at 08 11 42" src="https://user-images.githubusercontent.com/29867726/99639543-a4231180-2a3f-11eb-8909-cb337043e730.png">

