### PR TITLE
Downgraded simplecov to a version supported by Sonarcloud

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ group :development, :test do
   # Testing framework
   gem "rspec-rails", "~> 4.1.0"
   gem "rspec-sonarqube-formatter", "~> 1.5"
-  gem "simplecov", "~> 0.21.2"
+  gem "simplecov", "~> 0.17.1" # held back - https://jira.sonarsource.com/browse/SONARSLANG-477
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", "~> 3.35"
   # Factory builder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,12 +300,11 @@ GEM
       faraday
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
-    simplecov (0.21.2)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.2)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     sixarm_ruby_unaccent (1.2.0)
     sort_alphabetical (1.1.0)
       unicode_utils (>= 1.2.2)
@@ -385,7 +384,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   shoulda-matchers
-  simplecov (~> 0.21.2)
+  simplecov (~> 0.17.1)
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data


### PR DESCRIPTION
### Trello card

https://trello.com/c/gabkUApE

### Context

We're no longer getting code coverage statistics in Sonarcloud

### Changes proposed in this pull request

1. Downgrade Simplecov to 0.17.x as a stopgap



