### PR TITLE
Removed debug data from ban message and disable fail2ban on DEV servers

### DIFF
--- a/.env.rolling
+++ b/.env.rolling
@@ -1,3 +1,2 @@
 # Add public environment variables here for the Rolling environment
 GIT_URL=https://get-into-teaching-app-dev.london.cloudapps.digital/
-FAIL2BAN=1

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -49,9 +49,6 @@ module Rack
               Raven.capture_message <<~BAN_MESSAGE
                 Banning IP: #{obscured_ip} for #{FAIL2BAN_TIME.to_i / 60} minutes
                 accessing #{req.path} with '#{req.query_string}'
-
-                REMOTE_ADDR: #{req.get_header('REMOTE_ADDR')}
-                X_FORWARDED_FOR: #{req.get_header('HTTP_X_FORWARDED_FOR')}
               BAN_MESSAGE
             end
           end


### PR DESCRIPTION
### Trello card

https://trello.com/c/CvoMhTUe

### Context

We now know that Fail2ban is working correctly so remove the debug data prior to deployment to production

### Changes proposed in this pull request

1. Disable in DEV environment (`Rails.env.rolling?`) because this is getting triggered by the OWASP scan
2. Remove the debug data from the message raised in sentry when we ban someone



