### PR TITLE
Better Release Body

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,30 +278,33 @@ jobs:
            workflow: owasp
            token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
            inputs: '{"environment": "dev"}'
-      
+          
        - name: Generate Tag from PR Number
          id:   tag_version
          uses: DFE-Digital/github-actions/GenerateReleaseFromSHA@master
          with:
            sha: ${{github.sha}}
-
-       - name: Create Temporary Release File
-         if: steps.tag_version.outputs.pr_found == 1
-         run: echo "${{ steps.tag_version.outputs.pr_text }}" > ./temp.md
              
        - name: Create a GitHub Release
+         id: release
          if:   steps.tag_version.outputs.pr_found == 1
          uses: actions/create-release@v1
          env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          with:
             tag_name: ${{ steps.tag_version.outputs.pr_number }}
-            release_name: GiT Adviser Release ${{ steps.tag_version.outputs.pr_number }}
-            body_path: ./temp.md
+            release_name: Release ${{ steps.tag_version.outputs.pr_number }}
             commitish: ${{ github.sha }} 
             prerelease: false
             draft:      true
 
+       - name: Copy PR Info to Release
+         if: steps.release.outputs.id      
+         uses: DFE-Digital/github-actions/CopyPRtoRelease@master
+         with:
+           PR_NUMBER:  ${{ steps.tag_version.outputs.pr_number }}
+           RELEASE_ID: ${{ steps.release.outputs.id }}
+           TOKEN: ${{secrets.GITHUB_TOKEN}}       
   qa:
     name: Quality Assurance Deployment
     needs: development

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,7 +287,7 @@ jobs:
 
        - name: Create Temporary Release File
          if: steps.tag_version.outputs.pr_found == 1
-         run: echo "${{ steps.tag_version.outputs.pr_text }}" > ${PWD}/temp.md
+         run: echo "${{ steps.tag_version.outputs.pr_text }}" > ./temp.md
              
        - name: Create a GitHub Release
          if:   steps.tag_version.outputs.pr_found == 1
@@ -297,7 +297,7 @@ jobs:
          with:
             tag_name: ${{ steps.tag_version.outputs.pr_number }}
             release_name: GiT Adviser Release ${{ steps.tag_version.outputs.pr_number }}
-            body_path: ${PWD}/temp.md
+            body_path: ./temp.md
             commitish: ${{ github.sha }} 
             prerelease: false
             draft:      true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,6 +285,10 @@ jobs:
          with:
            sha: ${{github.sha}}
 
+       - name: Create Temporary Release File
+         if: steps.tag_version.outputs.pr_found == 1
+         run: echo "${{ steps.tag_version.outputs.pr_text }}" > ${PWD}/temp.md
+             
        - name: Create a GitHub Release
          if:   steps.tag_version.outputs.pr_found == 1
          uses: actions/create-release@v1
@@ -292,9 +296,8 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          with:
             tag_name: ${{ steps.tag_version.outputs.pr_number }}
-            release_name: Release ${{ steps.tag_version.outputs.pr_number }}
-            body: |
-                  ${{ steps.tag_version.outputs.pr_text }}
+            release_name: GiT Adviser Release ${{ steps.tag_version.outputs.pr_number }}
+            body_path: ${PWD}/temp.md
             commitish: ${{ github.sha }} 
             prerelease: false
             draft:      true


### PR DESCRIPTION
### Trello card
https://trello.com/c/Ueda1EDd/640-release-notes-are-only-first-line

### Context
The release is only created with the first line of the PR, I want to improve this to provide the full PR Body

### Changes proposed in this pull request
Create a MD file and use that to create the release

### Guidance to review
This will not effect the product
This should not make any effect to the SLACK output, that will come later
