### PR TITLE
Only restrict access on certain feedback actions

### DIFF
--- a/app/controllers/teacher_training_adviser/feedbacks_controller.rb
+++ b/app/controllers/teacher_training_adviser/feedbacks_controller.rb
@@ -51,7 +51,8 @@ module TeacherTrainingAdviser
     end
 
     def restrict_access
-      raise_forbidden if session[:username] != "feedback"
+      raise_forbidden if RESTRICTED_ACTIONS.include?(action_name) &&
+        session[:username] != "feedback"
     end
 
   protected


### PR DESCRIPTION
We are correctly prompting for the basic auth now, but incorrectly showing a forbidden page on rolling/pre-prod for actions a regular user should be able to do.

Take into account the `action_name` when restricting access in addition to determining if we should prompt for authentication.