### PR TITLE
Fix Rack::Attack exception

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -25,7 +25,7 @@ module Rack
 
   Rack::Attack.throttled_response = lambda do |env|
     accept_html = env["HTTP_ACCEPT"].include?("text/html")
-    return [429, {}, "Rate limit exceeded"] unless accept_html
+    return [429, {}, ["Rate limit exceeded"]] unless accept_html
 
     html = ApplicationController.render(
       template: "errors/too_many_requests",


### PR DESCRIPTION
According to the Rack::Attack docs we should be returning an array of strings here.