### PR TITLE
Add invisible captcha protection to feedback form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,8 @@ gem "sentry-ruby"
 # Ignore cloudfront IPs when getting customer IP address
 gem "actionpack-cloudfront"
 
+gem "invisible_captcha"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,8 @@ GEM
     htmlentities (4.3.4)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    invisible_captcha (2.0.0)
+      rails (>= 5.0)
     json (2.5.1)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -361,6 +363,7 @@ DEPENDENCIES
   foreman
   get_into_teaching_api_client_faraday!
   govuk_design_system_formbuilder
+  invisible_captcha
   listen (>= 3.0.5, < 3.6)
   pg
   prometheus-client

--- a/app/controllers/teacher_training_adviser/feedbacks_controller.rb
+++ b/app/controllers/teacher_training_adviser/feedbacks_controller.rb
@@ -1,5 +1,7 @@
 module TeacherTrainingAdviser
   class FeedbacksController < ApplicationController
+    invisible_captcha only: [:create], timestamp_threshold: 1.second
+
     def new
       @page_title = "Give feedback on this service"
       @feedback = Feedback.new

--- a/app/views/teacher_training_adviser/feedbacks/new.html.erb
+++ b/app/views/teacher_training_adviser/feedbacks/new.html.erb
@@ -26,6 +26,8 @@
                 </p>
               <% end %>
 
+              <%= invisible_captcha %>
+
               <%= f.govuk_submit "Submit feedback" %>
             <% end %>
         </div>

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,5 @@
+InvisibleCaptcha.setup do |config|
+  # Only enable in production so our automated integration
+  # tests don't fail.
+  config.timestamp_enabled = Rails.env.production?
+end

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -17,4 +17,17 @@ RSpec.feature "Feedback", type: :feature do
 
     expect(page).to have_text "Thank you"
   end
+
+  scenario "a bot submitting feedback (filling in the honeypot)" do
+    visit new_teacher_training_adviser_feedback_path
+
+    choose "Yes"
+    choose "Satisfied"
+    fill_in "If you are a human, ignore this field", with: "i-am-a-bot"
+
+    click_on "Submit feedback"
+
+    expect(page.status_code).to eq(200)
+    expect(page.body).to eq("")
+  end
 end


### PR DESCRIPTION
### Trello card

[Trello-1406](https://trello.com/c/HrLZDKvi/1406-create-new-feedback-form-for-tta-service)

### Context

At the moment a bot could easily submit the feedback form; we want to prevent that so that we only get authentic submissions from candidates.

Add `invisible_captcha` gem, which puts three forms of protection onto the page:

- A hidden honey pot field (if filled in the submission is rejected).
- A 'spinner' field (if modified the submission is rejected).
- A minimum submission time (too-fast submissions are rejected).

If a submission is rejected we render a HEAD 200 response, which should be enough to make the bot think it was successful/hopefully it then moves on.

### Changes proposed in this pull request

- Add invisible captcha protection to feedback form

### Guidance to review

You can manually trigger the bot protection by filling in the honey pot field before submitting.
