### PR TITLE
Ignore cloudfront IPs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,9 @@ gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teachi
 
 gem "sentry-raven"
 
+# Ignore cloudfront IPs when getting customer IP address
+gem "actionpack-cloudfront"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,8 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actionpack-cloudfront (1.0.8)
+      rails (>= 4.2)
     actiontext (6.0.3.5)
       actionpack (= 6.0.3.5)
       activerecord (= 6.0.3.5)
@@ -347,6 +349,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-cloudfront
   bootsnap (>= 1.1.0)
   brakeman
   byebug

--- a/config/initializers/exclude_cloudfront_ips.rb
+++ b/config/initializers/exclude_cloudfront_ips.rb
@@ -1,0 +1,4 @@
+if Rails.env.preprod? || Rails.env.rolling?
+  require "cloud_front_ip_filter"
+  CloudFrontIpFilter.configure!
+end

--- a/lib/cloud_front_ip_filter.rb
+++ b/lib/cloud_front_ip_filter.rb
@@ -1,0 +1,25 @@
+class CloudFrontIpFilter
+  def self.configure!
+    Rack::Request.ip_filter = new(Rack::Request.ip_filter)
+  end
+
+  def initialize(original_filter = nil)
+    @original_filter = original_filter
+  end
+
+  def call(ip)
+    @original_filter.call(ip) || cloudfront_ip?(ip)
+  end
+
+private
+
+  def cloudfront_ip?(ip)
+    cloudfront_proxies.any? do |range|
+      range.include? ip
+    end
+  end
+
+  def cloudfront_proxies
+    ActionPack::Cloudfront::IpRanges.cloudfront_proxies
+  end
+end

--- a/spec/lib/cloud_front_ip_filter_spec.rb
+++ b/spec/lib/cloud_front_ip_filter_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+require "cloud_front_ip_filter"
+
+RSpec.describe CloudFrontIpFilter do
+  subject { described_class.new original }
+
+  let(:original) { ->(ip) { /192\.168\.1\./.match?(ip) } }
+
+  describe "#call" do
+    context "with private ips" do
+      it { expect(subject.call("192.168.1.10")).to be true }
+      it { expect(subject.call("192.168.2.10")).to be false }
+      it { expect(subject.call("192.168.1.1")).to be true }
+      it { expect(subject.call("192.168.1.254")).to be true }
+    end
+
+    context "with other ips" do
+      it { expect(subject.call("51.8.222.98")).to be false }
+    end
+
+    context "with cloudfront ips" do
+      it { expect(subject.call("15.207.13.128")).to be true }
+      it { expect(subject.call("15.207.13.254")).to be true }
+    end
+
+    context "with ips just outside cloudfronts ranges" do
+      it { expect(subject.call("15.207.13.1")).to be false }
+      it { expect(subject.call("15.207.13.127")).to be false }
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

https://trello.com/c/CvoMhTUe

### Context

We current (incorrectly) treat the IP address of the CloudFront proxy as the legitimate address of the request client. This is probably causing incorrect behaviour in the request throttling behaviour.

It is definitely breaking the Fail2ban behaviour, though that is not currently turned on in production - because of this issue.

### Changes proposed in this pull request

1. Replace the `Rack::Request.ip_filter` proc with a class (which responds to `call`) - that in turn checks against the original `ip_filter` plus the list of ip addresses provided by the `actionpack-cloudfront` gem. That gem in turn will download the list from amazon's JSON endpoint on boot, and fall back to a static copy of the file included in the gem.

### Guidance to review

This is a difficult one to test prior to it reaching production? Hence the monkey patches to only apply it on Staging for now - once its been tested in staging I'll send through a follow up PR to enable it in production.
