### PR TITLE
Add help text on why we check Date of Birth

### DIFF
--- a/app/views/teacher_training_adviser/steps/_date_of_birth.html.erb
+++ b/app/views/teacher_training_adviser/steps/_date_of_birth.html.erb
@@ -1,4 +1,4 @@
 <%= f.govuk_date_field :date_of_birth,
 date_of_birth: true,
 legend: { text: 'Enter your date of birth' },
-hint: { text: 'For example, 31 3 1980' } %>
+hint: { text: 'For example, 31 3 1980. We use this information to confirm you are aged 18 or over.' } %>


### PR DESCRIPTION
Following GDS assessment, we were asked about why we collect DoB information. This help text addresses this query.

### Changes proposed in this pull request
Added line: We use this information to confirm you are aged 18 or over.

### Guidance to review
Does this render okay?
