### PR TITLE
Add Fail2ban to Rack::Attack config

### DIFF
--- a/.env.preprod
+++ b/.env.preprod
@@ -6,3 +6,4 @@
 # GOOGLE_AD_WORDS_ID=AW-1071004410
 # TWITTER_ID=o0wo4
 GIT_URL="https://get-into-teaching-app-test.london.cloudapps.digital/"
+FAIL2BAN=3

--- a/.env.preprod
+++ b/.env.preprod
@@ -6,4 +6,5 @@
 # GOOGLE_AD_WORDS_ID=AW-1071004410
 # TWITTER_ID=o0wo4
 GIT_URL="https://get-into-teaching-app-test.london.cloudapps.digital/"
+SKIP_REQ_LIMITS=true
 FAIL2BAN=3

--- a/.env.rolling
+++ b/.env.rolling
@@ -1,2 +1,3 @@
 # Add public environment variables here for the Rolling environment
 GIT_URL=https://get-into-teaching-app-dev.london.cloudapps.digital/
+FAIL2BAN=3

--- a/.env.rolling
+++ b/.env.rolling
@@ -1,3 +1,3 @@
 # Add public environment variables here for the Rolling environment
 GIT_URL=https://get-into-teaching-app-dev.london.cloudapps.digital/
-FAIL2BAN=3
+FAIL2BAN=1

--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -3,6 +3,4 @@ require File.expand_path("production.rb", __dir__)
 
 Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-test.london.cloudapps.digital"
-
-  Rack::Attack.enabled = false
 end

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -3,6 +3,4 @@ require File.expand_path("production.rb", __dir__)
 
 Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
-
-  Rack::Attack.enabled = false
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -39,8 +39,17 @@ module Rack
 
       blocklist("block hostile bots") do |req|
         Fail2Ban.filter("hostile-bots-#{req.ip}", maxretry: 0, findtime: 1.second, bantime: FAIL2BAN_TIME) do
-          FAIL2BAN_REGEX.match?(CGI.unescape(req.query_string)) ||
+          (
+            FAIL2BAN_REGEX.match?(CGI.unescape(req.query_string)) ||
             FAIL2BAN_REGEX.match?(req.path)
+          ).tap do |should_ban|
+            if should_ban
+              Raven.capture_message <<~BAN_MESSAGE
+                Banning IP: #{req.ip} for #{FAIL2BAN_TIME.to_i / 60} minutes
+                accessing #{req.path} with '#{req.query_string}'
+              BAN_MESSAGE
+            end
+          end
         end
       end
     end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -15,21 +15,23 @@ module Rack
       req.ip if req.path == "/csp_reports"
     end
 
-    # Throttle requests that issue a verification code by IP (5rpm)
-    throttle("issue_verification_code req/ip", limit: 5, period: 1.minute) do |req|
-      req.ip if (req.patch? || req.put?) && req.path == "/teacher_training_adviser/sign_up/identity"
-    end
+    unless ENV["SKIP_REQ_LIMITS"].to_s.in? %w[true yes 1]
+      # Throttle requests that issue a verification code by IP (5rpm)
+      throttle("issue_verification_code req/ip", limit: 5, period: 1.minute) do |req|
+        req.ip if (req.patch? || req.put?) && req.path == "/teacher_training_adviser/sign_up/identity"
+      end
 
-    # Throttle requests that resend a verification code by IP (5rpm)
-    throttle("resend_verification_code req/ip", limit: 5, period: 1.minute) do |req|
-      path_resends_verification_code = %r{/*./resend_verification}.match?(req.path)
+      # Throttle requests that resend a verification code by IP (5rpm)
+      throttle("resend_verification_code req/ip", limit: 5, period: 1.minute) do |req|
+        path_resends_verification_code = %r{/*./resend_verification}.match?(req.path)
 
-      req.ip if req.get? && path_resends_verification_code
-    end
+        req.ip if req.get? && path_resends_verification_code
+      end
 
-    # Throttle teacher training adviser sign ups by IP (5rpm)
-    throttle("teacher_training_adviser_sign_up req/ip", limit: 5, period: 1.minute) do |req|
-      req.ip if (req.patch? || req.put?) && req.path == "/teacher_training_adviser/sign_up/accept_privacy_policy"
+      # Throttle teacher training adviser sign ups by IP (5rpm)
+      throttle("teacher_training_adviser_sign_up req/ip", limit: 5, period: 1.minute) do |req|
+        req.ip if (req.patch? || req.put?) && req.path == "/teacher_training_adviser/sign_up/accept_privacy_policy"
+      end
     end
 
     if ENV["FAIL2BAN"].to_s.match? %r{\A\d+\z}

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,15 @@
 module Rack
   class Attack
+    FAIL2BAN_LIST = %w[
+      /etc/passwd
+      wp-admin
+      wp-login
+      wp-includes
+      .php
+    ].freeze
+
+    FAIL2BAN_REGEX = Regexp.new(FAIL2BAN_LIST.map(&Regexp.method(:quote)).join("|")).freeze
+
     # Throttle /csp_reports requests by IP (5rpm)
     throttle("csp_reports req/ip", limit: 5, period: 1.minute) do |req|
       req.ip if req.path == "/csp_reports"
@@ -20,6 +30,17 @@ module Rack
     # Throttle teacher training adviser sign ups by IP (5rpm)
     throttle("teacher_training_adviser_sign_up req/ip", limit: 5, period: 1.minute) do |req|
       req.ip if (req.patch? || req.put?) && req.path == "/teacher_training_adviser/sign_up/accept_privacy_policy"
+    end
+
+    if ENV["FAIL2BAN"].to_s.match? %r{\A\d+\z}
+      FAIL2BAN_TIME = ENV["FAIL2BAN"].to_s.to_i.minutes.freeze
+
+      blocklist("block hostile bots") do |req|
+        Fail2Ban.filter("hostile-bots-#{req.ip}", maxretry: 0, findtime: 1.second, bantime: FAIL2BAN_TIME) do
+          FAIL2BAN_REGEX.match?(CGI.unescape(req.query_string)) ||
+            FAIL2BAN_REGEX.match?(req.path)
+        end
+      end
     end
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -44,8 +44,10 @@ module Rack
             FAIL2BAN_REGEX.match?(req.path)
           ).tap do |should_ban|
             if should_ban
+              obscured_ip = req.ip.to_s.gsub(%r{\.\d+\.(\d+)\.}, ".***.***.")
+
               Raven.capture_message <<~BAN_MESSAGE
-                Banning IP: #{req.ip} for #{FAIL2BAN_TIME.to_i / 60} minutes
+                Banning IP: #{obscured_ip} for #{FAIL2BAN_TIME.to_i / 60} minutes
                 accessing #{req.path} with '#{req.query_string}'
               BAN_MESSAGE
             end


### PR DESCRIPTION
### Trello card

https://trello.com/c/CvoMhTUe

### Context

Bots poking around the site should be banned

### Changes proposed in this pull request

1. Added Fail2Ban configuration - this is configured with an environment variable `FAIL2BAN` which is an integer of the minutes to ban an ip for. The rule automatically bans any IP accessing a question able endpoint - ie wordpress or php files or etc/passwd
2. Enable FAIL2BAN for 1 minute in `rolling` for quick testing (eg the Review URLs
3. Enable FAIL2BAN for 3 minutes in `preprod` / aka staging
4. Enabled Rack::Attack in all environments, instead disabling only the req limits in `preprod` / aka staging - to allow for the cypress tests
5. Log to Sentry when an IP is blocked and for how long

### Guidance to review
This PR does not enable the checks in production yet
