### PR TITLE
Swap to new token exchange methods/endpoints

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: fc55a73e7192f95199f4c3d2e9c04c3e7eb6ada3
+  revision: f4d48fc3310db7e6a95df63f284a84f1375d5629
   specs:
-    get_into_teaching_api_client (1.1.7)
+    get_into_teaching_api_client (1.1.10)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.9)
+    get_into_teaching_api_client_faraday (0.1.13)
       activesupport
       faraday
       faraday-encoding
@@ -115,13 +115,15 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
-    faraday (1.1.0)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
     faraday-encoding (0.0.5)
       faraday
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
+    faraday-net_http (1.0.1)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     ffi (1.14.2)
@@ -133,7 +135,7 @@ GEM
       activemodel (>= 5.2)
       activesupport (>= 5.2)
     htmlentities (4.3.4)
-    i18n (1.8.7)
+    i18n (1.8.8)
       concurrent-ruby (~> 1.0)
     i18n_data (0.10.0)
     json (2.5.1)
@@ -263,7 +265,7 @@ GEM
     rubocop-rspec (1.42.0)
       rubocop (>= 0.87.0)
     ruby-progressbar (1.10.1)
-    ruby2_keywords (0.0.2)
+    ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)

--- a/app/models/teacher_training_adviser/steps/authenticate.rb
+++ b/app/models/teacher_training_adviser/steps/authenticate.rb
@@ -5,7 +5,7 @@ module TeacherTrainingAdviser
 
       def perform_existing_candidate_request(request)
         @api ||= GetIntoTeachingApiClient::TeacherTrainingAdviserApi.new
-        @api.get_pre_filled_teacher_training_adviser_sign_up(timed_one_time_password, request)
+        @api.exchange_access_token_for_teacher_training_adviser_sign_up(timed_one_time_password, request)
       end
     end
   end

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -463,11 +463,11 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
         receive(:create_candidate_access_token)
       allow_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to \
-        receive(:get_pre_filled_teacher_training_adviser_sign_up)
+        receive(:exchange_access_token_for_teacher_training_adviser_sign_up)
         .with(valid_code, anything)
         .and_return(existing_candidate)
       allow_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to \
-        receive(:get_pre_filled_teacher_training_adviser_sign_up)
+        receive(:exchange_access_token_for_teacher_training_adviser_sign_up)
         .with(invalid_code, anything)
         .and_raise(GetIntoTeachingApiClient::ApiError)
     end

--- a/spec/models/teacher_training_adviser/steps/authenticate_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/authenticate_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe TeacherTrainingAdviser::Steps::Authenticate do
 
   it { is_expected.to be_kind_of(::Wizard::Steps::Authenticate) }
 
-  it "calls get_pre_filled_teacher_training_adviser_sign_up on valid save!" do
+  it "calls exchange_access_token_for_teacher_training_adviser_sign_up on valid save!" do
     attributes = { "timed_one_time_password": "123456" }
     response = GetIntoTeachingApiClient::MailingListAddMember.new
     expect_any_instance_of(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to \
-      receive(:get_pre_filled_teacher_training_adviser_sign_up)
+      receive(:exchange_access_token_for_teacher_training_adviser_sign_up)
       .with("123456", anything)
       .and_return(response)
     subject.assign_attributes(attributes)


### PR DESCRIPTION
### Trello card

[Trello-776](https://trello.com/c/HILK0xws/776-mailing-list-sign-up-process-for-crm-data-migration)

### Context

The existing methods/endpoints to exchange an access token for a pre-filled TTA sign up model are being deprecated and removed. This commit transitions the codebase to use the new `exchange_access_token` method.

### Changes proposed in this pull request

- Swap to new token exchange methods/endpoints

### Guidance to review

I've manually tested a match back TTA sign up.