### PR TITLE
Add preset labels to all custom metrics

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+VCAP_APPLICATION="{\"application_name\": \"app-name\",\"space_name\": \"space-name\",\"organization_name\": \"org-name\"}"

--- a/config/initializers/01_vcap.rb
+++ b/config/initializers/01_vcap.rb
@@ -1,0 +1,7 @@
+if ENV["VCAP_SERVICES"].present?
+  Rails.application.config.x.vcap_services = JSON.parse(ENV["VCAP_SERVICES"])
+end
+
+if ENV["VCAP_APPLICATION"].present?
+  Rails.application.config.x.vcap_app = JSON.parse(ENV["VCAP_APPLICATION"])
+end

--- a/config/initializers/01_vcap_services.rb
+++ b/config/initializers/01_vcap_services.rb
@@ -1,3 +1,0 @@
-if ENV["VCAP_SERVICES"].present?
-  Rails.application.config.x.vcap_services = JSON.parse(ENV["VCAP_SERVICES"])
-end

--- a/lib/prometheus/metrics.rb
+++ b/lib/prometheus/metrics.rb
@@ -1,59 +1,76 @@
 module Prometheus
   module Metrics
+    def self.preset_labels
+      {
+        app: Rails.application.config.x.vcap_app["application_name"],
+        organisation: Rails.application.config.x.vcap_app["organization_name"],
+        space: Rails.application.config.x.vcap_app["space_name"],
+      }
+    end
+
     prometheus = Prometheus::Client.registry
 
     prometheus.counter(
       :tta_requests_total,
       docstring: "A counter of requests",
-      labels: %i[path method status],
+      labels: %i[path method status] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.histogram(
       :tta_request_duration_ms,
       docstring: "A histogram of request durations",
-      labels: %i[path method status],
+      labels: %i[path method status] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.histogram(
       :tta_request_view_runtime_ms,
       docstring: "A histogram of request view runtimes",
-      labels: %i[path method status],
+      labels: %i[path method status] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.histogram(
       :tta_render_view_ms,
       docstring: "A histogram of view rendering times",
-      labels: %i[identifier],
+      labels: %i[identifier] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.histogram(
       :tta_render_partial_ms,
       docstring: "A histogram of partial rendering times",
-      labels: %i[identifier],
+      labels: %i[identifier] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.counter(
       :tta_cache_read_total,
       docstring: "A counter of cache reads",
-      labels: %i[key hit],
+      labels: %i[key hit] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.counter(
       :tta_csp_violations_total,
       docstring: "A counter of CSP violations",
-      labels: %i[blocked_uri document_uri violated_directive],
+      labels: %i[blocked_uri document_uri violated_directive] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.counter(
       :tta_feedback_visit_total,
       docstring: "A counter of feedback visit responses",
-      labels: %i[successful],
+      labels: %i[successful] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.counter(
       :tta_feedback_rating_total,
       docstring: "A counter of feedback rating responses",
-      labels: %i[rating],
+      labels: %i[rating] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
   end
 end

--- a/spec/lib/metrics_spec.rb
+++ b/spec/lib/metrics_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of request durations") }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
     it { expect { subject.get(labels: %i[path method status]) }.to_not raise_error }
   end
 
@@ -24,6 +25,7 @@ RSpec.describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of request view runtimes") }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
     it { expect { subject.get(labels: %i[path method status]) }.to_not raise_error }
   end
 
@@ -32,6 +34,7 @@ RSpec.describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of view rendering times") }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
     it { expect { subject.get(labels: %i[identifier]) }.to_not raise_error }
   end
 
@@ -40,6 +43,7 @@ RSpec.describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of partial rendering times") }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
     it { expect { subject.get(labels: %i[identifier]) }.to_not raise_error }
   end
 
@@ -48,6 +52,7 @@ RSpec.describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of cache reads") }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
     it { expect { subject.get(labels: %i[key hit]) }.to_not raise_error }
   end
 
@@ -56,6 +61,7 @@ RSpec.describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of CSP violations") }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
     it { expect { subject.get(labels: %i[blocked_uri document_uri violated_directive]) }.to_not raise_error }
   end
 
@@ -64,6 +70,7 @@ RSpec.describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of feedback visit responses") }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
     it { expect { subject.get(labels: %i[successful]) }.to_not raise_error }
   end
 
@@ -72,6 +79,15 @@ RSpec.describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of feedback rating responses") }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
     it { expect { subject.get(labels: %i[rating]) }.to_not raise_error }
+  end
+
+  def expected_preset_labels
+    {
+      app: "app-name",
+      organisation: "org-name",
+      space: "space-name",
+    }
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-1404](https://trello.com/c/9UOVcX50/1404-improve-metrics-output-to-prometheus)

### Context

We want to be able to differentiate all metrics against preset labels:

- Application
- Organization
- Space

This will enable us to tailor alerts more suitably to the specific environment running.

### Changes proposed in this pull request

- Add preset labels to all custom metrics

### Guidance to review

