### PR TITLE
Prevent sign up completion when a 'dead end' step was encountered

### DIFF
--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -54,6 +54,8 @@ private
   def next_step_path
     if (next_key = @wizard.next_key)
       step_path next_key
+    elsif (non_proceedable_step = @wizard.first_non_proceedable_step)
+      step_path non_proceedable_step
     elsif (invalid_step = @wizard.first_invalid_step)
       step_path invalid_step
     else # all steps valid so completed

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -54,8 +54,8 @@ private
   def next_step_path
     if (next_key = @wizard.next_key)
       step_path next_key
-    elsif (non_proceedable_step = @wizard.first_non_proceedable_step)
-      step_path non_proceedable_step
+    elsif (exit_step = @wizard.first_exit_step)
+      step_path exit_step
     elsif (invalid_step = @wizard.first_invalid_step)
       step_path invalid_step
     else # all steps valid so completed

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -27,7 +27,7 @@ module Wizard
     end
 
     delegate :step, :key_index, :indexed_steps, :step_keys, to: :class
-    delegate :can_proceed?, to: :find_current_step
+    delegate :can_proceed?, to: :find_current_step, prefix: :step
     attr_reader :current_key
 
     def initialize(store, current_key)
@@ -66,16 +66,16 @@ module Wizard
       next_key.nil?
     end
 
-    def active_steps_valid?
+    def valid?
       active_steps.all?(&:valid?)
     end
 
-    def active_steps_proceedable?
+    def can_proceed?
       active_steps.all?(&:can_proceed?)
     end
 
     def complete!
-      last_step? && active_steps_valid? && active_steps_proceedable?
+      last_step? && valid? && can_proceed?
     end
 
     def invalid_steps
@@ -86,8 +86,8 @@ module Wizard
       active_steps.find(&:invalid?)
     end
 
-    def first_non_proceedable_step
-      active_steps.find { |step| !step.can_proceed? }
+    def first_exit_step
+      active_steps.find(&:exit?)
     end
 
     def later_keys(key = current_key)

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -66,12 +66,16 @@ module Wizard
       next_key.nil?
     end
 
-    def valid?
+    def active_steps_valid?
       active_steps.all?(&:valid?)
     end
 
+    def active_steps_proceedable?
+      active_steps.all?(&:can_proceed?)
+    end
+
     def complete!
-      last_step? && valid?
+      last_step? && active_steps_valid? && active_steps_proceedable?
     end
 
     def invalid_steps
@@ -80,6 +84,10 @@ module Wizard
 
     def first_invalid_step
       active_steps.find(&:invalid?)
+    end
+
+    def first_non_proceedable_step
+      active_steps.find { |step| !step.can_proceed? }
     end
 
     def later_keys(key = current_key)

--- a/app/models/wizard/step.rb
+++ b/app/models/wizard/step.rb
@@ -40,6 +40,10 @@ module Wizard
       true
     end
 
+    def exit?
+      !can_proceed?
+    end
+
     def persisted?
       !id.nil?
     end

--- a/app/views/teacher_training_adviser/steps/_form.html.erb
+++ b/app/views/teacher_training_adviser/steps/_form.html.erb
@@ -13,7 +13,7 @@
 
       <%= render current_step.key, current_step: current_step, f: f %>
 
-      <% if wizard.can_proceed? %>
+      <% if wizard.step_can_proceed? %>
         <%= f.govuk_submit(wizard.last_step? ? "Complete" : "Continue") %>
       <% end %>
     <% end %>

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -231,6 +231,48 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       expect(page).to have_text "Sign up complete"
     end
 
+    scenario "candidate tries to skip past a non-proceedable step" do
+      visit teacher_training_adviser_steps_path
+
+      expect(page).to have_text "About you"
+      fill_in_identity_step
+      click_on "Continue"
+
+      expect(page).to have_text "Are you returning to teaching?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_text "Do you have your previous teacher reference number?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_text "Which main subject did you previously teach?"
+      select "Physics"
+      click_on "Continue"
+
+      expect(page).to have_text "Which subject would you like to teach if you return to teaching?"
+      choose "Other"
+      click_on "Continue"
+
+      # Hit dead end
+      expect(page).to have_text "Get support"
+      expect(page).to_not have_text "Continue"
+
+      # Manually skip to review answers
+      visit teacher_training_adviser_step_path(:review_answers)
+
+      expect(page).to have_text "Check your answers before you continue"
+      click_on "Continue"
+
+      expect(page).to have_text "Read and accept the privacy policy"
+      check "Accept the privacy policy"
+      click_on "Complete"
+
+      # Forced back to dead end
+      expect(page).to have_text "Get support"
+      expect(page).to_not have_text "Continue"
+    end
+
     scenario "without a degree" do
       visit teacher_training_adviser_steps_path
 

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -231,7 +231,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       expect(page).to have_text "Sign up complete"
     end
 
