### PR TITLE
Update API client to remove types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: afef61cf2553e754a7447ba3ac5a98215780f5ff
+  revision: fc55a73e7192f95199f4c3d2e9c04c3e7eb6ada3
   specs:
-    get_into_teaching_api_client (1.1.6)
+    get_into_teaching_api_client (1.1.7)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.8)
+    get_into_teaching_api_client_faraday (0.1.9)
       activesupport
       faraday
       faraday-encoding
@@ -136,7 +136,7 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     i18n_data (0.10.0)
-    json (2.4.0)
+    json (2.4.1)
     listen (3.3.3)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -305,7 +305,7 @@ GEM
     timeliness (0.4.4)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.8)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
     unicode_utils (1.4.0)


### PR DESCRIPTION
The types are being deprecated and support has been removed from the API client. This updates the client in the app to ensure nobody accidentally references the old type methods going forward (they will be deleted from the API shortly).
