### PR TITLE
Hide pre-filled optional fields and steps

### DIFF
--- a/app/controllers/teacher_training_adviser/steps_controller.rb
+++ b/app/controllers/teacher_training_adviser/steps_controller.rb
@@ -22,11 +22,15 @@ module TeacherTrainingAdviser
     helper_method :step_path
 
     def wizard_store
-      ::Wizard::Store.new session_store
+      ::Wizard::Store.new app_store, crm_store
     end
 
-    def session_store
+    def app_store
       session[:sign_up] ||= {}
+    end
+
+    def crm_store
+      session[:sign_up_crm] ||= {}
     end
 
     def set_page_title

--- a/app/models/teacher_training_adviser/steps/has_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/has_teacher_id.rb
@@ -11,7 +11,10 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      !other_step(:returning_teacher).returning_to_teaching
+      teacher_id_prefilled = @store.crm(:teacher_id)
+      returning_teacher = other_step(:returning_teacher).returning_to_teaching
+
+      !returning_teacher || teacher_id_prefilled
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_telephone.rb
@@ -12,7 +12,13 @@ module TeacherTrainingAdviser::Steps
       true
     end
 
+    def optional?
+      true
+    end
+
     def skipped?
+      return true if super
+
       overseas_country_skippped = other_step(:overseas_country).skipped?
       degree_options = other_step(:have_a_degree).degree_options
       equivalent_degree = degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]

--- a/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
@@ -2,7 +2,13 @@ module TeacherTrainingAdviser::Steps
   class PreviousTeacherId < Wizard::Step
     attribute :teacher_id, :string
 
+    def optional?
+      true
+    end
+
     def skipped?
+      return true if super
+
       has_teacher_id_step = other_step(:has_teacher_id)
       has_teacher_id_skipped = has_teacher_id_step.skipped?
       has_id = has_teacher_id_step.has_id

--- a/app/models/teacher_training_adviser/steps/uk_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/uk_telephone.rb
@@ -12,7 +12,13 @@ module TeacherTrainingAdviser::Steps
       true
     end
 
+    def optional?
+      true
+    end
+
     def skipped?
+      return true if super
+
       uk_address_skipped = other_step(:uk_address).skipped?
       degree_options = other_step(:have_a_degree).degree_options
       equivalent_degree = degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -141,7 +141,7 @@ module Wizard
     def prepopulate_store(response, auth_method)
       hash = response.to_hash.transform_keys { |k| k.to_s.underscore }
       hash["auth_method"] = auth_method
-      @store.persist(hash)
+      @store.persist_crm(hash)
     end
 
     def all_steps

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -114,8 +114,10 @@ module Wizard
 
     def export_data
       matchback_data = @store.fetch(MATCHBACK_ATTRS)
-      step_data = all_steps.map(&:export).reduce({}, :merge)
-
+      # Ensure skipped step data is overwritten by shown step data.
+      # Important as two steps can write to the same attribute.
+      skipped_steps_first = all_steps.partition(&:skipped?).flatten
+      step_data = skipped_steps_first.map(&:export).reduce({}, :merge)
       step_data.merge!(matchback_data)
     end
 

--- a/app/models/wizard/step.rb
+++ b/app/models/wizard/step.rb
@@ -49,6 +49,12 @@ module Wizard
     end
 
     def skipped?
+      return false unless optional?
+
+      @store.fetch(attribute_names, source: :crm).values.all?(&:present?)
+    end
+
+    def optional?
       false
     end
 
@@ -58,9 +64,8 @@ module Wizard
     end
 
     def export
-      return {} if skipped?
-
-      Hash[attributes.keys.zip([])].merge attributes_from_store
+      attributes = skipped? ? attributes_from_crm : attributes_from_store
+      Hash[attributes.keys.zip([])].merge attributes
     end
 
     def reviewable_answers
@@ -68,6 +73,10 @@ module Wizard
     end
 
   private
