### PR TITLE
Improve Release Note

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -510,7 +510,7 @@ jobs:
          env:
            SLACK_COLOR:   ${{env.SLACK_SUCCESS}}
            SLACK_TITLE:   "Release Published: ${{steps.tag_id.outputs.release_name}}"
-           SLACK_MESSAGE: ${{steps.tag_id.outputs.release_body}}
+           SLACK_MESSAGE: ${{ fromJson( steps.tag_id.outputs.release_body) }}
            SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-RELEASE-NOTE-WEBHOOK }}
            MSG_MINIMAL:   true
 

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           SLACK_COLOR: ${{env.SLACK_SUCCESS}}
           SLACK_TITLE: "Release Published to ${{github.event.inputs.environment}}: ${{steps.tag_id.outputs.release_name}}"
-          SLACK_MESSAGE: ${{steps.tag_id.outputs.release_body}}
+          SLACK_MESSAGE: ${{ fromJson( steps.tag_id.outputs.release_body) }}
           SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-RELEASE-NOTE-WEBHOOK }}
           MSG_MINIMAL: true
 

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -45,7 +45,7 @@ jobs:
           TOKEN: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
 
       - name: Check if found
-        if: steps.tag_id.outputs.found == 0
+        if: steps.tag_id.outputs.release_id == ""
         run: |
              echo "::error ::Tag ${{ github.event.inputs.tag }} cannot be found in releases"
              exit 1


### PR DESCRIPTION
### Trello card
[Release Notes are only first line](https://trello.com/c/Ueda1EDd/640-release-notes-are-only-first-line)

### Context
When SLACK outputs a Release Note, it only presents the first line of the text, this is not adequate

### Changes proposed in this pull request
Change the github action to use Powershell and return a json string

### Guidance to review
No change to  application
