### PR TITLE
Muliti line Release Notes only pick first line

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,8 @@ jobs:
          with:
             tag_name: ${{ steps.tag_version.outputs.tag }}
             release_name: Release ${{ steps.tag_version.outputs.tag }}
-            body: ${{ steps.tag_version.outputs.changelog }}
+            body: |
+                  ${{ steps.tag_version.outputs.changelog }}
             commitish: ${{ steps.tag_version.outputs.sha}} 
             prerelease: false
             draft:      false


### PR DESCRIPTION
When a PR has more than one line of text, the first line is the only line sent to the Release.

This change should allow mulit-line YAML and thus permit larger comments to be transferred over.