+
+    def attributes_from_crm
+      @store.fetch attributes.keys, source: :crm
+    end
 
     def attributes_from_store
       @store.fetch attributes.keys

--- a/app/models/wizard/steps/authenticate.rb
+++ b/app/models/wizard/steps/authenticate.rb
@@ -28,7 +28,7 @@ module Wizard
       end
 
       def candidate_identity_data
-        @store.fetch(IDENTITY_ATTRS).transform_keys do |k|
+        @store.fetch(IDENTITY_ATTRS).compact.transform_keys do |k|
           k.camelize(:lower).to_sym
         end
       end

--- a/app/models/wizard/store.rb
+++ b/app/models/wizard/store.rb
@@ -1,40 +1,63 @@
 module Wizard
   class Store
-    attr_reader :data
-    delegate :keys, :to_h, :to_hash, to: :data
+    class InvalidBackingStore < RuntimeError; end
 
-    def initialize(data)
-      raise InvalidBackingStore unless data.respond_to?(:[]=)
+    delegate :keys, :to_h, :to_hash, to: :combined_data
 
-      @data = data
+    def initialize(app_data, crm_data)
+      stores = [app_data, crm_data]
+      raise InvalidBackingStore unless stores.all? { |s| s.respond_to?(:[]=) }
+
+      @app_data = app_data
+      @crm_data = crm_data
     end
 
     def [](key)
-      data[key.to_s]
+      combined_data[key.to_s]
     end
 
     def []=(key, value)
-      data[key.to_s] = value
+      @app_data[key.to_s] = value
     end
 
-    def fetch(*keys)
-      data.slice(*Array.wrap(keys).flatten.map(&:to_s)).stringify_keys
+    def crm(key)
+      @crm_data[key.to_s]
+    end
+
+    def fetch(*keys, source: :both)
+      array_of_keys = Array.wrap(keys).flatten.map(&:to_s)
+      Hash[array_of_keys.zip].merge(store(source).slice(*array_of_keys))
     end
 
     def persist(attributes)
-      data.merge! attributes.stringify_keys
+      @app_data.merge!(attributes.stringify_keys)
+
+      true
+    end
+
+    def persist_crm(attributes)
+      @crm_data.merge!(attributes.stringify_keys)
 
       true
     end
 
     def purge!
-      data.clear
+      @app_data.clear
+      @crm_data.clear
     end
 
-    def to_camelized_hash
-      data.transform_keys { |k| k.camelize(:lower).to_sym }
+  private
+
+    def store(source)
+      case source
+      when :crm then @crm_data
+      when :app then @app_data
+      else combined_data
+      end
     end
 
-    class InvalidBackingStore < RuntimeError; end
+    def combined_data
+      @crm_data.merge(@app_data)
+    end
   end
 end

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -456,6 +456,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
         addressPostcode: "TE7 1NG",
         dateOfBirth: Date.new(1999, 4, 27),
         telephone: "123456789",
+        teacherId: "12345",
       )
     end
 
@@ -550,6 +551,74 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
         address_line2: nil,
         address_city: "Manchester",
         address_postcode: "TE7 1NG",
