### PR TITLE
Lowercase 'teacher training advisers'

### DIFF
--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -8,7 +8,7 @@
             </p>
             <p>
                 The information below shows the cookies that are set by <a href="https://www.gov.uk/government/organisations/department-for-education" target="_blank" rel="noopener noreferrer">education.gov.uk<span class="govuk-visually-hidden">(Link opens in new
-            window)</span> <i class="fas fa-external-link-alt"></i></a> and the third-party services we use. At the header and footer of this page, you can change your preferences at any time for marketing cookies. 
+            window)</span> <i class="fas fa-external-link-alt"></i></a> and the third-party services we use. At the header and footer of this page, you can change your preferences at any time for marketing cookies.
             </p>
 
             <h3>1. Functional cookies</h3>
@@ -47,7 +47,7 @@
             </p>
 
             <h3>2. Non-functional cookies</h3>
-            <p>These cookies allow us to provide a more enhanced service and help us to learn what content our users like or don’t like, so we can make the service even better. they also help us to provide you with personalised content and teaching-related advertisements to help you with your consideration of Initial Teacher Training and returning to teaching . Whilst these cookies don’t collect your name or address, they do collect a unique user identifier code, which is linked to your device.</p>
+            <p>These cookies allow us to provide a more enhanced service and help us to learn what content our users like or don’t like, so we can make the service even better. they also help us to provide you with personalised content and teaching-related advertisements to help you with your consideration of Initial Teacher Training and returning to teaching. Whilst these cookies don’t collect your name or address, they do collect a unique user identifier code, which is linked to your device.</p>
             <p>The types of non-functional cookies we set are:</p>
 
             <h3>Website usage</h3>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -5,7 +5,7 @@
         <div class="govuk-grid-column-two-thirds">
           <h1 class="govuk-heading-l">Get an adviser</h1>
 
-          <p>If you want to become a teacher or return to teaching in England, a Teacher Training Adviser can guide you through the process with free one-to-one support.</p>
+          <p>If you want to become a teacher or return to teaching in England, a teacher training adviser can guide you through the process with free one-to-one support.</p>
           <p>Your adviser will help you with:</p>
           <ul>
             <li>getting school experience</li>


### PR DESCRIPTION
As 'teacher training advisers' isn't a service name it should be lower case. This change brings this application in line with the app and content repos.
