### PR TITLE
Improve email format validation

### DIFF
--- a/app/models/teacher_training_adviser/steps/identity.rb
+++ b/app/models/teacher_training_adviser/steps/identity.rb
@@ -8,7 +8,7 @@ module TeacherTrainingAdviser::Steps
 
     validates :first_name, presence: true, length: { maximum: 256 }
     validates :last_name, presence: true, length: { maximum: 256 }
-    validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, length: { maximum: 100 }
+    validates :email, presence: true, email_format: true
 
     before_validation :sanitize_input
 

--- a/app/validators/email_format_validator.rb
+++ b/app/validators/email_format_validator.rb
@@ -1,0 +1,30 @@
+class EmailFormatValidator < ActiveModel::EachValidator
+  EMAIL_WITH_FULLY_QUALIFIED_HOSTNAME = %r{\A[^\s@]+@[^\.\s]+\.[^\s]+\z}.freeze
+  MAXIMUM_LENGTH = 100 # As specified by the CRM
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    invalid_format = !is_an_email_uri?(value) || !is_fqdn?(value)
+
+    if invalid_format
+      record.errors.add(attribute, :invalid)
+    elsif too_long?(value)
+      record.errors.add(attribute, :too_long)
+    end
+  end
+
+private
+
+  def is_an_email_uri?(value)
+    value.to_s.match?(URI::MailTo::EMAIL_REGEXP)
+  end
+
+  def is_fqdn?(value)
+    value.to_s.match?(EMAIL_WITH_FULLY_QUALIFIED_HOSTNAME)
+  end
+
+  def too_long?(value)
+    value.to_s.length > MAXIMUM_LENGTH
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,6 +248,7 @@ en:
               blank: "You need to enter your last name"
               too_long: "You have entered too many characters - you need to enter your last name"
             email:
+              blank: "You need to enter your email address"
               invalid: "You need to enter your email address"
               too_long: "Your email address is too long - you need to enter a valid email address"
         teacher_training_adviser/steps/subject_taught:

--- a/spec/models/teacher_training_adviser/steps/identity_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/identity_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::Identity do
   end
 
   describe "email" do
-    it { is_expected.to_not allow_values(nil, "", "a@#{'a' * 101}.com").for :email }
+    it { is_expected.to_not allow_values(nil, "", "a@#{'a' * 101}.com", "some@thing").for :email }
     it { is_expected.to allow_values("test@test.com", "test%.mctest@domain.co.uk").for :email }
   end
 

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe EmailFormatValidator do
+  let :test_model do
+    Class.new do
+      include ActiveModel::Model
+      attr_accessor :email
+      validates :email, email_format: true
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "test")
+      end
+    end
+  end
+
+  before { instance.valid? }
+  subject { instance.errors }
+
+  context "with invalid addresses" do
+    %w[test.com test@@test.com test@test test@test.].each do |email|
+      let(:instance) { test_model.new(email: email) }
+
+      it "#{email} should not be valid" do
+        is_expected.to be_added(:email, :invalid)
+      end
+    end
+
+    context "when over 100 characters" do
+      let(:instance) { test_model.new(email: "#{'a' * 100}@test.com") }
+
+      it "is not be valid" do
+        is_expected.to be_added(:email, :too_long)
+      end
+    end
+  end
+
+  context "with valid addresses" do
+    %w[test@example.com testymctest@gmail.com test%.mctest@domain.co.uk]
+      .each do |email|
+      let(:instance) { test_model.new(email: email) }
+
+      it "#{email} should be valid" do
+        is_expected.to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
The built-in URI email regex appears to allow emails without fully qualified domains, such as `some@thing`. We use a custom email format validator in the GiT app that is more suitable for our use-case, so this is a lift and shift of that validator into the TTA codebase.