### PR TITLE
Don't create review apps for dependabot branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
   review:
     name: Review Deployment Process
     needs: build
-    if: github.ref != 'refs/heads/master' && github.event.pull_request.draft == false
+    if: github.ref != 'refs/heads/master' && startsWith(github.head_ref, 'dependabot/') == false && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
### Context

We don't use the Review Apps to verify dependabot branches so we don't need to create them

### Changes proposed in this pull request

1. Don't create review apps if branch name starts with 'dependabot/'



