### PR TITLE
Bug fix callback scheduled for returner

### DIFF
--- a/app/models/teacher_training_adviser/steps/uk_callback.rb
+++ b/app/models/teacher_training_adviser/steps/uk_callback.rb
@@ -26,10 +26,11 @@ module TeacherTrainingAdviser::Steps
 
     def skipped?
       uk_address_skipped = other_step(:uk_address).skipped?
-      degree_options = other_step(:have_a_degree).degree_options
-      equivalent_degree = degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]
+      have_a_degree_step = other_step(:have_a_degree)
+      have_a_degree_skipped = have_a_degree_step.skipped?
+      equivalent_degree = have_a_degree_step.degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]
 
-      uk_address_skipped || !equivalent_degree
+      uk_address_skipped || have_a_degree_skipped || !equivalent_degree
     end
   end
 end

--- a/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
@@ -24,18 +24,23 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
   end
 
   describe "#skipped?" do
-    it "returns false if UkAddress step was shown and degree_options is equivalent" do
+    it "returns false if UkAddress/HaveADegree steps were shown and degree_options is equivalent" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?) { false }
       expect_any_instance_of(TeacherTrainingAdviser::Steps::UkAddress).to receive(:skipped?) { false }
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
       expect(subject).to_not be_skipped
     end
 
     it "returns true if UkAddress was skipped" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?) { false }
       expect_any_instance_of(TeacherTrainingAdviser::Steps::UkAddress).to receive(:skipped?) { true }
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
       expect(subject).to be_skipped
     end
 
     it "returns true if degree_options is not equivalent" do
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::UkAddress).to receive(:skipped?) { false }
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?) { false }
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       expect(subject).to be_skipped
     end


### PR DESCRIPTION
### Trello card

[Trello-1405](https://trello.com/c/Ccwvwt0v/1405-bug-fix-no-degree-step-can-be-incorrectly-shown-on-returner-journey)

### Context

If a candidate goes all the way through the equivalent degree/UK path and schedules a phone call, then edits the answer for 'are you returning to teaching' and proceeds down the returner path as a UK candidate we end up exporting their `phone_call_scheduled_at` value incorrectly and the request fails the API validation.

Instead, we should treat the `UkCallback` step as `skipped?` unless they are shown the `HaveADegree` step.

### Changes proposed in this pull request

- Bug fix callback scheduled for returner

### Guidance to review