-    scenario "candidate tries to skip past a non-proceedable step" do
+    scenario "candidate tries to skip past an exit step" do
       visit teacher_training_adviser_steps_path
 
       expect(page).to have_text "About you"

--- a/spec/models/teacher_training_adviser/wizard_spec.rb
+++ b/spec/models/teacher_training_adviser/wizard_spec.rb
@@ -71,10 +71,12 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
         expect_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to \
           receive(:sign_up_teacher_training_adviser_candidate).with(request).once
       end
-      before { allow(subject).to receive(:valid?).and_return true }
+      before { allow(subject).to receive(:active_steps_valid?).and_return true }
+      before { allow(subject).to receive(:active_steps_proceedable?).and_return true }
       before { subject.complete! }
 
-      it { is_expected.to have_received(:valid?) }
+      it { is_expected.to have_received(:active_steps_valid?) }
+      it { is_expected.to have_received(:active_steps_proceedable?) }
       it { expect(store).to eql({}) }
     end
   end

--- a/spec/models/teacher_training_adviser/wizard_spec.rb
+++ b/spec/models/teacher_training_adviser/wizard_spec.rb
@@ -71,12 +71,12 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
         expect_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to \
           receive(:sign_up_teacher_training_adviser_candidate).with(request).once
       end
-      before { allow(subject).to receive(:active_steps_valid?).and_return true }
-      before { allow(subject).to receive(:active_steps_proceedable?).and_return true }
+      before { allow(subject).to receive(:valid?).and_return true }
+      before { allow(subject).to receive(:can_proceed?).and_return true }
       before { subject.complete! }
 
-      it { is_expected.to have_received(:active_steps_valid?) }
-      it { is_expected.to have_received(:active_steps_proceedable?) }
+      it { is_expected.to have_received(:valid?) }
+      it { is_expected.to have_received(:can_proceed?) }
       it { expect(store).to eql({}) }
     end
   end

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Wizard::Base do
     end
   end
 
-  describe "#active_steps_valid?" do
+  describe "#valid?" do
     let(:backingstore) { { "age" => 30, "postcode" => "TE571NG" } }
 
     before do
@@ -133,7 +133,7 @@ RSpec.describe Wizard::Base do
         receive(:valid?).and_return name_is_valid
     end
 
-    subject { wizard.active_steps_valid? }
+    subject { wizard.valid? }
 
     context "when all steps valid" do
       let(:name_is_valid) { true }
@@ -146,7 +146,7 @@ RSpec.describe Wizard::Base do
     end
   end
 
-  describe "#active_steps_proceedable?" do
+  describe "#can_proceed?" do
     let(:backingstore) { { "age" => 30, "postcode" => "TE571NG" } }
 
     before do
@@ -154,7 +154,7 @@ RSpec.describe Wizard::Base do
         receive(:can_proceed?).and_return name_can_proceed
     end
 
-    subject { wizard.active_steps_proceedable? }
+    subject { wizard.can_proceed? }
 
     context "when all steps are proceedable" do
       let(:name_can_proceed) { true }
@@ -169,8 +169,8 @@ RSpec.describe Wizard::Base do
 
   describe "complete!" do
     subject { wizardclass.new wizardstore, "postcode" }
-    before { allow(subject).to receive(:active_steps_valid?).and_return steps_valid }
-    before { allow(subject).to receive(:active_steps_proceedable?).and_return steps_can_proceed }
+    before { allow(subject).to receive(:valid?).and_return steps_valid }
+    before { allow(subject).to receive(:can_proceed?).and_return steps_can_proceed }
 
     context "when valid and proceedable" do
       let(:steps_valid) { true }

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Wizard::Base do
     end
   end
 
