### PR TITLE
Minor follow up tweaks to CSV exporting

### DIFF
--- a/app/models/teacher_training_adviser/feedback_search.rb
+++ b/app/models/teacher_training_adviser/feedback_search.rb
@@ -9,7 +9,7 @@ module TeacherTrainingAdviser
     include ::ActiveRecord::AttributeAssignment
 
     attribute :created_on_or_after, :date, default: -> { Time.zone.now.beginning_of_month.utc }
-    attribute :created_on_or_before, :date, default: -> { Time.zone.now.utc }
+    attribute :created_on_or_before, :date, default: -> { Time.zone.now.end_of_day.utc }
 
     validates :created_on_or_after, presence: true
     validates :created_on_or_before, presence: true
@@ -17,7 +17,7 @@ module TeacherTrainingAdviser
       on_or_before: :created_on_or_before,
     }
     validates :created_on_or_before, timeliness: {
-      on_or_before: Time.zone.now.utc,
+      on_or_before: Time.zone.now.end_of_day.utc,
     }
 
     def range

--- a/lib/teacher_training_adviser/feedback_exporter.rb
+++ b/lib/teacher_training_adviser/feedback_exporter.rb
@@ -10,6 +10,7 @@ module TeacherTrainingAdviser
       improvements
       created_at
     ].freeze
+    CSV_INJECT_CHARS = %w[+ - @ =].freeze
 
     def initialize(feedback)
       @feedback = feedback
@@ -22,7 +23,20 @@ module TeacherTrainingAdviser
           csv << f.attributes
             .select { |k, _| EXPORTABLE_ATTRS.include?(k) }
             .values
+            .map { |v| escape_csv_value(v) }
         end
+      end
+    end
+
+  private
+
+    def escape_csv_value(value)
+      str_value = value.to_s.strip
+
+      if CSV_INJECT_CHARS.include?(str_value.chars.first)
+        "'#{str_value}"
+      else
+        str_value
       end
     end
   end

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "Feedback", type: :feature do
     expect(page.body).to eq(
       <<~CSV,
         id,rating,successful_visit,unsuccessful_visit_explanation,improvements,created_at
-        #{feedback.id},satisfied,true,,,#{feedback.created_at}
+        #{feedback.id},satisfied,true,"","",#{feedback.created_at}
       CSV
     )
   end

--- a/spec/lib/teacher_training_adviser/feedback_exporter_spec.rb
+++ b/spec/lib/teacher_training_adviser/feedback_exporter_spec.rb
@@ -4,7 +4,7 @@ require "teacher_training_adviser/feedback_exporter"
 RSpec.describe TeacherTrainingAdviser::FeedbackExporter do
   let(:feedback) do
     [
-      create(:feedback, rating: :very_satisfied, successful_visit: true, improvements: "do better"),
+      create(:feedback, rating: :very_satisfied, successful_visit: true, improvements: " =cmd|' /C notepad'!'A1'"),
       create(:feedback, rating: :very_dissatisfied, successful_visit: false, unsuccessful_visit_explanation: "wasn't good"),
       create(:feedback, rating: :satisfied, successful_visit: true),
     ]
@@ -18,9 +18,9 @@ RSpec.describe TeacherTrainingAdviser::FeedbackExporter do
       is_expected.to eq(
         <<~CSV,
           id,rating,successful_visit,unsuccessful_visit_explanation,improvements,created_at
-          #{feedback[0].id},very_satisfied,true,,do better,#{feedback[0].created_at}
-          #{feedback[1].id},very_dissatisfied,false,wasn't good,,#{feedback[1].created_at}
-          #{feedback[2].id},satisfied,true,,,#{feedback[2].created_at}
+          #{feedback[0].id},very_satisfied,true,"",'=cmd|' /C notepad'!'A1',#{feedback[0].created_at}
+          #{feedback[1].id},very_dissatisfied,false,wasn't good,"",#{feedback[1].created_at}
+          #{feedback[2].id},satisfied,true,"","",#{feedback[2].created_at}
         CSV
       )
     end

--- a/spec/models/teacher_training_adviser/feedback_search_spec.rb
+++ b/spec/models/teacher_training_adviser/feedback_search_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TeacherTrainingAdviser::FeedbackSearch do
     it { is_expected.to validate_presence_of(:created_on_or_before) }
     it { is_expected.to validate_presence_of(:created_on_or_after) }
     it { is_expected.to allow_value(Time.zone.now.utc, 1.day.ago).for :created_on_or_before }
-    it { is_expected.to_not allow_value(1.day.from_now).for :created_on_or_before }
+    it { is_expected.to_not allow_value(2.days.from_now).for :created_on_or_before }
 
     context "when created_on_or_before is 5/2/2020" do
       before { subject.created_on_or_before = Date.new(2020, 2, 5) }