+      })
+      expect_sign_up_with_attributes(request_attributes)
+
+      click_on "Complete"
+
+      expect(page).to have_css "h1", text: "Thank you"
+      expect(page).to have_css "h1", text: "Sign up complete"
+    end
+
+    scenario "skipping pre-filled optional steps" do
+      visit teacher_training_adviser_steps_path
+
+      expect(page).to have_css "h1", text: "About you"
+      fill_in_identity_step
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Verify your email address"
+      fill_in "wizard-steps-authenticate-timed-one-time-password-field", with: valid_code
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Are you returning to teaching?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to_not have_css "h1", text: "Do you have your previous teacher reference number?"
+      expect(page).to_not have_css "h1", text: "What is your previous teacher reference number?"
+
+      expect(page).to have_css "h1", text: "Which main subject did you previously teach?"
+      select "Psychology"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Which subject would you like to teach if you return to teaching?"
+      choose "Physics"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Enter your date of birth"
+      expect(find_field("Day").value).to eq("27")
+      expect(find_field("Month").value).to eq("4")
+      expect(find_field("Year").value).to eq("1999")
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Where do you live?"
+      choose "UK"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "What is your address?"
+      expect(find_field("Address line 1").value).to eq("7 Main Street")
+      expect(find_field("Town or City").value).to eq("Manchester")
+      expect(find_field("Postcode").value).to eq("TE7 1NG")
+      click_on "Continue"
+
+      expect(page).to_not have_css "h1", text: "What is your telephone number?"
+
+      expect(page).to have_css "h1", text: "Check your answers before you continue"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Read and accept the privacy policy"
+      check "Accept the privacy policy"
+
+      request_attributes = uk_candidate_request_attributes({
+        subject_taught_id: SUBJECT_PSYCHOLOGY,
+        preferred_teaching_subject_id: SUBJECT_PHYSICS,
+        date_of_birth: "1999-04-27",
+        address_line1: "7 Main Street",
+        address_line2: nil,
+        address_city: "Manchester",
+        address_postcode: "TE7 1NG",
+        teacher_id: "12345",
       })
       expect_sign_up_with_attributes(request_attributes)
 

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -596,7 +596,6 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       first_name: "John",
       last_name: "Doe",
       date_of_birth: "1966-03-24",
-      telephone: "123456789",
       address_line1: "7",
       address_line2: "Main Street",
       address_city: "Edinburgh",

--- a/spec/models/teacher_training_adviser/steps/has_teacher_id_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/has_teacher_id_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe TeacherTrainingAdviser::Steps::HasTeacherId do
       wizardstore["returning_to_teaching"] = false
       expect(subject).to be_skipped
     end
+
+    it "returns true if teacher_id is pre-filled from crm" do
+      wizardstore.persist_crm({ "teacher_id" => "1234567" })
+      expect(subject).to be_skipped
+    end
   end
 
   describe "#reviewable_answers" do

--- a/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTelephone do
   include_context "sanitize fields", %i[telephone]
 
   it { is_expected.to be_contains_personal_details }
+  it { is_expected.to be_optional }
 
   context "attributes" do
     it { is_expected.to respond_to :telephone }
@@ -30,6 +31,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTelephone do
 
     it "returns true if degree_options is equivalent" do
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      expect(subject).to be_skipped
+    end
+
+    it "returns true when pre-filled with crm data" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
+      wizardstore.persist_crm({ "telephone" => "123456789" })
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/previous_teacher_id_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/previous_teacher_id_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe TeacherTrainingAdviser::Steps::PreviousTeacherId do
   include_context "wizard step"
   it_behaves_like "a wizard step"
 
+  it { is_expected.to be_optional }
+
   context "attributes" do
     it { is_expected.to respond_to :teacher_id }
   end
@@ -22,6 +24,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::PreviousTeacherId do
 
     it "returns true if has_id is false" do
       wizardstore["has_id"] = false
+      expect(subject).to be_skipped
+    end
+
+    it "returns true when pre-filled with crm data" do
+      wizardstore["has_id"] = true
+      wizardstore.persist_crm({ "teacher_id" => "123456" })
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/uk_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_telephone_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkTelephone do
   include_context "sanitize fields", %i[telephone]
 
   it { is_expected.to be_contains_personal_details }
+  it { is_expected.to be_optional }
 
   context "attributes" do
     it { is_expected.to respond_to :telephone }
@@ -30,6 +31,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkTelephone do
 
     it "returns true if degree_options is equivalent" do
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      expect(subject).to be_skipped
+    end
+
+    it "returns true when pre-filled with crm data" do
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
+      wizardstore.persist_crm({ "telephone" => "123456789" })
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/wizard_spec.rb
+++ b/spec/models/teacher_training_adviser/wizard_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
         "last_name" => "Joseph",
       }
     end
