### PR TITLE
SHA Required on Deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,7 +300,7 @@ jobs:
          with:
            workflow: Deploy to PaaS
            token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
-           inputs: '{"environment": "Test", "sha": "${{ github.sha }}" , "release_tag": "${{ needs.development.outputs.tag }}" }'
+           inputs: '{"environment": "Test", "sha": "${{ github.sha }}" }'
            ref: refs/heads/master
 
        - name: Wait for Deployment to QA
@@ -371,7 +371,7 @@ jobs:
          with:
            workflow: Deploy to PaaS
            token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
-           inputs: '{"environment": "Production" , "sha": "${{github.sha}}" , "release_tag": "${{needs.development.outputs.tag}}" }'
+           inputs: '{"environment": "Production ", "sha": "${{ github.sha }}" }'
            ref: refs/heads/master
 
        - name: Wait for Deployment to Production


### PR DESCRIPTION
Only the SHA is required on the deployment, the release_tag is not
required in the normal workflow running



