### PR TITLE
Remove redundant attribute from ReturningTeacher step

### DIFF
--- a/app/models/teacher_training_adviser/steps/returning_teacher.rb
+++ b/app/models/teacher_training_adviser/steps/returning_teacher.rb
@@ -4,7 +4,6 @@ module TeacherTrainingAdviser::Steps
 
     attribute :returning_to_teaching, :boolean
     attribute :degree_options, :string
-    attribute :preferred_education_phase_id
 
     validates :returning_to_teaching, inclusion: { in: [true, false] }
 

--- a/spec/models/teacher_training_adviser/steps/returning_teacher_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/returning_teacher_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe TeacherTrainingAdviser::Steps::ReturningTeacher do
   context "attributes" do
     it { is_expected.to respond_to :returning_to_teaching }
     it { is_expected.to respond_to :degree_options }
-    it { is_expected.to respond_to :preferred_education_phase_id }
   end
 
   describe "#returning_to_teaching" do


### PR DESCRIPTION
This was previously needed to default the `preferred_education_phase_id` to secondary when they are a returning teacher. This logic was moved to the API and subsequently removed from the app by PR #413 but the attribute was left in. This causes a bug when the user:

- Starts down the non-returner path
- Selects Primary as their education phase
- Backs out and goes down the returner path
- Completes the wizard

The `preferred_education_phase_id` is then submitted to the API as Primary (exported from the `ReturningTeacher` step) when it shouldn't be sent at all, as we default the value in the API now.

