### PR TITLE
Update international telephone validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem "actionpack-cloudfront"
 
 gem "invisible_captcha"
 
+gem "iso_country_codes"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,7 @@ GEM
       concurrent-ruby (~> 1.0)
     invisible_captcha (2.0.0)
       rails (>= 5.0)
+    iso_country_codes (0.7.8)
     json (2.5.1)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -381,6 +382,7 @@ DEPENDENCIES
   get_into_teaching_api_client_faraday!
   govuk_design_system_formbuilder
   invisible_captcha
+  iso_country_codes
   listen (>= 3.0.5, < 3.6)
   pg
   prometheus-client

--- a/app/models/teacher_training_adviser/steps/overseas_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_telephone.rb
@@ -2,7 +2,7 @@ module TeacherTrainingAdviser::Steps
   class OverseasTelephone < Wizard::Step
     attribute :address_telephone, :string
 
-    validates :address_telephone, telephone: true, allow_blank: true
+    validates :address_telephone, telephone: { international: true }, allow_blank: true
 
     before_validation if: :address_telephone do
       self.address_telephone = address_telephone.to_s.strip.presence

--- a/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
@@ -3,7 +3,7 @@ module TeacherTrainingAdviser::Steps
     attribute :address_telephone, :string
     attribute :time_zone, :string
 
-    validates :address_telephone, telephone: true, presence: true
+    validates :address_telephone, telephone: { international: true }, presence: true
     validates :time_zone, presence: true, unless: -> { Rails.env.production? }
 
     def self.contains_personal_details?

--- a/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
@@ -6,6 +6,10 @@ module TeacherTrainingAdviser::Steps
     validates :address_telephone, telephone: { international: true }, presence: true
     validates :time_zone, presence: true, unless: -> { Rails.env.production? }
 
+    before_validation if: :address_telephone do
+      self.address_telephone = address_telephone.to_s.strip.presence
+    end
+
     def self.contains_personal_details?
       true
     end

--- a/app/validators/telephone_validator.rb
+++ b/app/validators/telephone_validator.rb
@@ -1,6 +1,6 @@
 class TelephoneValidator < ActiveModel::EachValidator
   TELEPHONE_FORMAT = %r{\A[^a-zA-Z]+\z}.freeze
-  MINIMUM_LENGTH = 6
+  MINIMUM_LENGTH = 5
   MAXIMUM_LENGTH = 20
 
   def validate_each(record, attribute, value)

--- a/app/validators/telephone_validator.rb
+++ b/app/validators/telephone_validator.rb
@@ -6,6 +6,12 @@ class TelephoneValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
 
+    international = options.key?(:international)
+
+    if international && invalid_dial_in_code?(value)
+      record.errors.add(attribute, :invalid_dial_in_code)
+    end
+
     record.errors.add(attribute, :invalid) if invalid_format?(value)
     record.errors.add(attribute, :too_short) if too_short?(value)
     record.errors.add(attribute, :too_long) if too_long?(value)
@@ -15,6 +21,12 @@ private
 
   def invalid_format?(telephone)
     TELEPHONE_FORMAT !~ telephone
+  end
+
+  def invalid_dial_in_code?(telephone)
+    dial_in_codes = IsoCountryCodes.all.map(&:calling).map { |c| c[1..-1] }
+    sanitized_telephone = telephone.delete("^0-9")
+    dial_in_codes.none? { |code| sanitized_telephone.start_with?(code) }
   end
 
   def too_short?(telephone)

--- a/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
@@ -1,3 +1,3 @@
 <%= f.govuk_fieldset legend: { text: 'What is your telephone number?' } do %>
-  <%= f.govuk_phone_field :address_telephone, width: 20 %>
+  <%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+" %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
@@ -3,7 +3,7 @@
 <p>We will need to call you to discuss your qualifications. You must have the details of your overseas qualifications when we contact you.</p>
 <p>In the meantime, you can call us on Freephone <%= link_to("0800 389 2500", "tel://08003892500") %> between 8.30am and 5.30pm Monday to Friday.</p>
 
-<%= f.govuk_phone_field :address_telephone, width: 20 %>
+<%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+" %>
 
 <% unless Rails.env.production? %>
   <%= f.govuk_collection_select :time_zone,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,7 @@
 
 telephone_errors: &telephone_errors
   invalid: "Enter a telephone number in the correct format"
+  invalid_dial_in_code: "Telephone number must start with a country dial-in code (e.g. 44)"
   too_short: "Telephone number is too short (minimum is 5 characters)"
   too_long: "Telephone number is too long (maximum is 20 characters)"
 

