### PR TITLE
Bug Fix - Display Error in Workflow Error Message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,7 +221,7 @@ jobs:
            SLACK_COLOR: '#B90E0A'
            SLACK_ICON: https://github.com/rtCamp.png?size=48
            SLACK_TITLE: 'Failure: Preparing from Preview'
-           SLACK_MESSAGE: 'Failure with Review preperation for {{env.APPLICATION}}'
+           SLACK_MESSAGE: 'Failure with Review preperation for ${{env.APPLICATION}}'
            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
            SLACK_FOOTER: "${{env.APPLICATION}}"
 


### PR DESCRIPTION
When sending the review failure notification the name of the project
is not being displayed, because a $ was missing in the text.


