### PR TITLE
Log out health check responses

### DIFF
--- a/app/controllers/healthchecks_controller.rb
+++ b/app/controllers/healthchecks_controller.rb
@@ -3,6 +3,7 @@ class HealthchecksController < ApplicationController
 
   def show
     @healthcheck = Healthcheck.new
+    Rails.logger.info("HealthCheck: #{@healthcheck.to_h}")
     render json: @healthcheck
   end
 end

--- a/spec/requests/healthchecks_controller_spec.rb
+++ b/spec/requests/healthchecks_controller_spec.rb
@@ -2,11 +2,20 @@ require "rails_helper"
 
 RSpec.describe HealthchecksController do
   before do
-    allow_any_instance_of(Healthcheck).to receive(:test_api).and_return true
+    allow_any_instance_of(Healthcheck).to receive(:test_api) { true }
+    allow_any_instance_of(Healthcheck).to receive(:test_redis) { false }
+    allow_any_instance_of(Healthcheck).to receive(:app_sha) { "123" }
+    allow(Rails.logger).to receive(:info)
   end
 
   describe "#show" do
     before { get healthcheck_path }
+
     it { expect(response).to have_http_status(:success) }
+
+    it do
+      expected_healthcheck = { app_sha: "123", api: true, redis: false }
+      expect(Rails.logger).to have_received(:info).with("HealthCheck: #{expected_healthcheck}").once
+    end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-355](https://trello.com/c/ADNV86cu/355-development-log-healthchecks)

### Context

Logging out the health check response will assist with debugging if the app goes offline.

### Changes proposed in this pull request

- Log out health check responses

### Guidance to review

