### PR TITLE
document how to fix failure

### DIFF
--- a/docs/runbooks/pipelines/build_fails_at_release.md
+++ b/docs/runbooks/pipelines/build_fails_at_release.md
@@ -1,0 +1,11 @@
+# Create a GitHub Release
+
+## Symptoms
+When running a master release the build pipeline fails, due to the release already existing.
+
+## Solution
+1. Open the workflow logs at the error and expand the logs, so you can see all the inputs.
+2. Record the release number
+3. Have an admin: 
+  - Delete the release from the releases
+  - Delete the tag


### PR DESCRIPTION
[Moving Run Books ](https://trello.com/c/0GUCpmZv/1502-move-runbooks-from-confluence-to-github-pages)

Adding Procedures to assist with manually resolving common problems.