@@ -31,7 +31,7 @@ RSpec.describe TeacherTrainingAdviser::FeedbackSearch do
   describe "#created_on_or_before" do
     subject { instance.created_on_or_before }
 
-    it { is_expected.to eq(Time.zone.now.utc.to_date) }
+    it { is_expected.to eq(Time.zone.now.end_of_day.utc.to_date) }
   end
 
   describe "#range" do

--- a/spec/requests/basic_auth_spec.rb
+++ b/spec/requests/basic_auth_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe "Basic auth", type: :request do
   let(:password) { "password" }
 
   before do
-    allow(Rails.application.credentials.config).to receive(:[]).and_call_original
-    allow(Rails.application.credentials.config).to receive(:[]).with(:http_auth) { "#{username}=#{password}" }
+    allow_basic_auth_users([{ username: username, password: password }])
   end
 
   it "is not enforced on non-production environments" do
@@ -15,7 +14,7 @@ RSpec.describe "Basic auth", type: :request do
   end
 
   context "when production" do
-    before { allow(Rails.env).to receive(:production?) { true } }
+    before { allow(Rails).to receive(:env) { "production".inquiry } }
 
     it "is not enforced" do
       get root_path
@@ -24,11 +23,7 @@ RSpec.describe "Basic auth", type: :request do
   end
 
   context "when production-like (but not production)" do
-    before do
-      allow(Rails.env).to receive(:test?) { false }
-      allow(Rails.env).to receive(:development?) { false }
-      allow(Rails.env).to receive(:production?) { false }
-    end
+    before { allow(Rails).to receive(:env) { "rolling".inquiry } }
 
     it "returns unauthorized if credentials do not match" do
       get root_path, params: {}, headers: basic_auth_headers(username, "wrong-password")

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -149,10 +149,11 @@ RSpec.describe "Feedback" do
   describe "actions requiring basic auth" do
     context "when not dev/test environment" do
       before do
-        allow(Rails.env).to receive(:development?) { false }
-        allow(Rails.env).to receive(:test?) { false }
-        allow(Rails.application.credentials.config).to receive(:[]).and_call_original
-        allow(Rails.application.credentials.config).to receive(:[]).with(:http_auth) { "feedback=password1,user=password2" }
+        allow(Rails).to receive(:env) { "production".inquiry }
+        allow_basic_auth_users([
+          { username: "feedback", password: "password1" },
+          { username: "user", password: "password2" },
+        ])
       end
 
       describe "#index" do

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -108,9 +108,9 @@ RSpec.describe "Feedback" do
       is_expected.to eq(
         <<~CSV,
           id,rating,successful_visit,unsuccessful_visit_explanation,improvements,created_at
-          #{feedback[2].id},satisfied,true,,,#{feedback[2].created_at}
-          #{feedback[1].id},very_dissatisfied,true,,,#{feedback[1].created_at}
-          #{feedback[0].id},very_satisfied,true,,,#{feedback[0].created_at}
+          #{feedback[2].id},satisfied,true,"","",#{feedback[2].created_at}
+          #{feedback[1].id},very_dissatisfied,true,"","",#{feedback[1].created_at}
+          #{feedback[0].id},very_satisfied,true,"","",#{feedback[0].created_at}
         CSV
       )
     end

--- a/spec/support/spec_helpers/basic_auth.rb
+++ b/spec/support/spec_helpers/basic_auth.rb
@@ -1,5 +1,13 @@
 module SpecHelpers
   module BasicAuth
+    def allow_basic_auth_users(credentials = [])
+      allow(::BasicAuth).to receive(:authenticate) { false }
+
+      credentials.each do |c|
+        allow(::BasicAuth).to receive(:authenticate).with(c[:username], c[:password]) { true }
+      end
+    end
+
     def basic_auth_headers(username, password)
       value = ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
       { "HTTP_AUTHORIZATION" => value }


### PR DESCRIPTION
### Trello card

[Trello-1406](https://trello.com/c/HrLZDKvi/1406-create-new-feedback-form-for-tta-service)

### Context

A CSV cell that begins with `+`, `-`, `@` or `=` could contain malicious formula. To prevent CSV injection these cells must be prefixed with a `'`.

I noticed that in the review environment a validation error was occurring when the "Created on or before" date defaults to today; I think this is because the current time is being compared in the validation conditional, even though I couldn't replicate it locally. Updating to be `end_of_day` to see if that resolves it.

### Changes proposed in this pull request

- Escape CSV injection payloads
- Tweak created_on_or_before validation to be looser
- Prevent flakiness in environment tests

We're seeing flakiness around the tests against `BasicAuth` due to the credentials being memoized in a class variable and not cleared between runs.

Add helper to mock `BasicAuth.authenticate`, which bypasses the memoized credentials.

### Guidance to review

