### PR TITLE
Enabled Fail2Ban in production - initially just for a minute at a time

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -8,3 +8,4 @@ TWITTER_ID=o0wo4
 HOTJAR_ID=1871524
 GIT_URL=https://beta-getintoteaching.education.gov.uk/
 LID_ID=1
+FAIL2BAN=1


### PR DESCRIPTION
### Trello card

https://trello.com/c/CvoMhTUe

### Context

We should prevent bots poking around the site - particularly if they're looking for 'scammy' files

### Changes proposed in this pull request

1. Minimal 1 minute ban

### Guidance to review

Should be safe but we'll have to watch to see what the effects are

