### PR TITLE
Increase Deploy Timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   turnstyle:
     name: Wait for any previous deployments
-    timeout-minutes: 5
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
        - name: Turnstyle


### PR DESCRIPTION
Set the Deploy timeout to 30 minutes

When a deployment takes longer than 30 minutes stop the deployment.