-    let(:wizardstore) { Wizard::Store.new store }
+    let(:wizardstore) { Wizard::Store.new store, {} }
 
     subject { described_class.new wizardstore, "accept_privacy_policy" }
 

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe Wizard::Base do
       end
 
       it { is_expected.to include "name" => "Joe" }
-      it { is_expected.not_to include "age" }
+      it { is_expected.to include "age" => nil }
       it { is_expected.to include "postcode" => nil }
     end
 

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Wizard::Base do
 
     subject! do
       wizard.process_access_token(token, request)
-      wizardstore.fetch(%w[candidate_id first_name last_name email])
+      wizardstore.fetch(%w[candidate_id first_name last_name email], source: :crm)
     end
 
     it { is_expected.to eq response_hash }

--- a/spec/models/wizard/step_spec.rb
+++ b/spec/models/wizard/step_spec.rb
@@ -42,19 +42,51 @@ RSpec.describe Wizard::Step do
     it { is_expected.to have_attributes name: "Joe" }
     it { is_expected.to have_attributes age: 20 }
     it { is_expected.to have_attributes skipped?: false }
-  end
-
-  describe "#can_proceed" do
-    it { expect(subject).to be_can_proceed }
-  end
-
-  describe "#exit" do
-    it { expect(subject).to_not be_exit }
+    it { is_expected.to have_attributes optional?: false }
+    it { is_expected.to have_attributes can_proceed?: true }
+    it { is_expected.to have_attributes exit?: false }
   end
 
   describe "#other_step" do
     it { expect(subject.other_step(:first_step)).to be_kind_of(FirstStep) }
     it { expect(subject.other_step(FirstStep)).to be_kind_of(FirstStep) }
+  end
+
+  describe "#skipped?" do
+    context "when optional" do
+      before { expect(subject).to receive(:optional?) { true } }
+
+      context "when values for all attributes are present in the CRM" do
+        before do
+          crm_backingstore["name"] = "John"
+          crm_backingstore["age"] = 18
+        end
+
+        it { is_expected.to be_skipped }
+      end
+
+      context "when values for some attributes are present in the CRM" do
+        before do
+          crm_backingstore["name"] = "John"
+          crm_backingstore["age"] = nil
+        end
+
+        it { is_expected.not_to be_skipped }
+      end
+    end
+
+    context "when not optional" do
+      before { expect(subject).to receive(:optional?) { false } }
+
+      context "when values for all attributes are present in the CRM" do
+        before do
+          crm_backingstore["name"] = "John"
+          crm_backingstore["age"] = 18
+        end
+
+        it { is_expected.to_not be_skipped }
+      end
+    end
   end
 
   describe "#save!" do
@@ -91,5 +123,14 @@ RSpec.describe Wizard::Step do
     subject { instance.export }
     it { is_expected.to include "name" => "Joe" }
     it { is_expected.to include "age" => nil } # should only export persisted data
+
+    context "when the step is skipped" do
+      let(:crm_backingstore) { { "name" => "Jimmy" } }
+
+      before { expect(instance).to receive(:skipped?) { true } }
+
+      it { is_expected.to include "name" => "Jimmy" }
+      it { is_expected.to include "age" => nil } # should only export persisted data
+    end
   end
 end

--- a/spec/models/wizard/store_spec.rb
+++ b/spec/models/wizard/store_spec.rb
@@ -1,22 +1,29 @@
 require "rails_helper"
 
 RSpec.describe Wizard::Store do
