### PR TITLE
Add LID tracking pixel

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -7,3 +7,4 @@ GOOGLE_AD_WORDS_ID=AW-1071004410
 TWITTER_ID=o0wo4
 HOTJAR_ID=1871524
 GIT_URL=https://beta-getintoteaching.education.gov.uk/
+LID_ID=1

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,6 +10,7 @@ module ApplicationHelper
       "analytics-pinterest-id" => ENV["PINTEREST_ID"],
       "analytics-facebook-id" => ENV["FACEBOOK_ID"],
       "analytics-twitter-id" => ENV["TWITTER_ID"],
+      "analytics-lid-id" => ENV["LID_ID"],
       "pinterest-action" => "page",
       "snapchat-action" => "track",
       "snapchat-event" => "PAGE_VIEW",

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -38,4 +38,5 @@
       </div>
     </div>
   </div>
+  <span data-controller="lid" data-lid-action="track" data-lid-event="Adviser"></span>
 </main>

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -38,7 +38,11 @@
         <span data-controller="gtm"
               data-gtm-action="event"
               data-gtm-event="conversion"
-              data-gtm-event-data='{"send_to":"AW-1071004410/1Rs4CM_qitsBEPr12P4D"}'>
+              data-gtm-event-data='{"send_to":"AW-1071004410/1Rs4CM_qitsBEPr12P4D"}'></span>
+
+        <span data-controller="lid" 
+              data-lid-action="track" 
+              data-lid-event="CompleteApp"></span>
       </div>
     </div>
   </div>

--- a/app/webpacker/controllers/image_pixel_base_controller.js
+++ b/app/webpacker/controllers/image_pixel_base_controller.js
@@ -1,0 +1,16 @@
+import AnalyticsBaseController from "./analytics_base_controller"
+
+export default class extends AnalyticsBaseController {
+  get cookieCategory() {
+    return 'non-functional';
+  }
+
+  loadPixel(src) {
+    const img = document.createElement('img');
+    img.src = src;
+    img.width = 0;
+    img.height = 0;
+    img.style.display = 'none';
+    this.element.appendChild(img);
+  }
+}

--- a/app/webpacker/controllers/lid_controller.js
+++ b/app/webpacker/controllers/lid_controller.js
@@ -1,0 +1,34 @@
+import ImagePixelBaseController from "./image_pixel_base_controller"
+
+export default class extends ImagePixelBaseController {
+  static path = "/one.png"
+  static domains = [
+    'https://pixelg.adswizz.com',
+    'https://tracking.audio.thisisdax.com',
+  ];
+
+  get serviceId() {
+    return this.getServiceId('lid-id') ;
+  }
+
+  get serviceFunction() {
+    return window.lid;
+  }
+
+  get event() {
+    return this.data.get("event")
+  }
+
+  initService() {
+    // Empty as this is an image tracking pixel.
+    window.lid = () => {};
+  }
+
+  imgSrc(domain, event) {
+    return `${domain}${this.constructor.path}&?client=GovernmentDFE&action=cs&j=0&event=${event}`;
+  }
+
+  sendEvent() {
+    this.constructor.domains.forEach((domain) => this.loadPixel(this.imgSrc(domain, this.event)));
+  }
+}

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -8,6 +8,7 @@ SecureHeaders::Configuration.default do |config|
   config.referrer_policy = %w[origin-when-cross-origin strict-origin-when-cross-origin]
 
   google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com s.ytimg.com https://www.googleadservices.com https://www.google.com https://googleads.g.doubleclick.net]
