### PR TITLE
Prefill country dial in code

### DIFF
--- a/app/models/teacher_training_adviser/steps/overseas_country.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_country.rb
@@ -15,14 +15,27 @@ module TeacherTrainingAdviser::Steps
       generate_api_options(GetIntoTeachingApiClient::LookupItemsApi, :get_countries, OMIT_COUNTRY_IDS)
     end
 
+    def dial_in_code
+      codes = IsoCountryCodes.search_by_name(country_name)
+      codes.first.calling[1..-1]
+    rescue IsoCountryCodes::UnknownCodeError
+      nil
+    end
+
     def skipped?
       other_step(:uk_or_overseas).uk_or_overseas == UkOrOverseas::OPTIONS[:uk]
     end
 
     def reviewable_answers
       super.tap do |answers|
-        answers["country_id"] = self.class.options.key(country_id)
+        answers["country_id"] = country_name
       end
+    end
+
+  private
+
+    def country_name
+      self.class.options.key(country_id)
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_telephone.rb
@@ -16,6 +16,10 @@ module TeacherTrainingAdviser::Steps
       true
     end
 
+    def address_telephone_value
+      address_telephone || other_step(:overseas_country).dial_in_code
+    end
+
     def skipped?
       return true if super
 

--- a/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
@@ -24,6 +24,10 @@ module TeacherTrainingAdviser::Steps
       end
     end
 
+    def address_telephone_value
+      address_telephone || other_step(:overseas_country).dial_in_code
+    end
+
     def skipped?
       overseas_country_skipped = other_step(:overseas_country).skipped?
       degree_options = other_step(:have_a_degree).degree_options

--- a/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
@@ -1,3 +1,3 @@
 <%= f.govuk_fieldset legend: { text: 'What is your telephone number?' } do %>
-  <%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+" %>
+  <%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+", value: f.object.address_telephone_value %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
@@ -3,7 +3,7 @@
 <p>We will need to call you to discuss your qualifications. You must have the details of your overseas qualifications when we contact you.</p>
 <p>In the meantime, you can call us on Freephone <%= link_to("0800 389 2500", "tel://08003892500") %> between 8.30am and 5.30pm Monday to Friday.</p>
 
-<%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+" %>
+<%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+", value: f.object.address_telephone_value %>
 
 <% unless Rails.env.production? %>
   <%= f.govuk_collection_select :time_zone,

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -132,6 +132,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Continue"
 
       expect(page).to have_css "h1", text: "You told us you have an equivalent degree and live overseas"
+      expect(find_field("Contact telephone number").value).to eq "54"
       fill_in "Contact telephone number", with: "123456789"
       click_on "Continue"
 
@@ -197,6 +198,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Continue"
 
       expect(page).to have_css "h1", text: "You told us you have an equivalent degree and live overseas"
+      expect(find_field("Contact telephone number").value).to eq "54"
       fill_in "Contact telephone number", with: "123456789"
       select "(GMT-10:00) Hawaii"
       click_on "Continue"
@@ -284,6 +286,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Continue"
 
       expect(page).to have_css "h1", text: "What is your telephone number?"
+      expect(find_field("Overseas telephone number (optional)").value).to eq "54"
       fill_in "Overseas telephone number (optional)", with: "123456789"
       click_on "Continue"
 

--- a/spec/models/teacher_training_adviser/steps/overseas_country_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_country_spec.rb
@@ -43,4 +43,30 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasCountry do
 
     it { is_expected.to eq({ "country_id" => "Value" }) }
   end
+
+  describe "#dial_in_code" do
+    subject { instance.dial_in_code }
+
+    before do
+      countries = [
+        GetIntoTeachingApiClient::LookupItem.new(id: "italy-id", value: "Italy"),
+        GetIntoTeachingApiClient::LookupItem.new(id: "unknown-id", value: "Unknown"),
+      ]
+      allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
+        receive(:get_countries) { countries }
+      instance.country_id = country_id
+    end
+
+    context "when the country dial-in code is known" do
+      let(:country_id) { "italy-id" }
+
+      it { is_expected.to eq("39") }
+    end
+
+    context "when the country dial-in code is not known" do
+      let(:country_id) { "unknown-id" }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_telephone_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTelephone do
   include_context "wizard step"
   it_behaves_like "a wizard step"
   include_context "sanitize fields", %i[address_telephone]
+  include_context "#address_telephone_value"
 
   it { is_expected.to be_contains_personal_details }
   it { is_expected.to be_optional }

--- a/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTimeZone do
   include_context "wizard step"
   it_behaves_like "a wizard step"
   include_context "sanitize fields", %i[address_telephone]
+  include_context "#address_telephone_value"
 
   it { expect(described_class).to be TeacherTrainingAdviser::Steps::OverseasTimeZone }
 

--- a/spec/support/shared_examples/address_telephone_value.rb
+++ b/spec/support/shared_examples/address_telephone_value.rb
@@ -1,0 +1,24 @@
+RSpec.shared_examples "#address_telephone_value" do
+  describe "#address_telephone_value" do
+    subject { instance.address_telephone_value }
+
+    before do
+      instance.address_telephone = address_telephone
+      double = double("overseas_country")
+      allow(double).to receive(:dial_in_code) { "44" }
+      allow(instance).to receive(:other_step).with(:overseas_country) { double }
+    end
+
+    context "when address_telephone is present" do
+      let(:address_telephone) { "123456789" }
+
+      it { is_expected.to eq(address_telephone) }
+    end
+
+    context "when address_telephone is not present" do
+      let(:address_telephone) { nil }
+
+      it { is_expected.to eq("44") }
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-1618](https://trello.com/c/bOmVyBvV/1618-pre-fill-country-dial-in-code-from-country-selection)

### Context

A candidate selects their country of residence before entering their telephone number; we can lookup the dial-in code for their selected country and pre-fill the telephone input field to make entering their number easier/less error prone.

### Changes proposed in this pull request

- Prefill telephone dial-in code from country selection

### Guidance to review

