### PR TITLE
Include JSON code coverage report and use for sonarcloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
             rspec --format RspecSonarqubeFormatter --out /app/out/test-report.xml --format documentation
 
       - name: Fixup report file paths
-        run: sudo sed -i "s?\"/app/?\"${PWD}/?" coverage/.resultset.json
+        run: sudo sed -i "s?\"/app/?\"${PWD}/?" coverage/coverage.json
 
       - name:  Keep Code Coverage Report
         if: always()
@@ -189,7 +189,7 @@ jobs:
            -Dsonar.host.url=https://sonarcloud.io/
            -Dsonar.projectKey=get-teacher-training-adviser-service
            -Dsonar.testExecutionReportPaths=${PWD}/out/test-report.xml
-           -Dsonar.ruby.coverage.reportPaths=${PWD}/coverage/.resultset.json
+           -Dsonar.ruby.coverage.reportPaths=${PWD}/coverage/coverage.json
            -Dsonar.ruby.rubocop.reportPaths=${PWD}/out/rubocop-result.json
 
       - name: Trigger CVE Testing

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,12 +13,18 @@
 # it.
 
 require "simplecov"
+require "simplecov_json_formatter"
 require "active_support/testing/time_helpers"
 
 SimpleCov.start "rails" do
   add_filter "/bin/"
   add_filter "/db/"
   add_filter "/spec/"
+
+  formatter SimpleCov::Formatter::MultiFormatter.new [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::JSONFormatter,
+  ]
 end
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration


### PR DESCRIPTION
### Trello card

https://trello.com/c/gabkUApE

### Context

Simplecov is now capable of generating an 'official' json output - Sonarcloud should be using that instead of relying on the internal temporary json data.

### Changes proposed in this pull request

1. Added JSON formatter
2. Upload the 'official' `coverage.json` to sonarcloud instead of the private `.resultset.json`

### Guidance to review

According to https://jira.sonarsource.com/browse/SONARSLANG-477 this should now be working :crossed_fingers: 