+  lid_pixels = %w[pixelg.adswizz.com tracking.audio.thisisdax.com]
 
   config.csp = {
     default_src: %w['none'],
@@ -19,7 +20,7 @@ SecureHeaders::Configuration.default do |config|
     form_action: %w['self' tr.snapchat.com www.facebook.com],
     frame_ancestors: %w['self'],
     frame_src: %w['self' tr.snapchat.com www.facebook.com www.youtube.com *.hotjar.com *.doubleclick.net],
-    img_src: %W['self' *.gov.uk data: *.googleapis.com www.facebook.com ct.pinterest.com t.co www.facebook.com cx.atdmt.com ad.doubleclick.net i.ytimg.com adservice.google.com adservice.google.co.uk] + google_analytics,
+    img_src: %W['self' *.gov.uk data: *.googleapis.com www.facebook.com ct.pinterest.com t.co www.facebook.com cx.atdmt.com ad.doubleclick.net i.ytimg.com adservice.google.com adservice.google.co.uk] + google_analytics + lid_pixels,
     manifest_src: %w['self'],
     media_src: %w['self'],
     script_src: %W['self' 'unsafe-inline' 'unsafe-eval' *.googleapis.com *.gov.uk code.jquery.com *.youtube.com *.facebook.net *.hotjar.com *.pinimg.com sc-static.net static.ads-twitter.com analytics.twitter.com ad.doubleclick.com] + google_analytics,

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ApplicationHelper do
     let(:pinterest_id) { "6543" }
     let(:facebook_id) { "4321" }
     let(:twitter_id) { "1289" }
+    let(:lid_id) { "7698" }
 
     before do
       allow(ENV).to receive(:[]).and_call_original
@@ -21,6 +22,7 @@ RSpec.describe ApplicationHelper do
       allow(ENV).to receive(:[]).with("PINTEREST_ID").and_return pinterest_id
       allow(ENV).to receive(:[]).with("FACEBOOK_ID").and_return facebook_id
       allow(ENV).to receive(:[]).with("TWITTER_ID").and_return twitter_id
+      allow(ENV).to receive(:[]).with("LID_ID").and_return lid_id
     end
 
     subject { analytics_body_tag { "<h1>TEST</h1>".html_safe } }
@@ -44,24 +46,29 @@ RSpec.describe ApplicationHelper do
       it { is_expected.to have_css "body[data-analytics-pinterest-id=6543]" }
       it { is_expected.to have_css "body[data-analytics-facebook-id=4321]" }
       it { is_expected.to have_css "body[data-analytics-twitter-id=1289]" }
+      it { is_expected.to have_css "body[data-analytics-lid-id=7698]" }
     end
 
     context "with blank service ids" do
       let(:gtm_id) { "" }
       let(:adwords_id) { "" }
       let(:twitter_id) { "" }
+      let(:lid_id) { "" }
       it { is_expected.to have_css "body[data-analytics-gtm-id=\"\"]" }
       it { is_expected.to have_css "body[data-analytics-adwords-id=\"\"]" }
       it { is_expected.to have_css "body[data-analytics-twitter-id=\"\"]" }
+      it { is_expected.to have_css "body[data-analytics-lid-id=\"\"]" }
     end
 
     context "with no service ids" do
       let(:gtm_id) { nil }
       let(:adwords_id) { nil }
       let(:twitter_id) { nil }
+      let(:lid_id) { nil }
       it { is_expected.not_to have_css "body[data-analytics-gtm-id]" }
       it { is_expected.not_to have_css "body[data-analytics-adwords-id]" }
       it { is_expected.not_to have_css "body[data-analytics-twitter-id]" }
+      it { is_expected.not_to have_css "body[data-analytics-lid-id]" }
     end
 
     context "default events" do

--- a/spec/javascript/controllers/lid_controller_spec.js
+++ b/spec/javascript/controllers/lid_controller_spec.js
@@ -1,0 +1,54 @@
+import AnalyticsHelper from './analytics_spec_helper';
+import LidController from 'lid_controller';
+
+describe('LidController', () => {
+  const event = "testEvent";
+
+  document.body.innerHTML = `
+    <div
+      id="container"
+      data-controller="lid"
+      data-lid-action="track"
+      data-lid-event="${event}"
+    >
+    </div>
+    `;
+
+  // window appears to not be getting redefined between runs, so remove manually
+  afterEach(() => { delete window.lid })
+
+  AnalyticsHelper.describeWithCookieSet('lid', LidController, 'lid', 'non-functional')
+  AnalyticsHelper.describeWhenEventFires('lid', LidController, 'lid', 'non-functional')
+
+  describe("tracking pixels", () => {
+    beforeEach(() => { 
+      AnalyticsHelper.setAcceptedCookie();
+      AnalyticsHelper.initApp('lid', LidController, 'lid');
+    })
+
+    it("loads images from the correct domains", () => {
+      expect(LidController.domains).toEqual([
+        "https://pixelg.adswizz.com",
+        "https://tracking.audio.thisisdax.com",
+      ])
+    });
+
+    it("appends pixels using the correct path/event name", () => {
+      const container = document.getElementById('container');
+      const images = Array.from(container.querySelectorAll('img'));      
+      const match = images.every((image) => image.src.indexOf(`/one.png&?client=GovernmentDFE&action=cs&j=0&event=${event}`) != -1);
+      expect(match).toBeTruthy();
+    });
+
+    it("appends a pixel for each domain to the controller element", () => {
+      const container = document.getElementById('container');
+      const images = Array.from(container.querySelectorAll('img'));
+      const domains = LidController.domains;
+
+      domains.forEach((domain) => {
+        const match = images.some((image) => image.src.indexOf(domain) != -1);
+        expect(match).toBeTruthy();
+      });
+    })
+  })
+})

--- a/spec/requests/lid_tracking_pixels_spec.rb
+++ b/spec/requests/lid_tracking_pixels_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "LID tracking pixels" do
+  before { get path }
+  subject { response.body }
+
+  context "when visiting /" do
+    let(:path) { root_path }
+
+    it { is_expected.to include_analytics("lid", { action: "track", event: "Adviser" }) }
+  end
+
+  context "when visiting /teacher_training_adviser/sign_up/completed" do
+    let(:path) { completed_teacher_training_adviser_steps_path }
+
+    it { is_expected.to include_analytics("lid", { action: "track", event: "CompleteApp" }) }
+  end
+end

--- a/spec/support/matchers/analytics_matcher.rb
+++ b/spec/support/matchers/analytics_matcher.rb
@@ -1,0 +1,10 @@
+RSpec::Matchers.define :include_analytics do |controller, state|
+  match do |actual|
+    return false unless actual =~ %r{data-controller="#{controller}"}
+    return false unless state.all? do |key, value|
+      actual =~ %r{data-#{controller}-#{key}="#{value}"}
+    end
+
+    true
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-314](https://trello.com/c/8PmnT4DD/314-development-add-lid-pixels-to-pages-for-audio-advertising)

### Context

Lift & shift of https://github.com/DFE-Digital/get-into-teaching-app/pull/602

### Changes proposed in this pull request

- Add LID tracking pixel controller
- Enable LID tracking pixels in production
- Allow LID pixel in CSP
- Fire LID tracking pixel on home page & sign up completion

### Guidance to review

