### PR TITLE
reintroduce statuscake on terraform

### DIFF
--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -6,4 +6,14 @@ paas_additional_route_name    = "beta-adviser-getintoteaching"
 logging                       = 1
 additional_routes             = 1
 instances                     = 2
-alerts                        = {}
+alerts = {	
+  GiT_TTA_Production_Healthcheck = {	
+    website_name  = "Get Into Teaching Adviser (Production)"	
+    website_url   = "https://beta-adviser-getintoteaching.education.gov.uk/healthcheck.json"	
+    test_type     = "HTTP"	
+    check_rate    = 60	
+    contact_group = [185037]	
+    trigger_rate  = 0	
+    confirmations = 1
+  }	
+}


### PR DESCRIPTION
Now that the old statuscake instances have been cleaned up it is possible to restart the new instances

