### PR TITLE
Show telephone field on review answers step

### DIFF
--- a/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
@@ -4,6 +4,10 @@ module TeacherTrainingAdviser::Steps
 
     validates :telephone, telephone: true, presence: true
 
+    def self.contains_personal_details?
+      true
+    end
+
     def reviewable_answers
       {
         "telephone" => telephone,

--- a/app/models/teacher_training_adviser/steps/uk_callback.rb
+++ b/app/models/teacher_training_adviser/steps/uk_callback.rb
@@ -12,8 +12,13 @@ module TeacherTrainingAdviser::Steps
       self.telephone = telephone.to_s.strip.presence
     end
 
+    def self.contains_personal_details?
+      true
+    end
+
     def reviewable_answers
       {
+        "telephone" => telephone,
         "callback_date" => phone_call_scheduled_at&.to_date,
         "callback_time" => phone_call_scheduled_at&.to_time, # rubocop:disable Rails/Date
       }

--- a/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTimeZone do
 
   it { expect(described_class).to be TeacherTrainingAdviser::Steps::OverseasTimeZone }
 
+  it { expect(described_class).to be_contains_personal_details }
+
   context "attributes" do
     it { is_expected.to respond_to :telephone }
   end

--- a/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
   it_behaves_like "a wizard step"
   include_context "sanitize fields", %i[telephone]
 
+  it { expect(described_class).to be_contains_personal_details }
+
   context "attributes" do
     it { is_expected.to respond_to :phone_call_scheduled_at }
     it { is_expected.to respond_to :telephone }
@@ -41,19 +43,26 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
 
   describe "#reviewable_answers" do
     let(:date_time) { DateTime.new(2022, 1, 1, 10, 30) }
+    let(:telephone) { "123456789" }
     subject { instance.reviewable_answers }
-    before { instance.phone_call_scheduled_at = date_time }
+    before do
+      instance.phone_call_scheduled_at = date_time
+      instance.telephone = telephone
+    end
+
     it {
       is_expected.to eq({
         "callback_date" => date_time.to_date,
         "callback_time" => date_time.to_time, # rubocop:disable Rails/Date
+        "telephone" => telephone,
       })
     }
 
-    context "when the phone_call_scheduled_at is nil" do
+    context "when the phone_call_scheduled_at/telephone are nil" do
       let(:date_time) { nil }
+      let(:telephone) { nil }
 
-      it { is_expected.to eq({ "callback_date" => nil, "callback_time" => nil }) }
+      it { is_expected.to eq({ "callback_date" => nil, "callback_time" => nil, "telephone" => nil }) }
     end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-1369](https://trello.com/c/ZxF0ggqO/1369-telephone-not-visible-in-review-answers-page-when-equivalent-uk-based-candidate-books-callback)

### Context

The telephone field when filled in as part of the `OverseasTimezone` step was not presented under the personal details section; its now correctly located.

The `UkCallback` step has a mixture of personal/non-personal details and was only showing the non-personal (callback date/time) - it has been updated to render the telephone as well and the answers have been shifted into the personal details section.

Going forward it would make sense to split telephone/callback details into their own section perhaps (instead of trying to split a single steps answers across multiple sections when it contains a mixture of personal/non-personal details).

### Changes proposed in this pull request

- Show telephone field on review answers step

### Guidance to review

<img width="664" alt="Screenshot 2021-03-03 at 11 22 51" src="https://user-images.githubusercontent.com/29867726/109811305-8c544f80-7c22-11eb-8fd3-20aae00478d1.png">

