### PR TITLE
Enable CloudFront IP filtering in production

### DIFF
--- a/config/initializers/exclude_cloudfront_ips.rb
+++ b/config/initializers/exclude_cloudfront_ips.rb
@@ -1,4 +1,6 @@
-if Rails.env.preprod? || Rails.env.rolling?
+# Don't load in dev or test environments
+# Mirrors behaviour of actionpack-cloudfront
+unless Rails.env.development? || Rails.env.test?
   require "cloud_front_ip_filter"
   CloudFrontIpFilter.configure!
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/CvoMhTUe

### Context

Enable cloudfront IP filtering in all environments.

### Changes proposed in this pull request

1. Only exclude cloudfront ip filtering in Dev and Test environments

### Guidance to review

This matches the behaviour of the actionpack-cloudfront gem
