### PR TITLE
Migrate to GHCR

### DIFF
--- a/.github/common_environment.yml
+++ b/.github/common_environment.yml
@@ -1,4 +1,4 @@
-  DOCKERHUB_REPOSITORY:  dfedigital/get-teacher-training-adviser-service
+  DOCKER_REPOSITORY:     ghcr.io/dfe-digital/get-teacher-training-adviser-service
   DOMAIN:                london.cloudapps.digital
   APPLICATION:           Teacher Training Adviser Service
   PAAS_APPLICATION_NAME: get-teacher-training-adviser-service

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'SLACK-WEBHOOK, DOCKER-USERNAME, DOCKER-PASSWORD , ACTIONS-API-ACCESS-TOKEN, SONAR-TOKEN'
+           secrets: 'SLACK-WEBHOOK, ACTIONS-API-ACCESS-TOKEN, SONAR-TOKEN'
 
       - name: Lint Dockerfile
         uses: brpaz/hadolint-action@master
@@ -102,9 +102,9 @@ jobs:
         id: sha
         run: |
               echo ::set-output name=short::$(echo "${{ github.sha }}" | cut -c -7)
-              echo ::set-output name=image::${{ env.DOCKERHUB_REPOSITORY }}:sha-$(echo "${{ github.sha }}" | cut -c -7)
-              echo ::set-output name=local::localhost:5000/${{env.DOCKERHUB_REPOSITORY}}:sha-$(echo "${{ github.sha }}" | cut -c -7)
-              echo ::set-output name=pr_image::${{ env.DOCKERHUB_REPOSITORY }}:review-$(echo "${{ github.sha }}" | cut -c -7)
+              echo ::set-output name=image::${{ env.DOCKER_REPOSITORY }}:sha-$(echo "${{ github.sha }}" | cut -c -7)
+              echo ::set-output name=local::localhost:5000/${{env.DOCKER_REPOSITORY}}:sha-$(echo "${{ github.sha }}" | cut -c -7)
+              echo ::set-output name=pr_image::${{ env.DOCKER_REPOSITORY }}:review-$(echo "${{ github.sha }}" | cut -c -7)
 
       - name: Cache Docker layers
         uses: actions/cache@v2.1.5
@@ -114,14 +114,14 @@ jobs:
           restore-keys: |
              ${{ runner.os }}-buildx-
 
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Repository 
         uses: docker/login-action@v1
         with:
-          username: ${{ steps.azSecret.outputs.DOCKER-USERNAME }}
-          password: ${{ steps.azSecret.outputs.DOCKER-PASSWORD }}
+           username: ${{ github.repository_owner }}
+           password: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
 
 
-      - name: Build master and push to Docker Hub
+      - name: Build master and push to GitHub Container Repository
         if: github.ref == 'refs/heads/master'
         uses: docker/build-push-action@v2
         with:
@@ -135,7 +135,7 @@ jobs:
           build-args: |
                       APP_SHA=${{ steps.sha.outputs.short }}
 
-      - name: Build PR and push to Docker Hub
+      - name: Build PR and push to GitHub Container Repository
         if: github.ref != 'refs/heads/master'
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
                  echo ::set-output name=key::${pr_name}
                  echo "TF_VAR_paas_adviser_application_name=${pr_name}" >> $GITHUB_ENV
                  echo "TF_VAR_paas_adviser_route_name=${pr_name}"       >> $GITHUB_ENV
-                 echo ::set-output name=docker_image::${{env.DOCKERHUB_REPOSITORY}}:review-${{steps.sha.outputs.short}}
+                 echo ::set-output name=docker_image::${{env.DOCKER_REPOSITORY}}:review-${{steps.sha.outputs.short}}
              fi
 
              if [ "${{github.event.inputs.environment }}" == "Development" ]
@@ -87,7 +87,7 @@ jobs:
                  echo ::set-output name=control::$(echo "dev" )
                  echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-dev" )
                  echo ::set-output name=key::"tta.dev.terraform"
-                 echo ::set-output name=docker_image::${{env.DOCKERHUB_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
+                 echo ::set-output name=docker_image::${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
              fi
 
              if [ "${{github.event.inputs.environment }}" == "Test" ]
@@ -95,7 +95,7 @@ jobs:
                  echo ::set-output name=control::$(echo "test" )
                  echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-test" )
                  echo ::set-output name=key::"tta.test.terraform"
-                 echo ::set-output name=docker_image::${{env.DOCKERHUB_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
+                 echo ::set-output name=docker_image::${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
              fi
 
              if [ "${{github.event.inputs.environment }}" == "UR" ]
@@ -103,7 +103,7 @@ jobs:
                  echo ::set-output name=control::$(echo "ur" )
                  echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-ur" )
                  echo ::set-output name=key::"tta.ur.terraform"
-                 echo ::set-output name=docker_image::${{env.DOCKERHUB_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
+                 echo ::set-output name=docker_image::${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
              fi
 
              if [ "${{github.event.inputs.environment }}" == "Production" ]
@@ -111,7 +111,7 @@ jobs:
                  echo ::set-output name=control::$(echo "production" )
                  echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-prod" )
                  echo ::set-output name=key::"tta.prod.terraform"
-                 echo ::set-output name=docker_image::${{env.DOCKERHUB_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
+                 echo ::set-output name=docker_image::${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
              fi
 
        - uses: Azure/login@v1

--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -33,11 +33,6 @@ resource "cloudfoundry_app" "adviser_application" {
     }
   }
 
-  docker_credentials = {
-    username = data.azurerm_key_vault_secret.docker_username.value
-    password = data.azurerm_key_vault_secret.docker_password.value
-  }
-
   routes {
     route = cloudfoundry_route.adviser_route.id
   }

--- a/terraform/paas/data.tf
+++ b/terraform/paas/data.tf
@@ -12,16 +12,6 @@ locals {
   application_secrets = yamldecode(data.azurerm_key_vault_secret.application.value)
 }
 
-data "azurerm_key_vault_secret" "docker_username" {
-  key_vault_id = data.azurerm_key_vault.vault.id
-  name         = "DOCKER-USERNAME"
-}
-
-data "azurerm_key_vault_secret" "docker_password" {
-  key_vault_id = data.azurerm_key_vault.vault.id
-  name         = "DOCKER-PASSWORD"
-}
-
 data "azurerm_key_vault_secret" "paas_username" {
   key_vault_id = data.azurerm_key_vault.vault.id
   name         = "PAAS-USERNAME"


### PR DESCRIPTION
### Trello card
https://trello.com/c/F01QXCqc/1526-migrate-to-github-container-registry

### Context
Docker Hub have limited the amount of users and the amount of pulls that we can do, It is also another service we need to manage, when we can now use GHCR which keeps the docker image with the source and does not have the restrictions of docker hub.

### Changes proposed in this pull request
When building or deploying docker images store and retrieve them from GitHub Container Repository.

### Guidance to review
No change to application
