### PR TITLE
Rename telephone to address_telephone

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 365e04585db3fb1159bfd77f95daef2ec8d2b699
+  revision: 9e1ee278207b6c3499ca969c8d2e10bc2bb30a97
   specs:
-    get_into_teaching_api_client (1.1.14)
+    get_into_teaching_api_client (1.1.15)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.27)
+    get_into_teaching_api_client_faraday (0.1.29)
       activesupport
       faraday
       faraday-encoding
@@ -112,22 +112,26 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
+    ethon (0.14.0)
+      ffi (>= 1.15.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
-    faraday (1.3.0)
+    faraday (1.4.1)
+      faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
     faraday-encoding (0.0.5)
       faraday
+    faraday-excon (1.1.0)
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
     faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     faraday_middleware-circuit_breaker (0.4.1)

--- a/app/models/teacher_training_adviser/steps/overseas_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_telephone.rb
@@ -1,11 +1,11 @@
 module TeacherTrainingAdviser::Steps
   class OverseasTelephone < Wizard::Step
-    attribute :telephone, :string
+    attribute :address_telephone, :string
 
-    validates :telephone, telephone: true, allow_blank: true
+    validates :address_telephone, telephone: true, allow_blank: true
 
-    before_validation if: :telephone do
-      self.telephone = telephone.to_s.strip.presence
+    before_validation if: :address_telephone do
+      self.address_telephone = address_telephone.to_s.strip.presence
     end
 
     def self.contains_personal_details?

--- a/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
@@ -1,9 +1,9 @@
 module TeacherTrainingAdviser::Steps
   class OverseasTimeZone < Wizard::Step
-    attribute :telephone, :string
+    attribute :address_telephone, :string
     attribute :time_zone, :string
 
-    validates :telephone, telephone: true, presence: true
+    validates :address_telephone, telephone: true, presence: true
     validates :time_zone, presence: true, unless: -> { Rails.env.production? }
 
     def self.contains_personal_details?
@@ -15,7 +15,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def reviewable_answers
-      { "telephone" => telephone }.tap do |answers|
+      { "address_telephone" => address_telephone }.tap do |answers|
         answers["time_zone"] = time_zone if time_zone.present?
       end
     end

--- a/app/models/teacher_training_adviser/steps/uk_callback.rb
+++ b/app/models/teacher_training_adviser/steps/uk_callback.rb
@@ -2,14 +2,14 @@ module TeacherTrainingAdviser::Steps
   class UkCallback < Wizard::Step
     extend CallbackBookingQuotas
 
-    attribute :telephone, :string
+    attribute :address_telephone, :string
     attribute :phone_call_scheduled_at, :datetime
 
-    validates :telephone, telephone: true, presence: true
+    validates :address_telephone, telephone: true, presence: true
     validates :phone_call_scheduled_at, presence: true
 
-    before_validation if: :telephone do
-      self.telephone = telephone.to_s.strip.presence
+    before_validation if: :address_telephone do
+      self.address_telephone = address_telephone.to_s.strip.presence
     end
 
     def self.contains_personal_details?
@@ -18,7 +18,7 @@ module TeacherTrainingAdviser::Steps
 
     def reviewable_answers
       {
-        "telephone" => telephone,
+        "address_telephone" => address_telephone,
         "callback_date" => phone_call_scheduled_at&.to_date,
         "callback_time" => phone_call_scheduled_at&.to_time, # rubocop:disable Rails/Date
       }

--- a/app/models/teacher_training_adviser/steps/uk_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/uk_telephone.rb
@@ -1,11 +1,11 @@
 module TeacherTrainingAdviser::Steps
   class UkTelephone < Wizard::Step
-    attribute :telephone, :string
+    attribute :address_telephone, :string
 
-    validates :telephone, telephone: true, allow_blank: true
+    validates :address_telephone, telephone: true, allow_blank: true
 
-    before_validation if: :telephone do
-      self.telephone = telephone.to_s.strip.presence
+    before_validation if: :address_telephone do
+      self.address_telephone = address_telephone.to_s.strip.presence
     end
 
     def self.contains_personal_details?

--- a/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
@@ -1,3 +1,3 @@
 <%= f.govuk_fieldset legend: { text: 'What is your telephone number?' } do %>
-  <%= f.govuk_phone_field :telephone, width: 20 %>
+  <%= f.govuk_phone_field :address_telephone, width: 20 %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
@@ -3,7 +3,7 @@
 <p>We will need to call you to discuss your qualifications. You must have the details of your overseas qualifications when we contact you.</p>
 <p>In the meantime, if you need to speak to us you can, by using Freephone <%= link_to("0800 389 2500", "tel://08003892500") %> between 8.30am - 5.30pm Monday to Friday.</p>
 
-<%= f.govuk_phone_field :telephone, width: 20 %>
+<%= f.govuk_phone_field :address_telephone, width: 20 %>
 
 <% unless Rails.env.production? %>
   <%= f.govuk_collection_select :time_zone,

--- a/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
@@ -3,7 +3,7 @@
 <p>You need to book a callback with us.  We will contact you once your call is booked.</p>
 <p>You must have the details of your overseas qualifications when we contact you.</p>
 
-<%= f.govuk_phone_field :telephone, width: 20 %>
+<%= f.govuk_phone_field :address_telephone, width: 20 %>
 
 <%= f.govuk_select :phone_call_scheduled_at, callback_options(f.object.class.callback_booking_quotas), {} %>
 

--- a/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
@@ -1,3 +1,3 @@
 <%= f.govuk_fieldset legend: { text: 'What is your telephone number?' } do %>
-  <%= f.govuk_phone_field :telephone, width: 20 %>
+  <%= f.govuk_phone_field :address_telephone, width: 20 %>
 <% end %>

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -13,5 +13,6 @@ Rails.application.config.filter_parameters += %i[
   password
   teacher_id
   telephone
+  address_telephone
   timed_one_time_password
 ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,10 +84,10 @@ en:
       teacher_training_adviser_steps_overseas_callback:
         phone_call_scheduled_at: "Select your preferred day and time for a callback"
       teacher_training_adviser_steps_overseas_time_zone:
-        telephone: "Contact telephone number"
+        address_telephone: "Contact telephone number"
         time_zone: "Select your time zone"
       teacher_training_adviser_steps_overseas_telephone:
-        telephone: "Overseas telephone number (optional)"
+        address_telephone: "Overseas telephone number (optional)"
       teacher_training_adviser_steps_previous_teacher_id:
         teacher_id: "Teacher reference number (optional)."
       teacher_training_adviser_steps_what_subject_degree:
@@ -99,9 +99,9 @@ en:
       teacher_training_adviser_steps_start_teacher_training:
         initial_teacher_training_year_id: "When do you want to start your teacher training?"
       teacher_training_adviser_steps_uk_telephone:
-        telephone: "UK telephone number (optional)"
+        address_telephone: "UK telephone number (optional)"
       teacher_training_adviser_steps_uk_callback:
-        telephone: "Contact telephone number"
+        address_telephone: "Contact telephone number"
         phone_call_scheduled_at: "Select your preferred day and time for a callback"
       teacher_training_adviser_steps_overseas_country:
         country_id: "Which country do you live in?"
@@ -148,7 +148,7 @@ en:
       teacher_training_adviser_steps_what_subject_degree:
         degree_subject: "If your subject is not listed choose the option that is nearest to your degree."
       teacher_training_adviser_steps_uk_telephone:
-        telephone: "We recommend you provide us with your phone number as this is the most effective way to talk to your adviser."
+        address_telephone: "We recommend you provide us with your phone number as this is the most effective way to talk to your adviser."
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:
@@ -156,7 +156,7 @@ en:
       teacher_training_adviser_steps_have_a_degree:
         degree_options: "To use this service your bachelor's degree or predicted grade needs to be a 2:2 class honours or above."
       teacher_training_adviser_steps_overseas_telephone:
-        telephone_html: "We recommend you provide us with your phone number as this is the most effective way to talk to your adviser.<br /><br />For international numbers include the country code."
+        address_telephone_html: "We recommend you provide us with your phone number as this is the most effective way to talk to your adviser.<br /><br />For international numbers include the country code."
       teacher_training_adviser_steps_date_of_birth:
         date_of_birth: "For example, 31 3 1980. We use this information to confirm you are aged 18 or over."
   have_a_degree:
@@ -186,7 +186,9 @@ en:
     overseas_country:
       country_id: "Which country do you live in?"
     overseas_telephone:
-      telephone: "Telephone"
+      address_telephone: "Telephone"
+    overseas_time_zone:
+      address_telephone: "Telephone"
     previous_teacher_id:
       teacher_id: "What is your previous teacher reference number?"
     retake_gcse_maths_english:
@@ -212,10 +214,11 @@ en:
     uk_callback:
       callback_date: "Callback date"
       callback_time: "Callback time"
+      address_telephone: "Telephone"
     uk_or_overseas:
       uk_or_overseas: "Where do you live?"
     uk_telephone:
-      telephone: "Telephone"
+      address_telephone: "Telephone"
     what_degree_class:
       uk_degree_grade_id: "Which class is your degree?"
     what_subject_degree:
@@ -268,14 +271,14 @@ en:
               blank: "You need to choose a degree subject"
         teacher_training_adviser/steps/uk_callback:
           attributes:
-            telephone:
+            address_telephone:
               <<: *telephone_errors
               blank: "Enter a telephone number"
             phone_call_scheduled_at:
               blank: "You need to choose a time to call"
         teacher_training_adviser/steps/uk_telephone:
           attributes:
-            telephone:
+            address_telephone:
               <<: *telephone_errors
         teacher_training_adviser/steps/uk_address:
           attributes:
@@ -323,14 +326,14 @@ en:
               invalid_type: "Select yes if you are planning to retake either English or maths (or both) GCSEs, or equivalent"
         teacher_training_adviser/steps/overseas_time_zone:
           attributes:
-            telephone:
+            address_telephone:
               <<: *telephone_errors
               blank: "Enter a telephone number"
             time_zone:
               blank: "Select a time zone"
         teacher_training_adviser/steps/overseas_telephone:
           attributes:
-            telephone:
+            address_telephone:
               <<: *telephone_errors
         teacher_training_adviser/steps/has_teacher_id:
           attributes:

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -536,7 +536,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
         addressCity: "Manchester",
         addressPostcode: "TE7 1NG",
         dateOfBirth: Date.new(1999, 4, 27),
-        telephone: "123456789",
+        addressTelephone: "123456789",
         teacherId: "12345",
       )
     end
@@ -771,7 +771,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       first_name: "John",
       last_name: "Doe",
       date_of_birth: "1966-03-24",
-      telephone: "123456789",
+      address_telephone: "123456789",
     }
   end
 end

