### PR TITLE
Bump sentry-rails from 4.3.0 to 4.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,7 +280,7 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (2.3.1)
-    sentry-rails (4.3.0)
+    sentry-rails (4.3.1)
       rails (>= 5.0)
       sentry-ruby-core (~> 4.3.0)
     sentry-ruby (4.3.0)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,9 +2,4 @@ Sentry.init do |config|
   if ENV["SENTRY_DSN"].blank? && Rails.application.credentials.sentry_dsn.present?
     config.dsn = Rails.application.credentials.sentry_dsn
   end
-
-  # Sentry::BackgroundWorker requires ActiveRecord, but we don't use it so
-  # we have to manually override async and send events synchronously (or they
-  # just disappear with no error!).
-  config.async = ->(event, hint) { Sentry.send(event, hint) }
 end


### PR DESCRIPTION
Sentry has now removed its dependency on ActiveRecord so it works out of the box (we don't need the custom async handler).