### PR TITLE
Don't default preferred education phase for returners

### DIFF
--- a/app/models/teacher_training_adviser/steps/returning_teacher.rb
+++ b/app/models/teacher_training_adviser/steps/returning_teacher.rb
@@ -13,7 +13,6 @@ module TeacherTrainingAdviser::Steps
       return unless returning_to_teaching
 
       self.degree_options = DEGREE_OPTIONS[:returner]
-      self.preferred_education_phase_id = TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary].to_i
     end
 
     def reviewable_answers

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -74,7 +74,6 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       request_attributes = uk_candidate_request_attributes({
         subject_taught_id: SUBJECT_PSYCHOLOGY,
         preferred_teaching_subject_id: SUBJECT_PHYSICS,
-        preferred_education_phase_id: EDUCATION_PHASE_SECONDARY,
         teacher_id: "1234",
       })
       expect_sign_up_with_attributes(request_attributes)

--- a/spec/models/teacher_training_adviser/steps/returning_teacher_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/returning_teacher_spec.rb
@@ -16,16 +16,14 @@ RSpec.describe TeacherTrainingAdviser::Steps::ReturningTeacher do
   end
 
   describe "#returning_to_teaching=" do
-    it "sets degree_options and preferred_education_phase_id if returning_to_teaching is true" do
+    it "sets degree_options if returning_to_teaching is true" do
       subject.returning_to_teaching = true
       expect(subject.degree_options).to eq(TeacherTrainingAdviser::Steps::ReturningTeacher::DEGREE_OPTIONS[:returner])
-      expect(subject.preferred_education_phase_id).to eq(TeacherTrainingAdviser::Steps::StageInterestedTeaching::OPTIONS[:secondary])
     end
 
-    it "does not set degree_options or preferred_education_phase_id if returning_to_teaching is false" do
+    it "does not set degree_options if returning_to_teaching is false" do
       subject.returning_to_teaching = false
       expect(subject.degree_options).to be_nil
-      expect(subject.preferred_education_phase_id).to be_nil
     end
   end
 


### PR DESCRIPTION
By defaulting this in the app we have an edge case where a candidate proceeds as a returner then backs out and starts the new candidate journey. If they do this we will pre-fill the secondary education phase (as its defaulted when they selected returner).

Instead, we will default this value in the API so there is no need to set it for returners at all in the app.
