### PR TITLE
Explicitly send the candidate type_id on sign up

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 6c2969f0685d49b02527d2d499431498938c3a08
+  revision: fa632dc47559c4669328f0958d6838b64ad684ad
   specs:
-    get_into_teaching_api_client (1.1.10)
+    get_into_teaching_api_client (1.1.12)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.14)
+    get_into_teaching_api_client_faraday (0.1.16)
       activesupport
       faraday
       faraday-encoding
@@ -135,7 +135,7 @@ GEM
       activemodel (>= 5.2)
       activesupport (>= 5.2)
     htmlentities (4.3.4)
-    i18n (1.8.8)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     i18n_data (0.10.0)
     json (2.5.1)
@@ -153,7 +153,7 @@ GEM
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
-    minitest (5.14.3)
+    minitest (5.14.4)
     msgpack (1.4.2)
     multipart-post (2.1.1)
     nio4r (2.5.5)

--- a/app/models/teacher_training_adviser/steps/returning_teacher.rb
+++ b/app/models/teacher_training_adviser/steps/returning_teacher.rb
@@ -1,19 +1,10 @@
 module TeacherTrainingAdviser::Steps
   class ReturningTeacher < Wizard::Step
     OPTIONS = { returning_to_teaching: 222_750_001, interested_in_teaching: 222_750_000 }.freeze
-    DEGREE_OPTIONS = { returner: "returner" }.freeze
 
     attribute :type_id, :integer
-    attribute :degree_options, :string
 
     validates :type_id, pick_list_items: { method: :get_candidate_types }
-
-    def type_id=(value)
-      super
-      return unless value == OPTIONS[:returning_to_teaching]
-
-      self.degree_options = DEGREE_OPTIONS[:returner]
-    end
 
     def returning_to_teaching
       type_id == OPTIONS[:returning_to_teaching]

--- a/app/models/teacher_training_adviser/steps/returning_teacher.rb
+++ b/app/models/teacher_training_adviser/steps/returning_teacher.rb
@@ -1,17 +1,22 @@
 module TeacherTrainingAdviser::Steps
   class ReturningTeacher < Wizard::Step
+    OPTIONS = { returning_to_teaching: 222_750_001, interested_in_teaching: 222_750_000 }.freeze
     DEGREE_OPTIONS = { returner: "returner" }.freeze
 
-    attribute :returning_to_teaching, :boolean
+    attribute :type_id, :integer
     attribute :degree_options, :string
 
-    validates :returning_to_teaching, inclusion: { in: [true, false] }
+    validates :type_id, pick_list_items: { method: :get_candidate_types }
 
-    def returning_to_teaching=(value)
+    def type_id=(value)
       super
-      return unless returning_to_teaching
+      return unless value == OPTIONS[:returning_to_teaching]
 
       self.degree_options = DEGREE_OPTIONS[:returner]
+    end
+
+    def returning_to_teaching
+      type_id == OPTIONS[:returning_to_teaching]
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
@@ -6,7 +6,6 @@ module TeacherTrainingAdviser::Steps
 
     validates :preferred_education_phase_id, pick_list_items: { method: :get_candidate_preferred_education_phases }
 
-    PRIMARY_SUBJECT_ID = "b02655a1-2afa-e811-a981-000d3a276620".freeze
     OPTIONS = { primary: 222_750_000, secondary: 222_750_001 }.freeze
 
     def reviewable_answers

--- a/app/views/teacher_training_adviser/steps/_returning_teacher.html.erb
+++ b/app/views/teacher_training_adviser/steps/_returning_teacher.html.erb
@@ -1,4 +1,5 @@
-<%= f.govuk_radio_buttons_fieldset(:returning_to_teaching, legend: { text: 'Are you returning to teaching?'}, hint: { text: "If you have an overseas teaching qualification that's equivalent to our qualified teacher status (QTS), then select the 'yes' option and take the 'returning to teaching' route." }, inline: true) do %>
-  <%= f.govuk_radio_button :returning_to_teaching, true, label: { text: 'Yes' }, link_errors: true %>
-  <%= f.govuk_radio_button :returning_to_teaching, false, label: { text: 'No' } %>
+<% options = f.object.class::OPTIONS %>
+<%= f.govuk_radio_buttons_fieldset(:type_id, legend: { text: 'Are you returning to teaching?'}, hint: { text: "If you have an overseas teaching qualification that's equivalent to our qualified teacher status (QTS), then select the 'yes' option and take the 'returning to teaching' route." }, inline: true) do %>
+  <%= f.govuk_radio_button :type_id, options[:returning_to_teaching], label: { text: 'Yes' }, link_errors: true %>
+  <%= f.govuk_radio_button :type_id, options[:interested_in_teaching], label: { text: 'No' } %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,8 +176,8 @@ en:
               invalid_type: "You must select either primary or secondary"
         teacher_training_adviser/steps/returning_teacher:
           attributes:
