### PR TITLE
Update subject not found dead end copy

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,8 +66,8 @@ module ApplicationHelper
     link_to text, git_url("mailinglist/signup"), attributes
   end
 
-  def link_to_git_events(text, attributes = {})
-    link_to text, git_url("events"), attributes
+  def link_to_git_events(text, events_path: nil, **attributes)
+    link_to text, git_url(["events", events_path].compact.join("/")), **attributes
   end
 
   def internal_referer

--- a/app/views/teacher_training_adviser/steps/_subject_not_found.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_not_found.html.erb
@@ -5,8 +5,11 @@
         <h1 class="govuk-heading-l">Get support</h1>
 
         <p>Our teacher training advisers are here to support those returning to teach maths, physics or languages.</p>
+
         <p>
-          We can still offer you support, if you want to teach something else we can <%= link_to_git_mailing_list("send you information via email") %> or you can get advice by <%= link_to_git_events("attending a return to teaching event") %>.
+          We can still offer you support. You can get advice by <%= link_to_git_events("attending an online return to teaching event", events_path: "category/online-events") %>
+          or you can <%= link_to("search for a teaching role in England", "https://teaching-vacancies.service.gov.uk/") %>.
+          You can set up job alerts so that you do not miss out on any opportunities.
         </p>
     </div>
   </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -209,6 +209,15 @@ RSpec.describe ApplicationHelper do
       it { is_expected.to have_css "a[href=\"/url-not-set/events\"]" }
       it { is_expected.to have_css "a", text: "find an event" }
     end
+
+    context "when provided with a custom events_path" do
+      let(:link_text) { "find a special online event" }
+      let(:link_class) { "special-online-event-link" }
+      let(:events_path) { "online/special" }
+      subject { link_to_git_events(link_text, events_path: events_path, class: link_class) }
+
+      it { is_expected.to have_link(link_text, href: git_url + "events/#{events_path}", class: link_class) }
+    end
   end
 
   describe "#internal_referer" do


### PR DESCRIPTION
### Trello card

[709](https://trello.com/c/JCsVtsGK/709-update-content-in-dead-end-for-returner-tta-flow-to-better-reflect-support-options)

### Context

Minor rewording of the page required

### Changes proposed in this pull request

In addition to the rewording, now we're linking to a particular kind of event, the `#link_to_git_events` helper has been amended with a `events_path:` param that, in this case, allows us to link directly to `/events/category/online-events`.

![Screenshot from 2021-01-11 12-15-02](https://user-images.githubusercontent.com/128088/104181800-4b507380-5407-11eb-84fe-f9574a075456.png)


### Guidance to review

Is the change to the helper sensible? I thought above creating a generic `#link_to_git_page` helper and then using it as the basis for the other `#link_to_git...` methods, but went for low-impact for the time being.
