### PR TITLE
Fix feedback metric label not registering correctly

### DIFF
--- a/config/initializers/instrumentation.rb
+++ b/config/initializers/instrumentation.rb
@@ -89,7 +89,7 @@ ActiveSupport::Notifications.subscribe "tta.feedback" do |*args|
   prometheus = Prometheus::Client.registry
 
   metric = prometheus.get(:tta_feedback_visit_total)
-  metric.increment(labels: { successful: feedback.successful_visit?.to_s })
+  metric.increment(labels: { successful: feedback.successful_visit ? "1" : "0" })
 
   metric = prometheus.get(:tta_feedback_rating_total)
   metric.increment(labels: { rating: feedback.rating.to_s })

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -85,7 +85,9 @@ RSpec.describe "Instrumentation" do
   describe "tta.feedback" do
     let(:params) do
       {
-        teacher_training_adviser_feedback: attributes_for(:feedback),
+        teacher_training_adviser_feedback: attributes_for(
+          :feedback, successful_visit: false, unsuccessful_visit_explanation: "doesn't work!"
+        ),
       }
     end
 
@@ -93,7 +95,7 @@ RSpec.describe "Instrumentation" do
 
     it "increments the :tta_feedback_visit_total metric" do
       metric = registry.get(:tta_feedback_visit_total)
-      expect(metric).to receive(:increment).with(labels: { successful: "true" }).once
+      expect(metric).to receive(:increment).with(labels: { successful: "0" }).once
     end
 
     it "increments the :tta_feedback_rating_total metric" do


### PR DESCRIPTION
For some reason the metric label for `tta_feedback_visit_total` is always coming back as `true` and the `false` value is never present, even when its definitely been selected by a user.

I'm clutching at straws here, but trying different true/false values in case `false` is reserved/special for some reason.