-            returning_to_teaching:
-              inclusion: "Select yes if you are returning to teaching"
+            type_id:
+              invalid_type: "Select yes if you are returning to teaching"
         teacher_training_adviser/steps/retake_gcse_science:
           attributes:
             planning_to_retake_gcse_science_id:

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Sign up for a teacher training adviser", type: :feature do
-  PRIMARY_SUBJECT_ID = "b02655a1-2afa-e811-a981-000d3a276620".freeze
+  RETURNING_TO_TEACHING = 222_750_001
+  INTERESTED_IN_TEACHING = 222_750_000
   EDUCATION_PHASE_PRIMARY = 222_750_000
   EDUCATION_PHASE_SECONDARY = 222_750_001
   DEGREE_STATUS_HAS_DEGREE = 222_750_000
@@ -72,6 +73,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       check "Accept the privacy policy"
 
       request_attributes = uk_candidate_request_attributes({
+        type_id: RETURNING_TO_TEACHING,
         subject_taught_id: SUBJECT_PSYCHOLOGY,
         preferred_teaching_subject_id: SUBJECT_PHYSICS,
         teacher_id: "1234",
@@ -134,6 +136,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       check "Accept the privacy policy"
 
       request_attributes = overseas_candidate_request_attributes({
+        type_id: INTERESTED_IN_TEACHING,
         preferred_teaching_subject_id: SUBJECT_PHYSICS,
         degree_status_id: DEGREE_STATUS_HAS_DEGREE,
         degree_type_id: DEGREE_TYPE_EQUIVALENT,
@@ -214,6 +217,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       check "Accept the privacy policy"
 
       request_attributes = overseas_candidate_request_attributes({
+        type_id: INTERESTED_IN_TEACHING,
         uk_degree_grade_id: UK_DEGREE_GRADE_2_2,
         degree_status_id: DEGREE_STATUS_FIRST_YEAR,
         degree_type_id: DEGREE_TYPE_DEGREE,

--- a/spec/models/teacher_training_adviser/steps/has_teacher_id_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/has_teacher_id_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::HasTeacherId do
 
   describe "#skipped?" do
     it "returns false if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::ReturningTeacher).to receive(:returning_to_teaching) { true }
       expect(subject).to_not be_skipped
     end
 
     it "returns true if returning_to_teaching is false" do
-      wizardstore["returning_to_teaching"] = false
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::ReturningTeacher).to receive(:returning_to_teaching) { false }
       expect(subject).to be_skipped
     end
 

--- a/spec/models/teacher_training_adviser/steps/have_a_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/have_a_degree_spec.rb
@@ -43,12 +43,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::HaveADegree do
 
   describe "#skipped?" do
     it "returns false if returning_to_teaching is false" do
-      wizardstore["returning_to_teaching"] = false
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::ReturningTeacher).to receive(:returning_to_teaching) { false }
       expect(subject).to_not be_skipped
     end
 
     it "returns true if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::ReturningTeacher).to receive(:returning_to_teaching) { true }
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/returning_teacher_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/returning_teacher_spec.rb
@@ -5,30 +5,52 @@ RSpec.describe TeacherTrainingAdviser::Steps::ReturningTeacher do
   it_behaves_like "a wizard step"
 
   context "attributes" do
-    it { is_expected.to respond_to :returning_to_teaching }
+    it { is_expected.to respond_to :type_id }
     it { is_expected.to respond_to :degree_options }
   end
 
   describe "#returning_to_teaching" do
-    it { is_expected.to_not allow_values("", nil).for :returning_to_teaching }
-    it { is_expected.to allow_value(true, false).for :returning_to_teaching }
-  end
+    subject { instance.returning_to_teaching }
 
-  describe "#returning_to_teaching=" do
-    it "sets degree_options if returning_to_teaching is true" do
-      subject.returning_to_teaching = true
-      expect(subject.degree_options).to eq(TeacherTrainingAdviser::Steps::ReturningTeacher::DEGREE_OPTIONS[:returner])
+    context "when type_id is :returning_to_teaching" do
+      before { instance.type_id = described_class::OPTIONS[:returning_to_teaching] }
+      it { is_expected.to be_truthy }
     end
 
-    it "does not set degree_options if returning_to_teaching is false" do
-      subject.returning_to_teaching = false
+    context "when type_id is :interested_in_teaching" do
+      before { instance.type_id = described_class::OPTIONS[:interested_in_teaching] }
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe "#type_id" do
+    it { is_expected.to_not allow_values("", nil, 123).for :type_id }
+    it { is_expected.to allow_value(*described_class::OPTIONS.values).for :type_id }
+  end
+
+  describe "#type_id=" do
+    it "sets degree_options if type_id is :returning_to_teaching" do
+      subject.type_id = described_class::OPTIONS[:returning_to_teaching]
+      expect(subject.degree_options).to eq(described_class::DEGREE_OPTIONS[:returner])
+    end
+
+    it "does not set degree_options if type_id is :interested_in_teaching" do
+      subject.type_id = described_class::OPTIONS[:interested_in_teaching]
       expect(subject.degree_options).to be_nil
     end
   end
 
   describe "#reviewable_answers" do
     subject { instance.reviewable_answers }
-    before { instance.returning_to_teaching = true }
-    it { is_expected.to eq({ "returning_to_teaching" => "Yes" }) }
+
+    context "when returning to teaching" do
+      before { instance.type_id = described_class::OPTIONS[:returning_to_teaching] }
+      it { is_expected.to eq({ "returning_to_teaching" => "Yes" }) }
+    end
+
+    context "when interested in teaching" do
+      before { instance.type_id = described_class::OPTIONS[:interested_in_teaching] }
+      it { is_expected.to eq({ "returning_to_teaching" => "No" }) }
+    end
   end
 end

--- a/spec/models/teacher_training_adviser/steps/returning_teacher_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/returning_teacher_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe TeacherTrainingAdviser::Steps::ReturningTeacher do
 
   context "attributes" do
     it { is_expected.to respond_to :type_id }
-    it { is_expected.to respond_to :degree_options }
   end
 
   describe "#returning_to_teaching" do
@@ -26,18 +25,6 @@ RSpec.describe TeacherTrainingAdviser::Steps::ReturningTeacher do
   describe "#type_id" do
     it { is_expected.to_not allow_values("", nil, 123).for :type_id }
     it { is_expected.to allow_value(*described_class::OPTIONS.values).for :type_id }
-  end
-
-  describe "#type_id=" do
-    it "sets degree_options if type_id is :returning_to_teaching" do
-      subject.type_id = described_class::OPTIONS[:returning_to_teaching]
-      expect(subject.degree_options).to eq(described_class::DEGREE_OPTIONS[:returner])
-    end
-
-    it "does not set degree_options if type_id is :interested_in_teaching" do
-      subject.type_id = described_class::OPTIONS[:interested_in_teaching]
-      expect(subject.degree_options).to be_nil
-    end
   end
 
   describe "#reviewable_answers" do

--- a/spec/models/teacher_training_adviser/steps/review_answers_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/review_answers_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe TeacherTrainingAdviser::Steps::ReviewAnswers do
       TeacherTrainingAdviser::Steps::UkAddress => { "address_line1": "7 Main Street" },
       TeacherTrainingAdviser::Steps::UkTelephone => { "telephone": "123456789" },
       TeacherTrainingAdviser::Steps::HaveADegree => { "degree_options": "studying" },
-      TeacherTrainingAdviser::Steps::ReturningTeacher => { "returning_to_teaching": true },
+      TeacherTrainingAdviser::Steps::ReturningTeacher => {
+        "type_id": TeacherTrainingAdviser::Steps::ReturningTeacher::OPTIONS[:returning_to_teaching],
+      },
     }
   end
 

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
 
   describe "#skipped?" do
     it "returns false if returning_to_teaching is false" do
-      wizardstore["returning_to_teaching"] = false
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::ReturningTeacher).to receive(:returning_to_teaching) { false }
       expect(subject).to_not be_skipped
     end
 
     it "returns true if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::ReturningTeacher).to receive(:returning_to_teaching) { true }
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/subject_like_to_teach_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_like_to_teach_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::SubjectLikeToTeach do
 
   describe "#skipped?" do
     it "returns false if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::ReturningTeacher).to receive(:returning_to_teaching) { true }
       expect(subject).to_not be_skipped
     end
 
     it "returns true if returning_to_teaching is false" do
-      wizardstore["returning_to_teaching"] = false
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::ReturningTeacher).to receive(:returning_to_teaching) { false }
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/subject_not_found_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_not_found_spec.rb
@@ -8,19 +8,19 @@ RSpec.describe TeacherTrainingAdviser::Steps::SubjectNotFound do
 
   describe "#skipped?" do
     it "returns false if returning_to_teaching is true and preferred_teaching_subject_id is OTHER_SUBJECT_ID" do
-      wizardstore["returning_to_teaching"] = true
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::ReturningTeacher).to receive(:returning_to_teaching) { true }
       wizardstore["preferred_teaching_subject_id"] = TeacherTrainingAdviser::Steps::SubjectLikeToTeach::OTHER_SUBJECT_ID
       expect(subject).to_not be_skipped
     end
 
     it "returns true if returning_teacher is false" do
