### PR TITLE
Fix event CTA link when subject not found

### DIFF
--- a/app/views/teacher_training_adviser/steps/_subject_not_found.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_not_found.html.erb
@@ -6,7 +6,7 @@
 
         <p>Our teacher training advisers are here to support those returning to teach maths, physics or languages.</p>
         <p>
-          We can still offer you support, if you want to teach something else we can <%= link_to_git_mailing_list("send you information via email") %> or you can get advice by <%= link_to_git_mailing_list("attending a return to teaching event") %>.
+          We can still offer you support, if you want to teach something else we can <%= link_to_git_mailing_list("send you information via email") %> or you can get advice by <%= link_to_git_events("attending a return to teaching event") %>.
         </p>
     </div>
   </div>


### PR DESCRIPTION
Correct the CTA link to go to the events page