### PR TITLE
Update startpage content

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -15,7 +15,7 @@
             <li>writing your personal statement</li>
             <li>interview tips</li>
           </ul>
-          <h2 class ="govuk-heading-m"> Who can get an adviser?</h2>
+          <h2 class="govuk-heading-m">Who can get an adviser?</h2>
           <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, or an overseas qualification that is equivalent.</p>
           <p>You can get an adviser if you’re still studying for your degree. Before your final year, you can get advice and information for when you're ready to apply. If you're in your final year, you’ll need a predicted class 2:2 (honours) or higher.</p>
           <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession, you’ll need Qualified Teacher Status (QTS).</p>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -14,7 +14,7 @@
             <li>funding your course</li>
             <li>choosing the right training</li>
             <li>writing your personal statement</li>
-            <li>interview tips</li>
+            <li>interview tips</li> 
           </ul>
           <h2 class ="govuk-heading-m"> Who can get an adviser?</h2>
           <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, or an overseas qualification that is equivalent.</p>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -5,8 +5,7 @@
         <div class="govuk-grid-column-two-thirds">
           <h1 class="govuk-heading-l">Get an adviser</h1>
 
-          <p>If you want to become a teacher or return to teaching in England, a Teacher Training Adviser can guide you through the process with free one-to-one support.
-          </p>
+          <p>If you want to become a teacher or return to teaching in England, a Teacher Training Adviser can guide you through the process with free one-to-one support.</p>
           <p>Your adviser will help you with:</p>
           <ul>
             <li>getting school experience</li>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -4,36 +4,44 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <h1 class="govuk-heading-l">Get an adviser</h1>
-          <p>This service is for those who want to become a teacher in England.</p>
-          <p>To use this service you need to have one of the following:</p>
+   
+          <p>You can get one-on-one support from an experienced teacher.</p>
+          <p>If you want to become a teacher or return to teaching in England, an experienced teacher can guide you through the process.
+          </p>
+          <p>Your adviser will help you with:</p>
           <ul>
-            <li>a bachelor’s degree that is graded 2:2 class honours (or above)</li>
-            <li>a predicted grade for your degree that is 2:2 class honours (or above)</li>
-            <li>Qualified Teacher Status (QTS) that will enable you to return to teaching in England</li>
-            <li>an overseas qualification that is equivalent to a 2:2 class honours (or above)</li>
+            <li>getting school experience</li>
+            <li>funding your course</li>
+            <li>choosing the right training
+            </li>
+            <li>writing your personal statement
+            </li>
+            <li>interview tips
+            </li>
           </ul>
-          <p class="govuk-inset-text">If you're not in the final year of your degree, or wish to apply to teacher training at a future date, you can use this service to receive support and information for when you're ready to apply.</p>
-          <p>All our Teacher Training Advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training.</p>
-          <p>They will help you with:</p>
-          <ul>
-            <li>finding school experience</li>
-            <li>advice about teaching that is tailored to your needs</li>
-            <li>your application</li>
-            <li>finding national teaching events</li>
-          </ul>
-          <p>If you’re returning to teaching there are advisers who will help you with what you need to return to the profession.</p>
+          <h2 class ="govuk-heading-m"> Who can get an adviser?</h2>
+          <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, 
+          or an overseas qualification that is equivalent.</p>
+          <p>You can get an adviser if you’re still studying for your degree. 
+          You’ll need a predicted class 2:2 (honours) or higher. </p>
+          <p>If you’ve worked as a teacher before, and you’re thinking of 
+          returning to the profession, you’ll need Qualified Teacher Status (QTS).
+          </p>
+          
+          <a href="<%= teacher_training_adviser_step_path(:identity) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
+          Start now
+          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+          </svg>
+        </a>
+        
           <p class="govuk-body">There are teacher training options if you live in:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li><a href="https://teachinscotland.scot" class="govuk-link">Scotland</a></li>
             <li><a href="https://www.discoverteaching.wales/routes-into-teaching/" class="govuk-link">Wales</a></li>
             <li><a href="https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland" class="govuk-link">Northern Ireland</a></li>
           </ul>
-          <a href="<%= teacher_training_adviser_step_path(:identity) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
-            Start now
-            <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-              <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-            </svg>
-          </a>
+         
         </div>
       </div>
     </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -5,8 +5,8 @@
         <div class="govuk-grid-column-two-thirds">
           <h1 class="govuk-heading-l">Get an adviser</h1>
    
-          <p>You can get one-on-one support from an experienced teacher.</p>
-          <p>If you want to become a teacher or return to teaching in England, an experienced teacher can guide you through the process.
+          <p>You can get free one-on-one support from an experienced teacher.</p>
+          <p>If you want to become a teacher or return to teaching in England, a Teacher Training Adviser can guide you through the process.
           </p>
           <p>Your adviser will help you with:</p>
           <ul>