--- a/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
@@ -3,18 +3,18 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::OverseasTelephone do
   include_context "wizard step"
   it_behaves_like "a wizard step"
-  include_context "sanitize fields", %i[telephone]
+  include_context "sanitize fields", %i[address_telephone]
 
   it { is_expected.to be_contains_personal_details }
   it { is_expected.to be_optional }
 
   context "attributes" do
-    it { is_expected.to respond_to :telephone }
+    it { is_expected.to respond_to :address_telephone }
   end
 
-  describe "telephone" do
-    it { is_expected.to_not allow_values("abc12345", "12", "1" * 21).for :telephone }
-    it { is_expected.to allow_values(nil, "123456789").for :telephone }
+  describe "address_telephone" do
+    it { is_expected.to_not allow_values("abc12345", "12", "1" * 21).for :address_telephone }
+    it { is_expected.to allow_values(nil, "123456789").for :address_telephone }
   end
 
   describe "#skipped?" do
@@ -36,7 +36,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTelephone do
 
     it "returns true when pre-filled with crm data" do
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
-      wizardstore.persist_crm({ "telephone" => "123456789" })
+      wizardstore.persist_crm({ "address_telephone" => "123456789" })
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTimeZone do
 
   context "attributes" do
     it { is_expected.to respond_to :time_zone }
