### PR TITLE
Redirect beta domain to new prod domain

### DIFF
--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -1,0 +1,17 @@
+class RobotsController < ApplicationController
+  layout :none
+
+  # we're serving this from here rather than /public so we can apply any
+  # redirects from beta-beta-adviser-getintoteaching.education.gov.uk to
+  # adviser-getintoteaching.education.gov.uk - hopefully preventing any search
+  # engines from indexing the site under the beta domain
+  def show
+    render plain: <<~ROBOTS
+      User-agent: *
+      Allow: /$
+      Disallow: /
+
+      Sitemap: adviser-getintoteaching.education.gov.uk/sitemap.xml
+    ROBOTS
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,6 +52,7 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
+  config.x.enable_beta_redirects = false
 
   config.session_store :cache_store,
                        key: "_dfe_session",

--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -3,4 +3,5 @@ require File.expand_path("production.rb", __dir__)
 
 Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-test.london.cloudapps.digital"
+  config.x.enable_beta_redirects = false
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -107,6 +107,7 @@ Rails.application.configure do
   config.cache_store = :redis_cache_store, { namespace: "TTA" }
 
   config.x.git_api_endpoint = "https://get-into-teaching-api-prod.london.cloudapps.digital"
+  config.x.enable_beta_redirects = true
 
   config.session_store :cache_store,
                        key: "_dfe_session",

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -3,4 +3,5 @@ require File.expand_path("production.rb", __dir__)
 
 Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
+  config.x.enable_beta_redirects = false
 end

--- a/config/environments/userresearch.rb
+++ b/config/environments/userresearch.rb
@@ -3,6 +3,7 @@ require File.expand_path("production.rb", __dir__)
 
 Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
+  config.x.enable_beta_redirects = false
 
   Rack::Attack.enabled = false
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   get "/422", to: "errors#unprocessable_entity", via: :all
   get "/500", to: "errors#internal_server_error", via: :all
 
+  get "/robots.txt", to: "robots#show"
+
   namespace :teacher_training_adviser, path: "/teacher_training_adviser" do
     resources :steps,
               path: "/sign_up",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
+  if Rails.configuration.x.enable_beta_redirects
+    constraints(host: "beta-adviser-getintoteaching.education.gov.uk") do
+      get "/(*path)", to: redirect(host: "adviser-getintoteaching.education.gov.uk")
+    end
+  end
+
   root "pages#home"
 
   get "/teacher_training_adviser/not_available", to: "teacher_training_adviser/steps#not_available"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,0 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-
-User-agent: *
-Allow: /$
-Disallow: /
-

--- a/spec/requests/beta_redirect_spec.rb
+++ b/spec/requests/beta_redirect_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe "Redirecting beta-adviser-getintoteaching.education.gov.uk to adviser-getintoteaching.education.gov.uk", type: :request do
+  before { allow(Rails.configuration.x).to receive(:enable_beta_redirects).and_return(true) }
+  before { host!("beta-adviser-getintoteaching.education.gov.uk") }
+
+  it "redirects pages" do
+    get "/a-very-nice-page?something=value"
+
+    expect(response).to redirect_to("http://adviser-getintoteaching.education.gov.uk/a-very-nice-page?something=value")
+  end
+end

--- a/spec/requests/robots_spec.rb
+++ b/spec/requests/robots_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "Robots.txt", type: :request do
+  before { get "/robots.txt" }
+  subject { response.body }
+
+  it do
+    is_expected.to eq(
+      <<~ROBOTS,
+        User-agent: *
+        Allow: /$
+        Disallow: /
+
+        Sitemap: adviser-getintoteaching.education.gov.uk/sitemap.xml
+      ROBOTS
+    )
+  end
+end


### PR DESCRIPTION
- Redirect beta domain to new prod domain

We now have a non-beta production domain; all requests to the beta domain should be redirected.

- Serve robots.txt from Rails

We want to serve the robots.txt file from Rails so that we can intercept calls on the beta- domain and redirect them.