### PR TITLE
Publish release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,7 +264,7 @@ jobs:
                   ${{ steps.tag_version.outputs.pr_text }}
             commitish: ${{ github.sha }} 
             prerelease: false
-            draft:      false
+            draft:      true
 
   qa:
     name: Quality Assurance Deployment
@@ -339,18 +339,21 @@ jobs:
      runs-on: ubuntu-latest
      needs: [ cypress , development ] 
      steps:
+
        - name: Get Release Id from Tag
-         id:   tag_id
-         run: |
-              ID=$(curl -s -X GET "https://api.github.com/repos/${{github.repository}}/releases/tags/${{needs.development.outputs.release_tag}}" | jq -r .id )
-              echo ::set-output name=tag_id::"${ID}"
+         id: tag_id
+         uses: DFE-Digital/github-actions/DraftReleaseByTag@master
+         with:
+           TAG: ${{needs.development.outputs.release_tag}}
+           TOKEN: ${{secrets.ACTIONS_API_ACCESS_TOKEN}}
 
        - name: Publish Release  
+         if: steps.tag_id.outputs.found == 1
          uses: eregon/publish-release@v1
          env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          with:
-           release_id: ${{steps.tag_id.outputs.tag_id}}
+           release_id: ${{steps.tag_id.outputs.release_id}}
 
        - name: Trigger Deployment to Production
          uses: benc-uk/workflow-dispatch@v1.1


### PR DESCRIPTION
###  [Publish Release Notes](https://trello.com/b/lRXllOHK/get-into-teaching-private-beta)
### Context
The developers want to be able to see what releases are published on SLACK

### Changes
Step 1. Set the release to draft when first created and then when
the application is deployed then the release can be published

