### PR TITLE
Link GitHub PRs to Trello tickets automatically

### DIFF
--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -1,0 +1,40 @@
+name: Link Trello card
+
+on:
+  pull_request:
+    types: [ opened ]
+
+jobs:
+  attach-to-trello:
+    name: Link Trello card to this PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Pull Request url
+        id: pr-url
+        run: |
+          echo ::set-output name=url::$(jq -r .pull_request.html_url $GITHUB_EVENT_PATH)
+
+      - name: Extract Trello URL
+        id: trello-id
+        run: |
+          ruby -e \
+            'require "json" ; \
+              body = JSON.parse(ARGF.read).dig("pull_request", "body") ; \
+              if m = body.match(%r{https://trello.com/c/([a-zA-Z0-9]+)}) ; \
+                puts "::set-output name=id::#{m[1]}" ; \
+              end' \
+            $GITHUB_EVENT_PATH
+
+      - name: Link to Trello card
+        if: steps.trello-id.outputs.id
+        run: |
+          curl \
+            --silent \
+            --output /dev/null \
+            --show-error \
+            --fail \
+            --request POST \
+            --url 'https://api.trello.com/1/cards/${{ steps.trello-id.outputs.id }}/actions/comments' \
+            --data-urlencode "key=${{ secrets.TRELLO_KEY }}" \
+            --data-urlencode "token=${{ secrets.TRELLO_TOKEN }}" \
+            --data-urlencode "text=${{ steps.pr-url.outputs.url }}"


### PR DESCRIPTION
### Trello card

https://trello.com/c/2CUilw5w

### Context

When a PR is opened with a link to the associate Trello card, automatically add a comment to the Trello card with the associate Pull Request

### Changes proposed in this pull request

1. Create a comment in the trello card with a link to back to the PR

