### PR TITLE
ignore dependabot labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
                https://api.github.com/repos/${{ github.repository }}/issues/${{github.event.number }}/comments
 
       - name: Add Review Label
-        if: contains(github.event.pull_request.user.login, ‘dependabot’) == false
+        if: contains(github.event.pull_request.user.login, 'dependabot') == false
         uses: actions-ecosystem/action-add-labels@v1
         with:
           github_token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,6 +224,7 @@ jobs:
                https://api.github.com/repos/${{ github.repository }}/issues/${{github.event.number }}/comments
 
       - name: Add Review Label
+        if: contains(github.event.pull_request.user.login, ‘dependabot’) == false
         uses: actions-ecosystem/action-add-labels@v1
         with:
           github_token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}


### PR DESCRIPTION
when Dependabot creates a PR, it still goes to Review ( thats good) but it does not need a Myles review. so prevent the label being added

### Review comment
I tried `if: ! contains(github.event.pull_request.user.login, ‘dependabot’) ` and github hated it so stuck to`if: contains(github.event.pull_request.user.login, ‘dependabot’) == false`