### PR TITLE
Isolate API client HTTP cache store

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,6 +53,7 @@ Rails.application.configure do
 
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
   config.x.enable_beta_redirects = false
+  config.x.api_client_cache_store = ActiveSupport::Cache::MemoryStore.new
 
   config.session_store :cache_store,
                        key: "_dfe_session",

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -108,6 +108,7 @@ Rails.application.configure do
 
   config.x.git_api_endpoint = "https://get-into-teaching-api-prod.london.cloudapps.digital"
   config.x.enable_beta_redirects = true
+  config.x.api_client_cache_store = ActiveSupport::Cache::RedisCacheStore.new(namespace: "TTA-HTTP")
 
   config.session_store :cache_store,
                        key: "_dfe_session",

--- a/config/initializers/get_into_teaching_api_client.rb
+++ b/config/initializers/get_into_teaching_api_client.rb
@@ -7,7 +7,7 @@ GetIntoTeachingApiClient.configure do |config|
 
   config.api_key["Authorization"] = ENV["GIT_API_TOKEN"].presence || Rails.application.credentials.config[:api_key].presence
 
-  config.cache_store = Rails.cache
+  config.cache_store = Rails.application.config.x.api_client_cache_store
 
   config.circuit_breaker = {
     enabled: true,

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -46,14 +46,14 @@ RSpec.describe "Instrumentation" do
   end
 
   describe "cache_read.active_support" do
-    after { get privacy_policy_path }
+    after { Rails.cache.read("test") }
 
     it "observes the :tta_cache_read_total metric" do
       metric = registry.get(:tta_cache_read_total)
       expect(metric).to receive(:increment).with(labels: {
         key: instance_of(String),
         hit: false,
-      }).twice
+      }).once
     end
   end
 


### PR DESCRIPTION
### Context

The API client library is being updated to support cache invalidation under certain scenarios (for example, posting a new teaching event needs to clear the event search cache).

As invalidating specific response caches would be reasonably tricky (the caching is performed by a separate middleware) the API client instead blows away its entire cache store (the cache is short-lived and cheap). It is no longer safe to use `Rails.cache` for the API client and instead we need to isolate the cache, so we don't invalidate anything apart from cached HTTP responses.

The TTA service doesn't support any of the endpoints that invalidate cache at the moment, but we should still isolate the cache to protect against future changes.

### Changes proposed in this pull request

- Isolate Api client HTTP cache store

Use a new in-memory cache for development and a separate Redis namespace in production.

### Guidance to review

Api client change: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client/pull/49