### PR TITLE
Enable Fail2Ban in production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -7,3 +7,4 @@ GOOGLE_AD_WORDS_ID=AW-1071004410
 TWITTER_ID=o0wo4
 GIT_URL=https://beta-getintoteaching.education.gov.uk/
 LID_ID=1
+FAIL2BAN=1


### PR DESCRIPTION
### Trello card

https://trello.com/c/CvoMhTUe

### Context

We want to discourage attack bots from scanning the site - this change will do a crude identification and ban bots accordingly.

The actual identification logic may need to be exanded in the future.

### Changes proposed in this pull request

Enable Fail2Ban in production

### Guidance to review

For now its only being enabled for the minimum timeframe - ie 1 minute
