### PR TITLE
Update Fail2Ban settings

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -2,4 +2,4 @@
 GOOGLE_TAG_MANAGER_ID=GTM-K7TK4WM
 GIT_URL=https://beta-getintoteaching.education.gov.uk/
 LID_ID=1
-FAIL2BAN=1
+FAIL2BAN=5

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -46,10 +46,12 @@ module Rack
             if should_ban
               obscured_ip = req.ip.to_s.gsub(%r{\.\d+\.(\d+)\.}, ".***.***.")
 
-              Sentry.capture_message <<~BAN_MESSAGE
-                Banning IP: #{obscured_ip} for #{FAIL2BAN_TIME.to_i / 60} minutes
-                accessing #{req.path} with '#{req.query_string}'
-              BAN_MESSAGE
+              Rails.logger.info(
+                <<~BAN_MESSAGE,
+                  Banning IP: #{obscured_ip} for #{FAIL2BAN_TIME.to_i / 60} minutes
+                  accessing #{req.path} with '#{req.query_string}'
+                BAN_MESSAGE
+              )
             end
           end
         end


### PR DESCRIPTION
[Trello-1568](https://trello.com/c/2fmvfC4A/1568-look-to-increasing-fail2ban-time-for-a-longer-period)

- Update Fail2Ban length to 5 minutes

- Send Fail2Ban violations to the logs

We are receiving a fair amount of exceptions due to Fail2Ban being triggered; its not an exceptional case and shouldn't be treated as an error, so sending these to the logs and setting up a Grafana dashboard to monitor them feels more appropriate.