### PR TITLE
Switch to SemanticLogger in Production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,3 +95,10 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
+
+group :rolling, :preprod, :userresearch, :production, :pagespeed do
+  # loading the Gem monkey patches rails logger
+  # only load in prod-like environments when we actually need it
+  gem "amazing_print"
+  gem "rails_semantic_logger"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    amazing_print (1.3.0)
     ast (2.4.2)
     bindex (0.8.1)
     bootsnap (1.7.4)
@@ -208,6 +209,10 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_semantic_logger (4.5.1)
+      rack
+      railties (>= 3.2)
+      semantic_logger (~> 4.4)
     railties (6.0.3.5)
       actionpack (= 6.0.3.5)
       activesupport (= 6.0.3.5)
@@ -287,6 +292,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    semantic_logger (4.7.4)
+      concurrent-ruby (~> 1.0)
     semantic_range (2.3.1)
     sentry-rails (4.3.4)
       railties (>= 5.0)
@@ -355,6 +362,7 @@ PLATFORMS
 
 DEPENDENCIES
   actionpack-cloudfront
+  amazing_print
   bootsnap (>= 1.1.0)
   brakeman
   byebug
@@ -373,6 +381,7 @@ DEPENDENCIES
   puma (~> 5.2)
   rack-attack
   rails (~> 6.0.3)
+  rails_semantic_logger
   redis
   rspec-rails (~> 5.0.1)
   rspec-sonarqube-formatter (~> 1.5)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -67,16 +67,6 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
@@ -115,4 +105,21 @@ Rails.application.configure do
                        same_site: :lax,
                        expire_after: 1.day,
                        secure: true
+
+  # Configure Semantic Logging for production environments
+  # This cannot be conditionally loaded so we use it all the time in production
+  # like environments.
+  #
+  # The rails_semantic_logger gem overwrites the log initializer code and by
+  # this point its too late to monkey patch that
+  STDOUT.sync = true
+  SemanticLogger.application = ENV["SEMANTIC_LOGGER_APP"].presence || "Get Teacher Training Adviser Service"
+  config.rails_semantic_logger.started = false
+  config.rails_semantic_logger.processing = false
+  config.rails_semantic_logger.format = :json
+  config.rails_semantic_logger.add_file_appender = false
+  config.semantic_logger.add_appender \
+    io: STDOUT,
+    level: Rails.application.config.log_level,
+    formatter: config.rails_semantic_logger.format
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,3 +36,10 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+on_worker_boot do
+  if defined? SemanticLogger
+    # Re-open appenders after forking the process
+    SemanticLogger.reopen
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-1573](https://trello.com/c/futEUxSe/1573-trim-some-of-the-logging-fat)

### Context

We want to log in a compact JSON format, as we already do in the GiT app.

Add the SemanticLogger gem and configure so it will work well with logit.io.

Log at the `info` level in production instead of `debug`.

### Changes proposed in this pull request

- Switch to SemanticLogger

### Guidance to review