-      wizardstore["returning_to_teaching"] = false
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::ReturningTeacher).to receive(:returning_to_teaching) { false }
       wizardstore["preferred_teaching_subject_id"] = TeacherTrainingAdviser::Steps::SubjectLikeToTeach::OTHER_SUBJECT_ID
       expect(subject).to be_skipped
     end
 
     it "returns true if preferred_teaching_subject_id is not OTHER_SUBJECT_ID" do
-      wizardstore["returning_to_teaching"] = true
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::ReturningTeacher).to receive(:returning_to_teaching) { true }
       wizardstore["preferred_teaching_subject_id"] = "abc-123"
       expect(subject).to be_skipped
     end

--- a/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::SubjectTaught do
 
   describe "#skipped?" do
     it "returns false if returning_to_teaching is true" do
-      wizardstore["returning_to_teaching"] = true
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::ReturningTeacher).to receive(:returning_to_teaching) { true }
       expect(subject).to_not be_skipped
     end
 
     it "returns true if returning_to_teaching is false" do
-      wizardstore["returning_to_teaching"] = false
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::ReturningTeacher).to receive(:returning_to_teaching) { false }
       expect(subject).to be_skipped
     end
   end

--- a/spec/vcr/https_/get-into-teaching-api-dev_london_cloudapps_digital/api/pick_list_items/candidate/types.yml
+++ b/spec/vcr/https_/get-into-teaching-api-dev_london_cloudapps_digital/api/pick_list_items/candidate/types.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://get-into-teaching-api-dev.london.cloudapps.digital/api/pick_list_items/candidate/types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.3.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer 12c895a0a06347729ddeb19c6aa4dcb2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Wed, 24 Feb 2021 08:27:26 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '63'
+      connection:
+      - keep-alive
+      cache-control:
+      - private,max-age=300
+      etag:
+      - 9C7BEEC71835CBA685703D6135DA62B82E5926FB21DA3EA58A03C4E9628E38EC
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-vcap-request-id:
+      - 157ed920-6f1b-4713-5bfd-0501668c1a27
+    body:
+      encoding: UTF-8
+      string: '[{"id":222750000,"value":"ITT"},{"id":222750001,"value":"RTT"}]'
+  recorded_at: Wed, 24 Feb 2021 08:27:26 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
### Trello card