-  let(:backingstore) do
-    { "first_name" => "Joe", "age" => 20, "region" => "Manchester" }
-  end
-  let(:instance) { described_class.new backingstore }
+  let(:app_data) { { "first_name" => "Joe", "last_name" => nil, "age" => 20 } }
+  let(:crm_data) { { "first_name" => "James", "last_name" => "Doe", "region" => "Manchester" } }
+  let(:instance) { described_class.new app_data, crm_data }
+
   subject { instance }
 
   describe ".new" do
     context "with valid source data" do
-      it { is_expected.to be_instance_of(Wizard::Store) }
-      it { is_expected.to have_attributes data: backingstore }
+      it { is_expected.to be_instance_of(described_class) }
       it { is_expected.to respond_to :[] }
       it { is_expected.to respond_to :[]= }
     end
 
-    context "with invalid source data" do
-      subject { described_class.new nil }
+    context "with invalid app_data source" do
+      subject { described_class.new nil, crm_data }
+
+      it "should raise an InvalidBackingStore" do
+        expect { subject }.to raise_exception(Wizard::Store::InvalidBackingStore)
+      end
+    end
+
+    context "with invalid crm_data source" do
+      subject { described_class.new app_data, nil }
 
       it "should raise an InvalidBackingStore" do
         expect { subject }.to raise_exception(Wizard::Store::InvalidBackingStore)
@@ -25,14 +32,28 @@ RSpec.describe Wizard::Store do
   end
 
   describe "#[]" do
-    context "first_name" do
+    context "when the attribute exists in app and crm data" do
       subject { instance["first_name"] }
-      it { is_expected.to eql "Joe" }
+
+      it { is_expected.to eq("Joe") }
     end
 
-    context "age" do
+    context "when the attribute is nil in the app data and not nil in the crm data" do
+      subject { instance["last_name"] }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the attribute exists in only the app data" do
       subject { instance["age"] }
-      it { is_expected.to eql 20 }
+
+      it { is_expected.to eq(20) }
+    end
+
+    context "when the attribute exists in only the crm data" do
+      subject { instance["region"] }
+
+      it { is_expected.to eq("Manchester") }
     end
   end
 
@@ -43,20 +64,63 @@ RSpec.describe Wizard::Store do
     end
   end
 
+  describe "#crm" do
+    it { expect(instance.crm(:first_name)).to eq("James") }
+    it { expect(instance.crm(:age)).to be_nil }
+  end
+
   describe "#fetch" do
     context "with multiple keys" do
-      subject { instance.fetch :first_name, :region }
-      it "will return hash of requested keys" do
-        is_expected.to eql({ "first_name" => "Joe", "region" => "Manchester" })
+      subject { instance.fetch :first_name, :last_name, :age, :region, source: source }
+
+      context "when source is both" do
+        let(:source) { :both }
+
+        it { is_expected.to eql({ "first_name" => "Joe", "last_name" => nil, "age" => 20, "region" => "Manchester" }) }
+      end
+
+      context "when source is app" do
+        let(:source) { :app }
+
+        it { is_expected.to eql({ "first_name" => "Joe", "last_name" => nil, "age" => 20, "region" => nil }) }
+      end
+
+      context "when source is crm" do
+        let(:source) { :crm }
+
+        it { is_expected.to eql({ "first_name" => "James", "age" => nil, "last_name" => "Doe", "region" => "Manchester" }) }
       end
     end
 
     context "with array of keys" do
-      subject { instance.fetch %w[first_name region] }
-      it "will return hash of requested keys" do
-        is_expected.to eql({ "first_name" => "Joe", "region" => "Manchester" })
+      subject { instance.fetch %w[first_name age region] }
+
+      it { is_expected.to eql({ "first_name" => "Joe", "age" => 20, "region" => "Manchester" }) }
+    end
+
+    context "when a key is not present in the store" do
+      subject { instance.fetch %w[first_name missing_key] }
+
+      it "will return it with a nil value in the hash" do
+        is_expected.to eql({ "first_name" => "Joe", "missing_key" => nil })
       end
     end
