### PR TITLE
Add Postgres To TTA

### DIFF
--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -11,9 +11,14 @@ resource "cloudfoundry_app" "adviser_application" {
   memory       = 1024
   timeout      = 1000
   instances    = var.instances
-  service_binding {
-    service_instance = data.cloudfoundry_service_instance.redis.id
+
+  dynamic "service_binding" {
+    for_each = data.cloudfoundry_service_instance.linked
+    content {
+      service_instance = service_binding.value["id"]
+    }
   }
+
   dynamic "service_binding" {
     for_each = data.cloudfoundry_user_provided_service.logging
     content {

--- a/terraform/paas/data.tf
+++ b/terraform/paas/data.tf
@@ -1,9 +1,9 @@
-data azurerm_key_vault vault {
+data "azurerm_key_vault" "vault" {
   name                = var.azure_key_vault
   resource_group_name = var.azure_resource_group
 }
 
-data azurerm_key_vault_secret application {
+data "azurerm_key_vault_secret" "application" {
   key_vault_id = data.azurerm_key_vault.vault.id
   name         = "TTA-KEYS"
 }
@@ -12,42 +12,42 @@ locals {
   application_secrets = yamldecode(data.azurerm_key_vault_secret.application.value)
 }
 
-data azurerm_key_vault_secret docker_username {
+data "azurerm_key_vault_secret" "docker_username" {
   key_vault_id = data.azurerm_key_vault.vault.id
   name         = "DOCKER-USERNAME"
 }
 
-data azurerm_key_vault_secret docker_password {
+data "azurerm_key_vault_secret" "docker_password" {
   key_vault_id = data.azurerm_key_vault.vault.id
   name         = "DOCKER-PASSWORD"
 }
 
-data azurerm_key_vault_secret paas_username {
+data "azurerm_key_vault_secret" "paas_username" {
   key_vault_id = data.azurerm_key_vault.vault.id
   name         = "PAAS-USERNAME"
 }
 
-data azurerm_key_vault_secret paas_password {
+data "azurerm_key_vault_secret" "paas_password" {
   key_vault_id = data.azurerm_key_vault.vault.id
   name         = "PAAS-PASSWORD"
 }
 
-data azurerm_key_vault_secret statuscake_username {
+data "azurerm_key_vault_secret" "statuscake_username" {
   key_vault_id = data.azurerm_key_vault.vault.id
   name         = "SC-USERNAME"
 }
 
-data azurerm_key_vault_secret statuscake_password {
+data "azurerm_key_vault_secret" "statuscake_password" {
   key_vault_id = data.azurerm_key_vault.vault.id
   name         = "SC-PASSWORD"
 }
 
-data azurerm_key_vault_secret http_username {
+data "azurerm_key_vault_secret" "http_username" {
   key_vault_id = data.azurerm_key_vault.vault.id
   name         = "HTTP-USERNAME"
 }
 
-data azurerm_key_vault_secret http_password {
+data "azurerm_key_vault_secret" "http_password" {
   key_vault_id = data.azurerm_key_vault.vault.id
   name         = "HTTP-PASSWORD"
 }

--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -1,7 +1,7 @@
 paas_space                    = "get-into-teaching-production"
 paas_adviser_application_name = "get-teacher-training-adviser-service-prod"
 paas_adviser_route_name       = "get-teacher-training-adviser-service-prod"
-paas_redis_1_name             = "get-into-teaching-prod-redis-svc"
+paas_linked_services          = ["get-into-teaching-prod-redis-svc", "get-into-teaching-api-prod-pg-common-svc"]
 paas_additional_route_names   = ["beta-adviser-getintoteaching", "adviser-getintoteaching"]
 logging                       = 1
 additional_routes             = 1

--- a/terraform/paas/provider.tf
+++ b/terraform/paas/provider.tf
@@ -4,7 +4,7 @@ provider "cloudfoundry" {
   password = data.azurerm_key_vault_secret.paas_password.value
 }
 
-provider statuscake {
+provider "statuscake" {
   username = data.azurerm_key_vault_secret.statuscake_username.value
   apikey   = data.azurerm_key_vault_secret.statuscake_password.value
 }

--- a/terraform/paas/services.tf
+++ b/terraform/paas/services.tf
@@ -1,9 +1,7 @@
-data cloudfoundry_service redis {
-  name = "redis"
-}
 
-data "cloudfoundry_service_instance" "redis" {
-  name_or_id = var.paas_redis_1_name
+data "cloudfoundry_service_instance" "linked" {
+  for_each   = toset(var.paas_linked_services)
+  name_or_id = each.value
   space      = data.cloudfoundry_space.space.id
 }
 

--- a/terraform/paas/statuscake.tf
+++ b/terraform/paas/statuscake.tf
@@ -1,4 +1,4 @@
-resource statuscake_test alert {
+resource "statuscake_test" "alert" {
   for_each = var.alerts
 
   website_name  = each.value.website_name

--- a/terraform/paas/test.env.tfvars
+++ b/terraform/paas/test.env.tfvars
@@ -1,7 +1,7 @@
 paas_space                    = "get-into-teaching-test"
 paas_adviser_application_name = "get-teacher-training-adviser-service-test"
 paas_adviser_route_name       = "get-teacher-training-adviser-service-test"
-paas_redis_1_name             = "get-into-teaching-test-redis-svc"
+paas_linked_services          = ["get-into-teaching-test-redis-svc", "get-into-teaching-api-test-pg-common-svc"]
 paas_additional_route_names   = ["staging-adviser-getintoteaching"]
 logging                       = 1
 alerts                        = {}

--- a/terraform/paas/ur.env.tfvars
+++ b/terraform/paas/ur.env.tfvars
@@ -1,7 +1,7 @@
 paas_space                    = "get-into-teaching-test"
 paas_adviser_application_name = "get-teacher-training-adviser-service-ur"
 paas_adviser_route_name       = "get-teacher-training-adviser-service-ur"
-paas_redis_1_name             = "get-into-teaching-test-redis-svc"
+paas_linked_services          = ["get-into-teaching-test-redis-svc", "get-into-teaching-api-test-pg-common-svc"]
 logging                       = 0
 alerts                        = {}
 azure_key_vault               = "s146t01-kv"

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -2,13 +2,13 @@
 # or set with environment variables TF_VAR_xxxx
 
 
-variable api_url {
+variable "api_url" {
   default = "https://api.london.cloud.service.gov.uk"
 }
 
-variable AZURE_CREDENTIALS {}
-variable azure_key_vault {}
-variable azure_resource_group {}
+variable "AZURE_CREDENTIALS" {}
+variable "azure_key_vault" {}
+variable "azure_resource_group" {}
 
 variable "application_stopped" {
   default = false
@@ -34,8 +34,9 @@ variable "paas_logging_endpoint_port" {
   default = ""
 }
 
-variable "paas_redis_1_name" {
-  default = "get-into-teaching-dev-redis-svc"
+variable "paas_linked_services" {
+  default = ["get-into-teaching-dev-redis-svc"
+  , "get-into-teaching-api-dev-pg-common-svc"]
 }
 
 variable "paas_space" {
@@ -63,5 +64,5 @@ variable "paas_additional_route_names" {
 }
 
 variable "alerts" {
-  type = map
+  type = map(any)
 }


### PR DESCRIPTION
##  [Trello](https://trello.com/c/fnHpXkZt/1514-add-postgres-to-tta-service)

Allow the TTA service access to the Postgres DB

### Changes

- Renamed the variable for linking the redis service to be more generic and made it a list
- Terraform now collects data from the list
- Terraform now attaches the list of service_ids to the application

### Review 
This does not impact the application
The latest version of `terraform fmt` has got fussy and made a few format changes.

