### PR TITLE
Update completed.html.erb

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,8 +58,8 @@ module ApplicationHelper
     end
   end
 
-  def link_to_git_site(text = "Get into Teaching", attributes = {})
-    link_to text, git_url, attributes
+  def link_to_git_site(text = "Get into Teaching", path = "", attributes = {})
+    link_to text, git_url(path), attributes
   end
 
   def link_to_git_mailing_list(text, attributes = {})

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -15,6 +15,17 @@
         <p class="govuk-body">
           You must respond to the email within 6 weeks of receiving it otherwise you will have to sign up again.  
         </p>
+
+        <p class="govuk-body">
+        While you wait for your adviser, you can: 
+      <ul>
+        <li>Ask any immediate questions using the Get Into Teaching <a href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">online chat</a></li>
+        <li>Discover the different <a href="https://beta-getintoteaching.education.gov.uk/ways-to-train"> ways to train</a> to become a teacher</li>
+        <li>Find out about <a href="https://beta-getintoteaching.education.gov.uk/funding-your-training">funding</a></li>
+        <li><a href="https://beta-getintoteaching.education.gov.uk/events">Search for events</a> that might interest you</li>
+      </ul>
+        </p>
+
         <p class="govuk-body">
           If you have any questions or you need to update any of the information you provided, speak to one of our advisers on Freephone <a href="tel:08003892501">0800 389 2501</a> between 8.30am - 5pm Monday to Friday.
         </p>

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -13,16 +13,16 @@
           We've received your information. You’ll get an email from us soon which will outline the next steps for you to talk to an adviser.
         </p>
         <p class="govuk-body">
-          You must respond to the email within 6 weeks of receiving it otherwise you will have to sign up again.  
+          You must respond to the email within 6 weeks of receiving it otherwise you will have to sign up again.
         </p>
 
         <p class="govuk-body">
-        While you wait for your adviser, you can: 
+        While you wait for your adviser, you can:
       <ul>
-        <li>Ask any immediate questions using the Get Into Teaching <a href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">online chat</a></li>
-        <li>Discover the different <a href="https://beta-getintoteaching.education.gov.uk/ways-to-train"> ways to train</a> to become a teacher</li>
-        <li>Find out about <a href="https://beta-getintoteaching.education.gov.uk/funding-your-training">funding</a></li>
-        <li><a href="https://beta-getintoteaching.education.gov.uk/events">Search for events</a> that might interest you</li>
+        <li>Ask any immediate questions using the Get Into Teaching <%= link_to_git_site "online chat", "#talk-to-us" %></li>
+        <li>Discover the different <%= link_to_git_site "ways to train", "ways-to-train" %> to become a teacher</li>
+        <li>Find out about <%= link_to_git_site "funding", "funding-your-training" %></li>
+        <li><%= link_to_git_site "Search for events", "events" %> that might interest you</li>
       </ul>
         </p>
 
@@ -51,8 +51,8 @@
               data-gtm-event="conversion"
               data-gtm-event-data='{"send_to":"AW-1071004410/1Rs4CM_qitsBEPr12P4D"}'></span>
 
-        <span data-controller="lid" 
-              data-lid-action="track" 
+        <span data-controller="lid"
+              data-lid-action="track"
               data-lid-event="CompleteApp"></span>
       </div>
     </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -144,8 +144,14 @@ RSpec.describe ApplicationHelper do
       it { is_expected.to have_css "a", text: "Teaching site" }
     end
 
+    context "with path" do
+      subject { link_to_git_site "Show content", "content/page", class: "govuk-link" }
+      it { is_expected.to have_css 'a.govuk-link[href="http://test.url/content/page"]' }
+      it { is_expected.to have_css "a.govuk-link", text: "Show content" }
+    end
+
     context "with attributes" do
-      subject { link_to_git_site "Teaching site", class: "govuk-link" }
+      subject { link_to_git_site "Teaching site", "", class: "govuk-link" }
       it { is_expected.to have_css 'a.govuk-link[href="http://test.url/"]' }
       it { is_expected.to have_css "a.govuk-link", text: "Teaching site" }
     end


### PR DESCRIPTION
### Trello card
https://trello.com/c/SLCvkKyf/600-content-spike-what-signposting-can-we-give-to-the-tta-confirmation-page-to-help-people-do-their-own-research-eg-go-and-look-at-p
### Context
We had feedback from TTAs that some users had not done too much research before their initial conversation (email/phone etc.). 

### Changes proposed in this pull request
Added an unordered list to the confirmation page with various links to key pages users may find useful.

### Guidance to review
Test links and check code is fine. Can we use shortened versions of the links on the TTA service to go to a PB site?

Review Link: https://review-teacher-training-adviser-521.london.cloudapps.digital/teacher_training_adviser/sign_up/completed