-  describe "#valid?" do
+  describe "#active_steps_valid?" do
     let(:backingstore) { { "age" => 30, "postcode" => "TE571NG" } }
 
     before do
@@ -133,30 +133,60 @@ RSpec.describe Wizard::Base do
         receive(:valid?).and_return name_is_valid
     end
 
-    subject { wizard.valid? }
+    subject { wizard.active_steps_valid? }
 
-    context "with all steps completed" do
+    context "when all steps valid" do
       let(:name_is_valid) { true }
       it { is_expected.to be true }
     end
 
-    context "with missing step" do
+    context "when a step is invalid" do
       let(:name_is_valid) { false }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#active_steps_proceedable?" do
+    let(:backingstore) { { "age" => 30, "postcode" => "TE571NG" } }
+
+    before do
+      allow_any_instance_of(TestWizard::Name).to \
+        receive(:can_proceed?).and_return name_can_proceed
+    end
+
+    subject { wizard.active_steps_proceedable? }
+
+    context "when all steps are proceedable" do
+      let(:name_can_proceed) { true }
+      it { is_expected.to be true }
+    end
+
+    context "when a step cannot proceed" do
+      let(:name_can_proceed) { false }
       it { is_expected.to be false }
     end
   end
 
   describe "complete!" do
     subject { wizardclass.new wizardstore, "postcode" }
-    before { allow(subject).to receive(:valid?).and_return steps_valid }
+    before { allow(subject).to receive(:active_steps_valid?).and_return steps_valid }
+    before { allow(subject).to receive(:active_steps_proceedable?).and_return steps_can_proceed }
 
-    context "when valid" do
+    context "when valid and proceedable" do
       let(:steps_valid) { true }
+      let(:steps_can_proceed) { true }
       it { is_expected.to have_attributes complete!: true }
     end
 
-    context "when invalid" do
+    context "when proceedable but not valid" do
       let(:steps_valid) { false }
+      let(:steps_can_proceed) { true }
+      it { is_expected.to have_attributes complete!: false }
+    end
+
+    context "when valid but not proceedable" do
+      let(:steps_valid) { true }
+      let(:steps_can_proceed) { false }
       it { is_expected.to have_attributes complete!: false }
     end
   end

--- a/spec/models/wizard/step_spec.rb
+++ b/spec/models/wizard/step_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe Wizard::Step do
     it { expect(subject).to be_can_proceed }
   end
 
+  describe "#exit" do
+    it { expect(subject).to_not be_exit }
+  end
+
   describe "#other_step" do
     it { expect(subject.other_step(:first_step)).to be_kind_of(FirstStep) }
     it { expect(subject.other_step(FirstStep)).to be_kind_of(FirstStep) }


### PR DESCRIPTION
### Sentry issue

https://sentry.io/organizations/dfe-bat/issues/1864908606/?project=5276960&query=is%3Aunresolved

### Context

Currently it is possible for a candidate to hit a 'dead end' and then manually skip to the review answers screen (which they may have open in another tab) and attempt to complete the sign up, which will result in a 500 error.

This is possible because we currently only check that all 'active' (non-skipped) steps are _valid_, but we neglect to check if they are a 'dead end' step themselves. An example of this would be:

- Returning candidate selects 'Other' as the subject they would like to teach, which is stored as `-1` in the `preferred_teaching_subject_id` attribute (and valid, otherwise they would not to the 'Get support' step).
- Candidate is presented with the 'Get support' dead-end step.
- Candidate manually skips ahead to the review answers screen, is prompted to fill in any other steps they have skipped and can complete the sign up.
- `-1` is submitted to the API for `preferred_teaching_subject_id` and an error is raised as this is not a valid GUID.

To prevent this, we introduce another check on completion to ensure the candidate was able to proceed through all valid steps. If this is not the case the candidate gets redirected to the dead-end step, explaining why they can't proceed (at which point they can choose to go back and change their answer in order to continue).

### Changes proposed in this pull request

- Prevent completing sign up on skipping a 'dead end' step

### Guidance to review

I'm not happy with my choice of naming for 'steps that cannot be proceeded through' - I've referenced these as `non_proceedable` steps, but I'm pretty sure that's not a word. I was going to go with 'dead_end' steps, but I wasn't wild about that either as an opposite to `can_proceed?`. Suggestions welcome 😄 