### PR TITLE
Update Sentry gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,8 @@ gem "country_select", "~> 5.0"
 # api client
 gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teaching-api-ruby-client", require: "api/client"
 
-gem "sentry-raven"
+gem "sentry-rails"
+gem "sentry-ruby"
 
 # Ignore cloudfront IPs when getting customer IP address
 gem "actionpack-cloudfront"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,8 +288,16 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (2.3.1)
-    sentry-raven (3.1.1)
+    sentry-rails (4.3.0)
+      rails (>= 5.0)
+      sentry-ruby-core (~> 4.3.0)
+    sentry-ruby (4.3.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.3.0)
+    sentry-ruby-core (4.3.0)
+      concurrent-ruby
+      faraday
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
     simplecov (0.21.2)
@@ -374,7 +382,8 @@ DEPENDENCIES
   rubocop-govuk
   scss_lint-govuk
   secure_headers
-  sentry-raven
+  sentry-rails
+  sentry-ruby
   shoulda-matchers
   simplecov (~> 0.21.2)
   spring

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,7 @@ private
   end
 
   def session_expired(exception)
-    Raven.capture_exception(exception)
+    Sentry.capture_exception(exception)
     redirect_to session_expired_path
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -46,7 +46,7 @@ module Rack
             if should_ban
               obscured_ip = req.ip.to_s.gsub(%r{\.\d+\.(\d+)\.}, ".***.***.")
 
-              Raven.capture_message <<~BAN_MESSAGE
+              Sentry.capture_message <<~BAN_MESSAGE
                 Banning IP: #{obscured_ip} for #{FAIL2BAN_TIME.to_i / 60} minutes
                 accessing #{req.path} with '#{req.query_string}'
               BAN_MESSAGE

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,4 +2,9 @@ Sentry.init do |config|
   if ENV["SENTRY_DSN"].blank? && Rails.application.credentials.sentry_dsn.present?
     config.dsn = Rails.application.credentials.sentry_dsn
   end
+
+  # Sentry::BackgroundWorker requires ActiveRecord, but we don't use it so
+  # we have to manually override async and send events synchronously (or they
+  # just disappear with no error!).
+  config.async = ->(event, hint) { Sentry.send(event, hint) }
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,4 @@
-Raven.configure do |config|
+Sentry.init do |config|
   if ENV["SENTRY_DSN"].blank? && Rails.application.credentials.sentry_dsn.present?
     config.dsn = Rails.application.credentials.sentry_dsn
   end

--- a/spec/requests/invalid_authenticity_token_spec.rb
+++ b/spec/requests/invalid_authenticity_token_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Invalid Authenticity Token", type: :request do
   before do
     ActionController::Base.allow_forgery_protection = true
-    allow(Raven).to receive(:capture_exception)
+    allow(Sentry).to receive(:capture_exception)
   end
 
   after do
@@ -16,7 +16,7 @@ RSpec.describe "Invalid Authenticity Token", type: :request do
       params = { "authenticity_token" => "expired", identity: identity_params }
       put teacher_training_adviser_step_path(:identity), params: params
       expect(response).to redirect_to session_expired_path
-      expect(Raven).to have_received(:capture_exception)
+      expect(Sentry).to have_received(:capture_exception)
     end
   end
 end


### PR DESCRIPTION
The `sentry-raven` gem we were using is deprecated/in maintenance mode. Sentry now have two gems that replace it (`sentry-ruby` and `sentry-rails`).

Update to new gems and migrate existing code (migration guide: https://docs.sentry.io/platforms/ruby/guides/rails/migration/)

The `Sentry::BackgroundWorker` sends events to Sentry async by default, using `ActiveRecord::Base.connection_pool`. We don't use `ActiveRecord` in the app, so this was failing silently with an `unrecognized constant ActiveRecord`. Instead of pulling in `ActiveRecord` just for this (which has its own difficulties as it tries to connect to a DB by default) we override the `async` handler to just send everything synchronously (which is how `sentry-raven` was working).