[Trello-1343](https://trello.com/c/FLYEKcpU/1343-improve-how-we-check-for-returning-teachers)

### Context

We currently do not send to the API if the candidate is a returning teacher vs interested in teaching. This means the logic to determine if a candidate is a returner in the API is a bit convoluted. The API now supports sending the candidate type explicitly, which will mean we can clean that logic up and also has the benefit of being able to pre-fill the "Are you returning to teaching?" step in the TTA service.

### Changes proposed in this pull request

- Update API client to include typd_id

- Update ReturningTeacher step to send type_id

In the past we haven't sent a specific attribute value in response to the `ReturningTeacher` step (the previous `returning_to_teaching` attribute was transient and only used to control the flow of the following wizard steps).

The API now accepts a `type_id` as part of the `TeacherTrainingAdviserSignUp` request model, so we will populate this on the `ReturningTeacher` step.

The existing `returning_to_teaching` attribute has been removed but a method that behaves the same takes its place, avoiding further refactoring (really it should be `returning_to_teaching?` but this PR is big enough so we can pick up that refactor later on).

- Remove degree_options from ReturningTeacher step

I think this is a layover from before we refactored the TTA service to use the wizard code in the GiT app. I can't see it referenced anywhere, so removing.

- Removes unused PRIMARY_SUBJECT_ID constant

### Guidance to review

