### PR TITLE
Update feedback link

### DIFF
--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -20,7 +20,7 @@
         </p>
 
         <p class="govuk-body">
-          <a href="https://www.gov.uk/service-manual/service-assessments/get-feedback-page" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+          <a href="https://docs.google.com/forms/d/e/1FAIpQLSfIBfaYUk07Fb6dxUKAokiPoGGL73ZYVGHM1mSNyA-K-6QRbA/viewform" target="blank" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
         </p>
 
         <span data-controller="pinterest"


### PR DESCRIPTION
We want the feedback link to go to the same Google form as the main website, not GOV.uk. Also updates the link to open in a new page.