### PR TITLE
Build from working cached build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,41 @@
-FROM ruby:2.6.6-alpine3.13
+FROM dfedigital/get-teacher-training-adviser-service:sha-936e09d
 
-ENV RAILS_ENV=production \
-    NODE_ENV=production \
-    RAILS_SERVE_STATIC_FILES=true \
-    RAILS_LOG_TO_STDOUT=true \
-    RACK_TIMEOUT_SERVICE_TIMEOUT=60 \
-    BUNDLE_WITHOUT=development
-
-RUN mkdir /app
-WORKDIR /app
-
-EXPOSE 3000
-ENTRYPOINT ["bundle", "exec"]
-CMD ["rails", "server" ]
-
-# hadolint ignore=DL3018
-RUN apk add --no-cache build-base tzdata git nodejs yarn
-
-# install NPM packages removign artifacts
-COPY package.json yarn.lock ./
-RUN yarn install && yarn cache clean
-
-# Install bundler
-RUN gem install bundler --version=2.2.8
+# ENV RAILS_ENV=production \
+#     NODE_ENV=production \
+#     RAILS_SERVE_STATIC_FILES=true \
+#     RAILS_LOG_TO_STDOUT=true \
+#     RACK_TIMEOUT_SERVICE_TIMEOUT=60 \
+#     BUNDLE_WITHOUT=development
 
 ARG APP_SHA
-RUN echo "${APP_SHA}" > /etc/get-teacher-training-adviser-service-sha
+
+# RUN mkdir /app
+# WORKDIR /app
+
+# EXPOSE 3000
+# ENTRYPOINT ["bundle", "exec"]
+# CMD ["rails", "server" ]
+
+# hadolint ignore=DL3018
+# RUN apk add --no-cache build-base tzdata git nodejs yarn
+
+# install NPM packages removign artifacts
+# COPY package.json yarn.lock ./
+# RUN yarn install && yarn cache clean
+
+# Install bundler
+# RUN gem install bundler --version=2.2.8
 
 # Install Gems removing artifacts
-COPY .ruby-version Gemfile Gemfile.lock ./
+# COPY .ruby-version Gemfile Gemfile.lock ./
 # hadolint ignore=SC2046
-RUN bundle install --jobs=$(nproc --all) && \
-    rm -rf /root/.bundle/cache && \
-    rm -rf /usr/local/bundle/cache
+# RUN bundle install --jobs=$(nproc --all) && \
+#     rm -rf /root/.bundle/cache && \
+#     rm -rf /usr/local/bundle/cache
 
 # Add code and compile assets
 COPY . .
 RUN bundle exec rake assets:precompile
+
+RUN echo "${APP_SHA}" > /etc/get-teacher-training-adviser-service-sha
+


### PR DESCRIPTION
### Trello card

https://trello.com/c/c4lViBfR

### Context

Builds are broken because they depend upon a no longer available mimemagic gem, and the docker cache has expired.

### Changes proposed in this pull request

1. Use the last working build as a cache source as a stop gap fix



