### PR TITLE
Remove logic to default the preferred_teaching_subject_id

### DIFF
--- a/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
@@ -18,13 +18,5 @@ module TeacherTrainingAdviser::Steps
     def skipped?
       other_step(:have_a_degree).skipped?
     end
-
-    def export
-      if preferred_education_phase_id == OPTIONS[:primary] && !skipped?
-        super.merge("preferred_teaching_subject_id" => PRIMARY_SUBJECT_ID)
-      else
-        super
-      end
-    end
   end
 end

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -219,7 +219,6 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
         degree_type_id: DEGREE_TYPE_DEGREE,
         initial_teacher_training_year_id: TEACHER_TRAINING_YEAR_2022,
         preferred_education_phase_id: EDUCATION_PHASE_PRIMARY,
-        preferred_teaching_subject_id: PRIMARY_SUBJECT_ID,
         has_gcse_maths_and_english_id: HAS_GCSE,
         has_gcse_science_id: HAS_GCSE,
         degree_subject: "Maths",


### PR DESCRIPTION
If a candidate selects their preferred education phase to be 'primary' we should also be setting their preferred teaching subject to 'primary'. This is already done in the API, so its no longer necessary to default it in the app:

https://github.com/DFE-Digital/get-into-teaching-api/blob/master/GetIntoTeachingApi/Models/TeacherTrainingAdviserSignUp.cs#L177-L185