### PR TITLE
Circuit breaker redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ dump.rdb
 
 /config/credentials/*.key
 
+*.idea

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,17 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: fa632dc47559c4669328f0958d6838b64ad684ad
+  revision: 73e455e0f3fd17a2308c6fb0a2dde5f5985ee812
   specs:
     get_into_teaching_api_client (1.1.12)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.16)
+    get_into_teaching_api_client_faraday (0.1.17)
       activesupport
       faraday
       faraday-encoding
       faraday-http-cache
       faraday_middleware
+      faraday_middleware-circuit_breaker
       get_into_teaching_api_client
 
 GEM
@@ -126,6 +127,9 @@ GEM
     faraday-net_http (1.0.1)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
+    faraday_middleware-circuit_breaker (0.4.1)
+      faraday (>= 0.9, < 2.0)
+      stoplight (~> 2.1)
     ffi (1.14.2)
     foreman (0.87.2)
     globalid (0.4.2)
@@ -305,6 +309,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stoplight (2.2.1)
     thor (1.1.0)
     thread_safe (0.3.6)
     timeliness (0.4.4)

--- a/app/controllers/concerns/circuit_breaker.rb
+++ b/app/controllers/concerns/circuit_breaker.rb
@@ -1,0 +1,19 @@
+module CircuitBreaker
+  class NotAvailablePathMissingError < RuntimeError; end
+
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from GetIntoTeachingApiClient::CircuitBrokenError, with: :redirect_to_not_available
+  end
+
+protected
+
+  def redirect_to_not_available
+    redirect_to(not_available_path)
+  end
+
+  def not_available_path
+    raise NotAvailablePathMissingError, "#not_available_path hasn't been overridden"
+  end
+end

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -3,7 +3,7 @@ module WizardSteps
 
   included do
     class_attribute :wizard_class
-    before_action :load_wizard, :load_current_step, except: %i[index completed resend_verification]
+    before_action :load_wizard, :load_current_step, only: %i[show update]
   end
 
   def index

--- a/app/controllers/teacher_training_adviser/steps_controller.rb
+++ b/app/controllers/teacher_training_adviser/steps_controller.rb
@@ -1,10 +1,17 @@
 module TeacherTrainingAdviser
   class StepsController < ApplicationController
+    include CircuitBreaker
     include WizardSteps
     self.wizard_class = TeacherTrainingAdviser::Wizard
 
     around_action :set_time_zone, only: [:show] # rubocop:disable Rails/LexicallyScopedActionFilter
     before_action :set_page_title, only: [:show] # rubocop:disable Rails/LexicallyScopedActionFilter
+
+  protected
+
+    def not_available_path
+      teacher_training_adviser_not_available_path
+    end
 
   private
 

--- a/app/views/teacher_training_adviser/not_available.html.erb
+++ b/app/views/teacher_training_adviser/not_available.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-width-container">
+  <h1>Sorry, the adviser service is currently unavailable</h1>
+  <p>To sign up whilst this service is unavailable, you can call us on
+    <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a>
+  </p>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   root "pages#home"
 
+  get "/teacher_training_adviser/not_available", to: "teacher_training_adviser/steps#not_available"
+
   get "/404", to: "errors#not_found", via: :all
   get "/422", to: "errors#unprocessable_entity", via: :all
   get "/500", to: "errors#internal_server_error", via: :all

--- a/spec/requests/circuit_breaker_spec.rb
+++ b/spec/requests/circuit_breaker_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "Circuit breaker" do
+  let(:error) { GetIntoTeachingApiClient::CircuitBrokenError }
+
+  before do
+    allow_any_instance_of(
+      GetIntoTeachingApiClient::PickListItemsApi,
+    ).to receive(:get_qualification_degree_status).and_raise(error)
+  end
+
+  context "when the API returns a CircuitBrokenError" do
+    it "the TeacherTrainingAdviser::Steps controller redirects to an error page" do
+      get teacher_training_adviser_step_path(TeacherTrainingAdviser::Steps::StageOfDegree.key)
+      expect(response).to redirect_to(teacher_training_adviser_not_available_path)
+    end
+  end
+end


### PR DESCRIPTION
### Trello card
https://trello.com/c/e9vBMLJE

### Context
When repeated API failures occur, circuit breaker middleware in the Ruby client will raise a GetIntoTeachingApiClient::CircuitBrokenError. This is an attempt to reduce the impact of any future service failures.

### Changes proposed in this pull request
- Redirect to service unavailable page when there is a GetIntoTeachingApiClient::CircuitBrokenError
