### PR TITLE
Minor tidy up of basic auth logic

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,9 +23,7 @@ class ApplicationController < ActionController::Base
 protected
 
   def authenticate?
-    # Site-wide authentication present in all production-like
-    # environments, but not in production itself.
-    !Rails.env.production? && !Rails.env.test? && !Rails.env.development?
+    BasicAuth.env_requires_auth?
   end
 
 private

--- a/app/controllers/teacher_training_adviser/feedbacks_controller.rb
+++ b/app/controllers/teacher_training_adviser/feedbacks_controller.rb
@@ -51,19 +51,20 @@ module TeacherTrainingAdviser
     end
 
     def restrict_access
-      raise_forbidden if RESTRICTED_ACTIONS.include?(action_name) &&
-        session[:username] != "feedback"
+      raise_forbidden if action_restricted? && session[:username] != "feedback"
     end
 
   protected
 
     def authenticate?
-      return false if Rails.env.test? || Rails.env.development?
-
-      Rails.env.production? ? RESTRICTED_ACTIONS.include?(action_name) : true
+      Rails.env.production? ? action_restricted? : super
     end
 
   private
+
+    def action_restricted?
+      RESTRICTED_ACTIONS.include?(action_name)
+    end
 
     def load_recent_feedback
       @recent_feedback = Feedback.recent.limit(RECENT_AMOUNT)

--- a/lib/basic_auth.rb
+++ b/lib/basic_auth.rb
@@ -16,5 +16,11 @@ class BasicAuth
     def http_auth
       Rails.application.credentials.config[:http_auth] || ""
     end
+
+    def env_requires_auth?
+      # Site-wide authentication present in all production-like
+      # environments, but not in production itself.
+      !Rails.env.production? && !Rails.env.test? && !Rails.env.development?
+    end
   end
 end

--- a/spec/lib/basic_auth_spec.rb
+++ b/spec/lib/basic_auth_spec.rb
@@ -11,6 +11,28 @@ RSpec.describe BasicAuth do
     described_class.class_variable_set(:@@credentials, nil)
   end
 
+  describe ".env_requires_auth?" do
+    before { allow(Rails).to receive(:env) { env.inquiry } }
+    subject { instance.env_requires_auth? }
+
+    ENV_AUTH = {
+      "production" => false,
+      "rolling" => true,
+      "preprod" => true,
+      "userresearch" => true,
+      "test" => false,
+      "development" => false,
+    }.freeze
+
+    ENV_AUTH.each do |k, auth|
+      context "when #{k}" do
+        let(:env) { k }
+
+        it { is_expected.to eq(auth) }
+      end
+    end
+  end
+
   describe ".credentials" do
     subject { instance.credentials }
 


### PR DESCRIPTION
Shift the site-wide auth determination into the `BasicAuth` module and clean up the `FeedbacksController` with call to
`super`. 