--- a/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTelephone do
   end
 
   describe "address_telephone" do
-    it { is_expected.to_not allow_values("abc12345", "12", "1" * 21).for :address_telephone }
+    it { is_expected.to_not allow_values("abc12345", "12", "1" * 21, "000000000").for :address_telephone }
     it { is_expected.to allow_values(nil, "123456789").for :address_telephone }
   end
 

--- a/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTimeZone do
   end
 
   describe "address_telephone" do
-    it { is_expected.to_not allow_values(nil, "abc12345", "12", "1" * 21).for :address_telephone }
+    it { is_expected.to_not allow_values(nil, "abc12345", "12", "1" * 21, "000000000").for :address_telephone }
     it { is_expected.to allow_values("123456789").for :address_telephone }
   end
 

--- a/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::OverseasTimeZone do
   include_context "wizard step"
   it_behaves_like "a wizard step"
+  include_context "sanitize fields", %i[address_telephone]
 
   it { expect(described_class).to be TeacherTrainingAdviser::Steps::OverseasTimeZone }
 

--- a/spec/validators/telephone_validator_spec.rb
+++ b/spec/validators/telephone_validator_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe TelephoneValidator do
     validates :telephone, telephone: true
   end
 
+  class InternationalTelephoneTestModel
+    include ActiveModel::Model
+    attr_accessor :telephone
+    validates :telephone, telephone: { international: true }
+  end
+
   before { instance.valid? }
   subject { instance.errors.details[:telephone] }
 
@@ -23,5 +29,32 @@ RSpec.describe TelephoneValidator do
   context "when invalid format" do
     let(:instance) { TelephoneTestModel.new(telephone: "abc123") }
     it { is_expected.to include error: :invalid }
+  end
+
+  context "when international" do
+    context "when invalid country dial-in code" do
+      let(:instance) { InternationalTelephoneTestModel.new(telephone: "001234535") }
+      it { is_expected.to include error: :invalid_dial_in_code }
+    end
+
+    context "when valid country dial-in code" do
+      let(:instance) { InternationalTelephoneTestModel.new(telephone: "447564738475") }
+      it { is_expected.to_not include error: :invalid_dial_in_code }
+    end
+
+    context "when valid country dial-in code with leading +" do
+      let(:instance) { InternationalTelephoneTestModel.new(telephone: "+447564738475") }
+      it { is_expected.to_not include error: :invalid_dial_in_code }
+    end
+
+    context "when valid country dial-in code with leading +()" do
+      let(:instance) { InternationalTelephoneTestModel.new(telephone: "(44)7564738475") }
+      it { is_expected.to_not include error: :invalid_dial_in_code }
+    end
+
+    context "when valid country dial-in code with spaces" do
+      let(:instance) { InternationalTelephoneTestModel.new(telephone: "4 4 7564 7384 75") }
+      it { is_expected.to_not include error: :invalid_dial_in_code }
+    end
   end
 end

--- a/spec/validators/telephone_validator_spec.rb
+++ b/spec/validators/telephone_validator_spec.rb
@@ -16,8 +16,18 @@ RSpec.describe TelephoneValidator do
   before { instance.valid? }
   subject { instance.errors.details[:telephone] }
 
+  context "when the minimum length" do
+    let(:instance) { TelephoneTestModel.new(telephone: "12346") }
+    it { is_expected.to be_empty }
+  end
+
+  context "when the maximum length" do
+    let(:instance) { TelephoneTestModel.new(telephone: "1" * 20) }
+    it { is_expected.to be_empty }
+  end
+
   context "when too short" do
-    let(:instance) { TelephoneTestModel.new(telephone: "123") }
+    let(:instance) { TelephoneTestModel.new(telephone: "1234") }
     it { is_expected.to include error: :too_short }
   end
 


### PR DESCRIPTION
### Trello card

[Trello-1597](https://trello.com/c/WCPR0FxQ/1597-overseas-number-validation-sanitisation)

### Context

When a candidate is overseas we need to ensure that their telephone number will be in a format that the TPUK dialling system supports. On the client-side this means the number needs to be prefixed by the country dial-in code (e.g. 44). The API will then sanitise the number further to remove non-numerical values, white space and a proceeding `+`.

### Changes proposed in this pull request

- Update international telephone validation

### Guidance to review

<img width="1383" alt="Screenshot 2021-06-02 at 11 07 02" src="https://user-images.githubusercontent.com/29867726/120462264-ab35bf80-c392-11eb-83c0-38c677b520b1.png">