-    it { is_expected.to respond_to :telephone }
+    it { is_expected.to respond_to :address_telephone }
   end
 
-  describe "telephone" do
-    it { is_expected.to_not allow_values(nil, "abc12345", "12", "1" * 21).for :telephone }
-    it { is_expected.to allow_values("123456789").for :telephone }
+  describe "address_telephone" do
+    it { is_expected.to_not allow_values(nil, "abc12345", "12", "1" * 21).for :address_telephone }
+    it { is_expected.to allow_values("123456789").for :address_telephone }
   end
 
   context "time_zone" do
@@ -58,20 +58,20 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTimeZone do
   describe "#reviewable_answers" do
     subject { instance.reviewable_answers }
     before do
-      instance.telephone = "1234567"
+      instance.address_telephone = "1234567"
       instance.time_zone = "London"
     end
     it {
       is_expected.to eq({
         "time_zone" => "London",
-        "telephone" => "1234567",
+        "address_telephone" => "1234567",
       })
     }
 
     context "when time_zone is nil" do
       before { instance.time_zone = nil }
 
-      it { is_expected.to eq({ "telephone" => "1234567" }) }
+      it { is_expected.to eq({ "address_telephone" => "1234567" }) }
     end
   end
 end

--- a/spec/models/teacher_training_adviser/steps/review_answers_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/review_answers_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::ReviewAnswers do
       TeacherTrainingAdviser::Steps::Identity => { "first_name": "Joe" },
       TeacherTrainingAdviser::Steps::DateOfBirth => { "date_of_birth": 20.years.ago },
       TeacherTrainingAdviser::Steps::UkAddress => { "address_line1": "7 Main Street" },
