### PR TITLE
Only allow root page to be indexed

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,6 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 
 User-agent: *
+Allow: /$
 Disallow: /
 


### PR DESCRIPTION
We only want to allow the root page of the TTA service to be indexed by search engines.