### PR TITLE
Retrieve Logit Secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
          id:   azSecret
          with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'HTTP-USERNAME, HTTP-PASSWORD'
+           secrets: 'HTTP-USERNAME, HTTP-PASSWORD, LOGIT-API'
 
        - uses: hashicorp/setup-terraform@v1.3.2
          with:


### PR DESCRIPTION
On deploy retrieve the Logit.io API key so we can log a deployment event, thus enabling some sort of chart in Grafana 