-      TeacherTrainingAdviser::Steps::UkTelephone => { "telephone": "123456789" },
+      TeacherTrainingAdviser::Steps::UkTelephone => { "address_telephone": "123456789" },
       TeacherTrainingAdviser::Steps::HaveADegree => { "degree_options": "studying" },
       TeacherTrainingAdviser::Steps::ReturningTeacher => {
         "type_id": TeacherTrainingAdviser::Steps::ReturningTeacher::OPTIONS[:returning_to_teaching],

--- a/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
   it_behaves_like "exposes callback booking quotas"
   include_context "wizard step"
   it_behaves_like "a wizard step"
-  include_context "sanitize fields", %i[telephone]
+  include_context "sanitize fields", %i[address_telephone]
 
   it { expect(described_class).to be_contains_personal_details }
 
   context "attributes" do
     it { is_expected.to respond_to :phone_call_scheduled_at }
-    it { is_expected.to respond_to :telephone }
+    it { is_expected.to respond_to :address_telephone }
   end
 
   context "phone_call_scheduled_at" do
@@ -18,9 +18,9 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
     it { is_expected.to allow_value(Time.zone.now).for :phone_call_scheduled_at }
   end
 
-  context "telephone" do
-    it { is_expected.to_not allow_values(nil, "", "abc12345", "12", "1" * 21).for :telephone }
-    it { is_expected.to allow_values("123456789").for :telephone }
+  context "address_telephone" do
+    it { is_expected.to_not allow_values(nil, "", "abc12345", "12", "1" * 21).for :address_telephone }
+    it { is_expected.to allow_values("123456789").for :address_telephone }
   end
 
   describe "#skipped?" do
@@ -48,26 +48,26 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
 
   describe "#reviewable_answers" do
     let(:date_time) { DateTime.new(2022, 1, 1, 10, 30) }
-    let(:telephone) { "123456789" }
+    let(:address_telephone) { "123456789" }
     subject { instance.reviewable_answers }
     before do
       instance.phone_call_scheduled_at = date_time
-      instance.telephone = telephone
+      instance.address_telephone = address_telephone
     end
 
     it {
       is_expected.to eq({
         "callback_date" => date_time.to_date,
         "callback_time" => date_time.to_time, # rubocop:disable Rails/Date
-        "telephone" => telephone,
+        "address_telephone" => address_telephone,
       })
     }
 
-    context "when the phone_call_scheduled_at/telephone are nil" do
+    context "when the phone_call_scheduled_at/address_telephone are nil" do
       let(:date_time) { nil }
-      let(:telephone) { nil }
+      let(:address_telephone) { nil }
 
-      it { is_expected.to eq({ "callback_date" => nil, "callback_time" => nil, "telephone" => nil }) }
+      it { is_expected.to eq({ "callback_date" => nil, "callback_time" => nil, "address_telephone" => nil }) }
     end
   end
 end

--- a/spec/models/teacher_training_adviser/steps/uk_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_telephone_spec.rb
@@ -3,18 +3,18 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::UkTelephone do
   include_context "wizard step"
   it_behaves_like "a wizard step"
-  include_context "sanitize fields", %i[telephone]
+  include_context "sanitize fields", %i[address_telephone]
 
   it { is_expected.to be_contains_personal_details }
   it { is_expected.to be_optional }
 
   context "attributes" do
-    it { is_expected.to respond_to :telephone }
+    it { is_expected.to respond_to :address_telephone }
   end
 
-  describe "telephone" do
-    it { is_expected.to_not allow_values("abc12345", "12", "1" * 21).for :telephone }
-    it { is_expected.to allow_values(nil, "123456789").for :telephone }
+  describe "address_telephone" do
+    it { is_expected.to_not allow_values("abc12345", "12", "1" * 21).for :address_telephone }
+    it { is_expected.to allow_values(nil, "123456789").for :address_telephone }
   end
 
   describe "#skipped?" do
@@ -36,7 +36,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkTelephone do
 
     it "returns true when pre-filled with crm data" do
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
-      wizardstore.persist_crm({ "telephone" => "123456789" })
+      wizardstore.persist_crm({ "address_telephone" => "123456789" })
       expect(subject).to be_skipped
     end
   end


### PR DESCRIPTION
The API currently supports both field names, but telephone is being deprecated in favour of address_telephone.
