### PR TITLE
Change surname to 'last name' throughout

### DIFF
--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -5,7 +5,7 @@
   <%= f.govuk_text_field :first_name, width: 20,
     label: { text: 'First name' } %>
   <%= f.govuk_text_field :last_name, width: 20,
-    label: { text: 'Surname' } %>
+    label: { text: 'Last name' } %>
     <%= f.govuk_email_field :email, width: 20,
     label: { text: 'Email address' } %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,15 +103,15 @@ en:
           attributes:
             timed_one_time_password:
               invalid: Please enter the latest verification code sent to your email address
-              wrong_length: The verification code should be 6 digits 
+              wrong_length: The verification code should be 6 digits
         teacher_training_adviser/steps/identity:
           attributes:
             first_name:
               blank: "You need to enter your first name"
               too_long: "You have entered too many characters - you need to enter your first name"
             last_name:
-              blank: "You need to enter your surname"
-              too_long: "You have entered too many characters - you need to enter your surname"
+              blank: "You need to enter your last name"
+              too_long: "You have entered too many characters - you need to enter your last name"
             email:
               invalid: "You need to enter your email address"
               too_long: "Your email address is too long - you need to enter a valid email address"

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -562,7 +562,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
 
   def fill_in_identity_step
     fill_in "First name", with: "John"
-    fill_in "Surname", with: "Doe"
+    fill_in "Last name", with: "Doe"
     fill_in "Email address", with: "john@doe.com"
   end
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/V9okgwUp/740-content-change-surname-to-last-name-in-sign-up-forms


### Context and changes

Change the labels from 'Surname' to 'Last name'.

This was highlighted in the DAC report, surname is slightly less culturally-sensitive than last name. This still doesn't fall in line
with [GOV.UK's recommendation](https://design-system.service.gov.uk/patterns/names/) of asking for a full name but they need to be separate in order to placate the CRM.
