### PR TITLE
Fix bug where NoDegree step is shown incorrectly

### DIFF
--- a/app/models/teacher_training_adviser/steps/no_degree.rb
+++ b/app/models/teacher_training_adviser/steps/no_degree.rb
@@ -5,7 +5,10 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
-      other_step(:have_a_degree).degree_options != HaveADegree::DEGREE_OPTIONS[:no]
+      have_a_degree_step = other_step(:have_a_degree)
+      have_degree = have_a_degree_step.degree_options != HaveADegree::DEGREE_OPTIONS[:no]
+
+      have_a_degree_step.skipped? || have_degree
     end
   end
 end

--- a/spec/models/teacher_training_adviser/steps/no_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/no_degree_spec.rb
@@ -7,13 +7,21 @@ RSpec.describe TeacherTrainingAdviser::Steps::NoDegree do
   it { is_expected.to_not be_can_proceed }
 
   describe "#skipped?" do
-    it "returns false if degree_options is no" do
+    it "returns false if degree_options is no and HaveADegree step was shown" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?) { false }
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:no]
       expect(subject).to_not be_skipped
     end
 
-    it "returns true if degree_options is not no" do
+    it "returns true if degree_options is not no and HaveADegree step was shown" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?) { false }
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if HaveADegree step is skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?) { true }
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:no]
       expect(subject).to be_skipped
     end
   end


### PR DESCRIPTION
### Trello card

[Trello-1405](https://trello.com/c/Ccwvwt0v/1405-bug-fix-no-degree-step-can-be-incorrectly-shown-on-returner-journey)

### Context

If a candidate initially starts their journey as a non-returner and then selects no degree we will show them the exit step informing them that they have to have a degree.

If they they go back and try to carry on as a returner they will see the same exit step. Instead, we should be ignoring their selected degree option when on the returner journey.

### Changes proposed in this pull request

- Fix bug where NoDegree step is shown incorrectly

### Guidance to review

