### PR TITLE
Added Secrets Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ dump.rdb
 /config/credentials/*.key
 
 *.idea
+fetch_config.rb

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+ifndef VERBOSE
+.SILENT:
+endif
+
+help:
+	echo "Secrets:"
+	echo "  This makefile gives the user the ability to safely display and edit azure secrets which are used by this project. "
+	echo ""
+	echo "Commands:"
+	echo "  edit-app-secrets  - Edit Application specific Secrets."
+	echo "  print-app-secrets - Display Application specific Secrets."
+	echo ""
+	echo "Parameters:"
+	echo "All commands take the parameter development|review|test|production"
+	echo ""
+	echo "Examples:"
+	echo ""
+	echo "To edit the Application secrets for Development"
+	echo "        make  development edit-app-secrets"
+	echo ""
+
+APPLICATION_SECRETS=TTA-KEYS
+
+.PHONY: development
+development:
+	$(eval export KEY_VAULT=s146d01-kv)
+	$(eval export AZ_SUBSCRIPTION=s146-getintoteachingwebsite-development)
+
+.PHONY: review
+review:
+	$(eval export KEY_VAULT=s146d01-kv)
+	$(eval export AZ_SUBSCRIPTION=s146-getintoteachingwebsite-development)
+
+.PHONY: test
+test:
+	$(eval export KEY_VAULT=s146t01-kv)
+	$(eval export AZ_SUBSCRIPTION=s146-getintoteachingwebsite-test)
+
+.PHONY: production
+production:
+	$(eval export KEY_VAULT=s146p01-kv)
+	$(eval export AZ_SUBSCRIPTION=s146-getintoteachingwebsite-production)
+
+set-azure-account: ${environment}
+	echo "Logging on to ${AZ_SUBSCRIPTION}"
+	az account set -s ${AZ_SUBSCRIPTION}
+
+install-fetch-config: 
+	[ ! -f fetch_config.rb ]  \
+	    && echo "Installing fetch_config.rb" \
+	    && curl -s https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/scripts/fetch_config/fetch_config.rb -o fetch_config.rb \
+	    && chmod +x fetch_config.rb \
+	    || true
+
+edit-app-secrets: install-fetch-config set-azure-account
+	./fetch_config.rb -s azure-key-vault-secret:${KEY_VAULT}/${APPLICATION_SECRETS} -e -d azure-key-vault-secret:${KEY_VAULT}/${APPLICATION_SECRETS} -f yaml -c
+
+print-app-secrets: install-fetch-config set-azure-account 
+	./fetch_config.rb -s azure-key-vault-secret:${KEY_VAULT}/${APPLICATION_SECRETS}  -f yaml


### PR DESCRIPTION
### Trello card
[Provide Method to Assist Developers with Secrets](https://trello.com/c/qqFKSJo6/1385-provide-method-to-assist-developers-with-secrets)

### Context
The DevOps team want the Developers to handle the Azure secrets in a standard way, and want to provide tooling to support this.

### Changes proposed in this pull request
Makefile added which provided commands to manage secrets

### Guidance to review
No changes to Application or Delivery

