### PR TITLE
Bump API client to fix deprecation warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 73e455e0f3fd17a2308c6fb0a2dde5f5985ee812
+  revision: ea07b478ff51a4238c8f32e40859b2c6f890275b
   specs:
-    get_into_teaching_api_client (1.1.12)
+    get_into_teaching_api_client (1.1.13)
+      addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.17)
+    get_into_teaching_api_client_faraday (0.1.18)
       activesupport
       faraday
       faraday-encoding
@@ -132,7 +133,7 @@ GEM
     faraday_middleware-circuit_breaker (0.4.1)
       faraday (>= 0.9, < 2.0)
       stoplight (~> 2.1)
-    ffi (1.14.2)
+    ffi (1.15.0)
     foreman (0.87.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)


### PR DESCRIPTION
The API client had deprecation warnings for Ruby 2.7; these have since been fixed, so updating the app to pull in the new version.

I gave this a quick smoke test locally and it all seems fine.