### PR TITLE
Update statuscake.tf

### DIFF
--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -15,5 +15,7 @@ alerts = {
     contact_group = [185037]	
     trigger_rate  = 0	
     confirmations = 1
+    custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
+    status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
   }	
 }

--- a/terraform/paas/statuscake.tf
+++ b/terraform/paas/statuscake.tf
@@ -8,6 +8,8 @@ resource statuscake_test alert {
   contact_group = each.value.contact_group
   trigger_rate  = each.value.trigger_rate
   confirmations = each.value.confirmations
+  custom_header = each.value.custom_header
+  status_codes  = each.value.status_codes
   basic_user    = var.HTTPAUTH_USERNAME
   basic_pass    = var.HTTPAUTH_PASSWORD
   test_tags     = ["GIT", "BETA"]

--- a/terraform/paas/statuscake.tf
+++ b/terraform/paas/statuscake.tf
@@ -7,7 +7,7 @@ resource statuscake_test alert {
   check_rate    = each.value.check_rate
   contact_group = each.value.contact_group
   trigger_rate  = each.value.trigger_rate
-  custom_header = each.value.custom_header
+  confirmations = each.value.confirmations
   basic_user    = var.HTTPAUTH_USERNAME
   basic_pass    = var.HTTPAUTH_PASSWORD
   test_tags     = ["GIT", "BETA"]


### PR DESCRIPTION
The statuscake provider allows the 'status' fields to be defaulted, which seems to work fine on the first run, but on subsequent runs it tries to set them to NULL.  I guess the provider is trying to use the statefile as the master, so it is not really practical to allow these to default.


