### PR TITLE
Bug Fix - Time out waiting for Tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -357,6 +357,7 @@ jobs:
            ref: refs/heads/master
            repo: get-into-teaching-frontend-tests
            intervalSeconds: 30
+           timeoutSeconds: 1800 
 
        - name: Check for test failure
          if: steps.wait-for-build.outputs.conclusion == 'failure'


### PR DESCRIPTION
The default time out on action-wait-for-check is only 600 seconds
but the current time to run the tests is about 1400 seconds. so
increased to 1800, giving a bit of slack for slow days

