### PR TITLE
Show Turbolinks progress indicator

### DIFF
--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -35,6 +35,11 @@ $govuk-global-styles: true;
   width: 1px;
 }
 
+.turbolinks-progress-bar {
+  height: 5px;
+  background-color: #0076bd;
+}
+
 @import 'cookie-banner' ;
 
 .footer-bottom {


### PR DESCRIPTION
### Trello card

[Trello-724](https://trello.com/c/SDLkj67Z/724-add-css-for-the-turbolinks-progress-bar)

### Context

Add CSS to style the Turbolinks progress indicator, using the GiT blue for the background colour.

### Changes proposed in this pull request

- Show Turbolinks progress indicator

### Guidance to review

![Screenshot 2021-01-19 at 09 01 30](https://user-images.githubusercontent.com/29867726/105011504-f0d19b80-5a34-11eb-89d5-53cfdca2de1f.png)


