### PR TITLE
Log to Sentry when CircuitBrokenError is thrown in client Gem

### DIFF
--- a/app/controllers/concerns/circuit_breaker.rb
+++ b/app/controllers/concerns/circuit_breaker.rb
@@ -4,7 +4,10 @@ module CircuitBreaker
   extend ActiveSupport::Concern
 
   included do
-    rescue_from GetIntoTeachingApiClient::CircuitBrokenError, with: :redirect_to_not_available
+    rescue_from GetIntoTeachingApiClient::CircuitBrokenError do |exception|
+      Sentry.capture_exception(exception)
+      redirect_to_not_available
+    end
   end
 
 protected

--- a/spec/requests/circuit_breaker_spec.rb
+++ b/spec/requests/circuit_breaker_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "Circuit breaker" do
     allow_any_instance_of(
       GetIntoTeachingApiClient::PickListItemsApi,
     ).to receive(:get_qualification_degree_status).and_raise(error)
+
+    expect(Sentry).to receive(:capture_exception).with(error)
   end
 
   context "when the API returns a CircuitBrokenError" do


### PR DESCRIPTION
### Trello card
https://trello.com/c/Z9YPUZ5Q

### Context
The API client will raise a CircuitBrokenError if there are repeated API failures. See PR [here](https://github.com/DFE-Digital/get-into-teaching-api-ruby-client/pull/37)

When this happens, the error should be logged to Sentry

### Changes proposed in this pull request
- Log to Sentry when CircuitBrokenError is raised in the client Gem