### PR TITLE
Remove country_select gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,8 +39,6 @@ gem "redis"
 
 gem "prometheus-client"
 
-gem "country_select", "~> 5.0"
-
 # api client
 gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teaching-api-ruby-client", require: "api/client"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,13 +97,6 @@ GEM
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
-    countries (3.0.1)
-      i18n_data (~> 0.10.0)
-      sixarm_ruby_unaccent (~> 1.1)
-      unicode_utils (~> 1.4)
-    country_select (5.0.0)
-      countries (~> 3.0)
-      sort_alphabetical (~> 1.1)
     crass (1.0.6)
     diff-lcs (1.4.4)
     docile (1.3.5)
@@ -144,7 +137,6 @@ GEM
     htmlentities (4.3.4)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
-    i18n_data (0.10.0)
     json (2.5.1)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -298,9 +290,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
-    sixarm_ruby_unaccent (1.2.0)
-    sort_alphabetical (1.1.0)
-      unicode_utils (>= 1.2.2)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -321,7 +310,6 @@ GEM
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
-    unicode_utils (1.4.0)
     validates_timeliness (4.1.1)
       timeliness (>= 0.3.10, < 1)
     vcr (6.0.0)
@@ -356,7 +344,6 @@ DEPENDENCIES
   byebug
   canonical-rails
   capybara (~> 3.35)
-  country_select (~> 5.0)
   dotenv-rails
   factory_bot_rails
   foreman


### PR DESCRIPTION
It looks like we used to use this, probably before the API endpoint to get countries was available. There's no reference to it now so removing.