### PR TITLE
RubyCop Artefact Missing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Rubocop_results
-          path: ${PWD}/out/rubocop-result.json
+          path: ${{ github.workspace }}/out/rubocop-result.json
 
       - name: Run Brakeman static security scanner
         run: |-


### PR DESCRIPTION
### Trello
[Artefacts Missing](https://trello.com/c/T9VjNdeY/751-rubocop-no-artifacts-will-be-uploaded)

### Issue
The Rubocop test results artefact was not being kept.

### Review 
There are no code changes