+  end
+
+  describe "#persist" do
+    subject! { instance.persist({ first_name: "Jim" }) }
+
+    it { is_expected.to be_truthy }
+    it { expect(instance["first_name"]).to eq("Jim") }
+    it { expect(instance["age"]).to eq(20) }
+  end
+
+  describe "#persist_crm" do
+    subject! { instance.persist_crm({ first_name: "Jim" }) }
+
+    it { is_expected.to be_truthy }
+    it { expect(instance.crm("first_name")).to eq("Jim") }
+    it { expect(instance.crm("age")).to be_nil }
   end
 
   describe "#purge!" do
@@ -65,13 +129,6 @@ RSpec.describe Wizard::Store do
 
     it "will remove all keys" do
       is_expected.to have_attributes empty?: true
-    end
-  end
-
-  describe "#to_camelized_hash" do
-    subject { instance.to_camelized_hash }
-    it "returns returns a hash with camelCase keys" do
-      is_expected.to eq(firstName: "Joe", age: 20, region: "Manchester")
     end
   end
 end

--- a/spec/support/shared_examples/wizard_support.rb
+++ b/spec/support/shared_examples/wizard_support.rb
@@ -188,6 +188,12 @@ class TestWizard < Wizard::Base
     validates :name, presence: true
   end
 
+  # To simulate two steps writing to the same attribute.
+  class OtherAge < Wizard::Step
+    attribute :age, :integer
+    validates :age, presence: false
+  end
+
   class Age < Wizard::Step
     attribute :age, :integer
     validates :age, presence: true
@@ -198,5 +204,5 @@ class TestWizard < Wizard::Base
     validates :postcode, presence: true
   end
 
-  self.steps = [Name, Age, Postcode].freeze
+  self.steps = [Name, OtherAge, Age, Postcode].freeze
 end

--- a/spec/support/shared_examples/wizard_support.rb
+++ b/spec/support/shared_examples/wizard_support.rb
@@ -1,6 +1,7 @@
 RSpec.shared_context "wizard store" do
   let(:backingstore) { { "name" => "Joe", "age" => 35 } }
-  let(:wizardstore) { Wizard::Store.new backingstore }
+  let(:crm_backingstore) { {} }
+  let(:wizardstore) { Wizard::Store.new backingstore, crm_backingstore }
 end
 
 RSpec.shared_context "wizard step" do


### PR DESCRIPTION
This is a lift and shift of the app PR https://github.com/DFE-Digital/get-into-teaching-app/pull/907

- Add crm data support to store

We want to hide steps that are optional and have been pre-filled with candidate information.

In order to determine if a step can be pre-filled from the CRM we need to retain the CRM values in the store so that they
can later be queried independently of the data written by the app.

The `fetch` method has also been updated to return values for all keys passed in; this makes the logic to determine if all
values are present in a store simpler (otherwise we would also have to check the `count` to ensure all values are present):

```
fetch(%[...], source: :crm).values.all(&:present?)
```

- Add support for optional steps

An optional step will be skipped if (and only if) the step attributes were all pre-filled from the CRM data.

Data will be send to the API for skipped steps going forward.

This is going to be useful because skipped step values will be `nil` for new candidates and will contain the data already in the CRM for existing candidates. Ultimately this will make it easier to update the API to support sending `nil` values to the CRM (it avoids having to duplicate the logic for 'was this step shown to the user' in the API).

- Give precedence to shown steps during export

We have a number of steps that write to the same attribute. With the way we currently export the later of the steps value is used (regardless of if its skipped or not). This can lead to incorrect data being exported; instead, we need to prioritise the shown steps so that they overwrite data exported from skipped steps.

- Skip optional steps

Updates the optional steps to return true for `optional?`. Updates the `skipped?` logic of these steps to ensure the default 'skip if optional and pre-filled' logic is applied.

Add feature spec to cover skipping optional steps after a matchback.