@@ -23,7 +23,7 @@
           <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, 
           or an overseas qualification that is equivalent.</p>
           <p>You can get an adviser if you’re still studying for your degree. 
-          You’ll need a predicted class 2:2 (honours) or higher. </p>
+          Before your final year, you can get advice and information for when you're ready to apply. If you're in your final year, you’ll need a predicted class 2:2 (honours) or higher. </p>
           <p>If you’ve worked as a teacher before, and you’re thinking of 
           returning to the profession, you’ll need Qualified Teacher Status (QTS).
           </p>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -5,43 +5,33 @@
         <div class="govuk-grid-column-two-thirds">
           <h1 class="govuk-heading-l">Get an adviser</h1>
    
-          <p>You can get free one-on-one support from an experienced teacher.</p>
+          <p>You can get free one-to-one support from an experienced teacher.</p>
           <p>If you want to become a teacher or return to teaching in England, a Teacher Training Adviser can guide you through the process.
           </p>
           <p>Your adviser will help you with:</p>
           <ul>
             <li>getting school experience</li>
             <li>funding your course</li>
-            <li>choosing the right training
-            </li>
-            <li>writing your personal statement
-            </li>
-            <li>interview tips
-            </li>
+            <li>choosing the right training</li>
+            <li>writing your personal statement</li>
+            <li>interview tips</li>
           </ul>
           <h2 class ="govuk-heading-m"> Who can get an adviser?</h2>
-          <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, 
-          or an overseas qualification that is equivalent.</p>
-          <p>You can get an adviser if you’re still studying for your degree. 
-          Before your final year, you can get advice and information for when you're ready to apply. If you're in your final year, you’ll need a predicted class 2:2 (honours) or higher. </p>
-          <p>If you’ve worked as a teacher before, and you’re thinking of 
-          returning to the profession, you’ll need Qualified Teacher Status (QTS).
-          </p>
-          
+          <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, or an overseas qualification that is equivalent.</p>
+          <p>You can get an adviser if you’re still studying for your degree. Before your final year, you can get advice and information for when you're ready to apply. You’ll need a predicted class 2:2 (honours) or higher.</p>
+          <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession, you’ll need Qualified Teacher Status (QTS).</p>
           <a href="<%= teacher_training_adviser_step_path(:identity) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
           </svg>
         </a>
-        
           <p class="govuk-body">There are teacher training options if you live in:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li><a href="https://teachinscotland.scot" class="govuk-link">Scotland</a></li>
             <li><a href="https://www.discoverteaching.wales/routes-into-teaching/" class="govuk-link">Wales</a></li>
             <li><a href="https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland" class="govuk-link">Northern Ireland</a></li>
           </ul>
-         
         </div>
       </div>
     </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -17,7 +17,7 @@
           </ul>
           <h2 class ="govuk-heading-m"> Who can get an adviser?</h2>
           <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, or an overseas qualification that is equivalent.</p>
-          <p>You can get an adviser if you’re still studying for your degree. Before your final year, you can get advice and information for when you're ready to apply. You’ll need a predicted class 2:2 (honours) or higher.</p>
+          <p>You can get an adviser if you’re still studying for your degree. Before your final year, you can get advice and information for when you're ready to apply. If you're in your final year, you’ll need a predicted class 2:2 (honours) or higher.</p>
           <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession, you’ll need Qualified Teacher Status (QTS).</p>
           <a href="<%= teacher_training_adviser_step_path(:identity) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
           Start now

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -14,7 +14,7 @@
             <li>funding your course</li>
             <li>choosing the right training</li>
             <li>writing your personal statement</li>
-            <li>interview tips</li> 
+            <li>interview tips</li>
           </ul>
           <h2 class ="govuk-heading-m"> Who can get an adviser?</h2>
           <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, or an overseas qualification that is equivalent.</p>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -4,9 +4,8 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <h1 class="govuk-heading-l">Get an adviser</h1>
-   
-          <p>You can get free one-to-one support from an experienced teacher.</p>
-          <p>If you want to become a teacher or return to teaching in England, a Teacher Training Adviser can guide you through the process.
+
+          <p>If you want to become a teacher or return to teaching in England, a Teacher Training Adviser can guide you through the process with free one-to-one support.
           </p>
           <p>Your adviser will help you with:</p>
           <ul>


### PR DESCRIPTION
### Trello card
https://trello.com/c/UBw5S7wu/586-review-content-on-welcome-page-for-tta-service

### Context
We have >30% drop out on the startpage of our GOV.UK styled Get an Adviser service. This may be due to the volume of copy we present, and its user friendliness.

### Changes proposed in this pull request

Updated copy:
- better value exchange of what the Get an Adviser service offers
- clearer copy on requirements and eligibility

### Guidance to review

Is this a sufficient improvement on previous copy? If so, deploy and analyse drop off rates.