### PR TITLE
Various TTA changes based on feedback

### DIFF
--- a/app/models/teacher_training_adviser/steps/have_a_degree.rb
+++ b/app/models/teacher_training_adviser/steps/have_a_degree.rb
@@ -6,9 +6,9 @@ module TeacherTrainingAdviser::Steps
 
     DEGREE_OPTIONS = {
       yes: "yes",
+      equivalent: "equivalent",
       no: "no",
       studying: "studying",
-      equivalent: "equivalent",
     }.freeze
 
     DEGREE_STATUS_OPTIONS = {

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -16,7 +16,7 @@
           </ul>
           <h2 class="govuk-heading-m">Who can get an adviser?</h2>
           <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, or an overseas qualification that is equivalent.</p>
-          <p>You can get an adviser if you’re still studying for your degree. Before your final year, you can get advice for when you're ready to apply. If you're in your final year, you’ll need a predicted class 2:2 (honours) or higher.</p>
+          <p>You can get an adviser if you’re still studying for your degree. Before your final year, you can get advice for when you're ready to apply. If you're in your final year, you’ll need a predicted class 2:2 (honours) or higher.</p> 
           <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession to teach maths, physics or modern languages, you’ll need <a href = "https://www.gov.uk/guidance/qualified-teacher-status-qts">qualified teacher status (QTS)</a>.</p>
           <a href="<%= teacher_training_adviser_step_path(:identity) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
           Start now

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -17,7 +17,7 @@
           <h2 class="govuk-heading-m">Who can get an adviser?</h2>
           <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, or an overseas qualification that is equivalent.</p>
           <p>You can get an adviser if you’re still studying for your degree. Before your final year, you can get advice for when you're ready to apply. If you're in your final year, you’ll need a predicted class 2:2 (honours) or higher.</p>
-          <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession, you’ll need qualified teacher status (QTS).</p>
+          <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession to teach maths, physics or modern languages, you’ll need qualified teacher status (QTS).</p>
           <a href="<%= teacher_training_adviser_step_path(:identity) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -17,7 +17,7 @@
           <h2 class="govuk-heading-m">Who can get an adviser?</h2>
           <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, or an overseas qualification that is equivalent.</p>
           <p>You can get an adviser if you’re still studying for your degree. Before your final year, you can get advice for when you're ready to apply. If you're in your final year, you’ll need a predicted class 2:2 (honours) or higher.</p>
-          <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession to teach maths, physics or modern languages, you’ll need qualified teacher status (QTS).</p>
+          <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession to teach maths, physics or modern languages, you’ll need <a href = "https://www.gov.uk/guidance/qualified-teacher-status-qts">qualified teacher status (QTS)</a>.</p>
           <a href="<%= teacher_training_adviser_step_path(:identity) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -17,7 +17,7 @@
           <h2 class="govuk-heading-m">Who can get an adviser?</h2>
           <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, or an overseas qualification that is equivalent.</p>
           <p>You can get an adviser if you’re still studying for your degree. Before your final year, you can get advice for when you're ready to apply. If you're in your final year, you’ll need a predicted class 2:2 (honours) or higher.</p> 
-          <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession to teach maths, physics or modern languages, you’ll need <a href = "https://www.gov.uk/guidance/qualified-teacher-status-qts">qualified teacher status (QTS)</a>.</p>
+          <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession to teach maths, physics or modern languages, you’ll need <a href = "https://www.gov.uk/guidance/qualified-teacher-status-qts" target=\"blank\">qualified teacher status (QTS)</a>.</p>
           <a href="<%= teacher_training_adviser_step_path(:identity) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -17,7 +17,7 @@
           <h2 class="govuk-heading-m">Who can get an adviser?</h2>
           <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, or an overseas qualification that is equivalent.</p>
           <p>You can get an adviser if you’re still studying for your degree. Before your final year, you can get advice for when you're ready to apply. If you're in your final year, you’ll need a predicted class 2:2 (honours) or higher.</p> 
-          <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession to teach maths, physics or modern languages, you’ll need <a href = "https://www.gov.uk/guidance/qualified-teacher-status-qts" target=\"blank\">qualified teacher status (QTS)</a>.</p>
+          <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession to teach maths, physics or modern languages, you’ll need qualified teacher status (QTS)</a>.</p>
           <a href="<%= teacher_training_adviser_step_path(:identity) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">

--- a/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_fieldset legend: { text: 'You told us you have an equivalent degree and live overseas' } do %>
 
-<p>We will need to call you to discuss your qualifications. You must have the details of your overseas qualifications when we contact you.</p>
+<p>We will need to call you to check your degree. You must have the details of your overseas qualifications when we contact you.</p>
 <p>In the meantime, you can call us on Freephone <%= link_to("0800 389 2500", "tel://08003892500") %> between 8.30am and 5.30pm Monday to Friday.</p>
 
 <%= f.govuk_phone_field :address_telephone, width: 20 %>

--- a/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_fieldset legend: { text: 'You told us you have an equivalent degree and live in the United Kingdom' } do %>
 
-<p>You need to book a callback with us.  We will contact you once your call is booked.</p>
+<p>You need to book a callback with us to check your degree. We will contact you once your call is booked.</p>
 <p>You must have the details of your overseas qualifications when we contact you.</p>
 
 <%= f.govuk_phone_field :address_telephone, width: 20 %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,7 +152,7 @@ en:
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:
-        type_id_html: "Select 'yes' if you are a returning teacher and have <a href=\"https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa\" target=\"blank\">qualified teacher status</a> (QTS), or have an overseas teaching qualification that's equivalent to QTS."
+        type_id_html: "Select 'yes' if you are a returning teacher and have qualified teacher status (QTS), or have an overseas teaching qualification that's <a href=\"https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa\" target=\"blank\">equivalent to QTS</a>."
       teacher_training_adviser_steps_have_a_degree:
         degree_options: "To use this service your bachelor's degree or predicted grade needs to be a 2:2 class honours or above."
       teacher_training_adviser_steps_overseas_telephone:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,7 +62,7 @@ en:
       teacher_training_adviser_steps_gcse_maths_english:
         has_gcse_maths_and_english_id: "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?"
       teacher_training_adviser_steps_returning_teacher:
-        type_id: "Are you qualified to teach the the UK?"
+        type_id: "Are you qualified to teach in the UK?"
       teacher_training_adviser_steps_has_teacher_id:
         has_id: "Do you have your previous teacher reference number?"
       teacher_training_adviser_steps_have_a_degree:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,7 +152,7 @@ en:
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:
-        type_id_html: "Select 'yes' if you have previously taught in England and have <a href=\"https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa\" target=\"blank\">qualified teacher status</a> (QTS), or have an overseas teaching qualification that's equivalent to QTS."
+        type_id_html: "Select 'yes' if you are a returning teacher and have <a href=\"https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa\" target=\"blank\">qualified teacher status</a> (QTS), or have an overseas teaching qualification that's equivalent to QTS."
       teacher_training_adviser_steps_have_a_degree:
         degree_options: "To use this service your bachelor's degree or predicted grade needs to be a 2:2 class honours or above."
       teacher_training_adviser_steps_overseas_telephone:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,7 +152,7 @@ en:
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:
-        type_id_html: "Select 'yes' if you have an overseas teaching qualification that's equivalent to <a href=\"https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa\" target=\"blank\">qualified teacher status</a> (QTS)."
+        type_id_html: "Select 'yes' if you have previously taught in England and are returning to the profession, or have an overseas teaching qualification that's equivalent to <a href=\"https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa\" target=\"blank\">qualified teacher status</a> (QTS)."
       teacher_training_adviser_steps_have_a_degree:
         degree_options: "To use this service your bachelor's degree or predicted grade needs to be a 2:2 class honours or above."
       teacher_training_adviser_steps_overseas_telephone:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,7 +152,7 @@ en:
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:
-        type_id_html: "Select 'yes' if you have previously taught in England and are returning to the profession, or have an overseas teaching qualification that's equivalent to <a href=\"https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa\" target=\"blank\">qualified teacher status</a> (QTS)."
+        type_id_html: "Select 'yes' if you have previously taught in England and have <a href=\"https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa\" target=\"blank\">qualified teacher status</a> (QTS), or have an overseas teaching qualification that's equivalent to QTS."
       teacher_training_adviser_steps_have_a_degree:
         degree_options: "To use this service your bachelor's degree or predicted grade needs to be a 2:2 class honours or above."
       teacher_training_adviser_steps_overseas_telephone:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,7 +152,7 @@ en:
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:
-        type_id: "Select 'yes' if you have an overseas teaching qualification that's equivalent to <a href=\"https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa\" target=\"blank\">qualified teacher status</a> (QTS)."
+        type_id_html: "Select 'yes' if you have an overseas teaching qualification that's equivalent to <a href=\"https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa\" target=\"blank\">qualified teacher status</a> (QTS)."
       teacher_training_adviser_steps_have_a_degree:
         degree_options: "To use this service your bachelor's degree or predicted grade needs to be a 2:2 class honours or above."
       teacher_training_adviser_steps_overseas_telephone:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,7 +152,7 @@ en:
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:
-        type_id: "Select 'yes' if you have an overseas teaching qualification that's equivalent to qualified teacher status (QTS)."
+        type_id: "Select 'yes' if you have an overseas teaching qualification that's equivalent to <a href="https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa" target=\"blank\">qualified teacher status</a> (QTS)."
       teacher_training_adviser_steps_have_a_degree:
         degree_options: "To use this service your bachelor's degree or predicted grade needs to be a 2:2 class honours or above."
       teacher_training_adviser_steps_overseas_telephone:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,9 +141,9 @@ en:
       teacher_training_adviser_steps_have_a_degree:
         degree_options_options:
           "yes": "Yes"
-          "no": "No"
-          studying: "I'm studying for a degree"
           equivalent: "I have an equivalent qualification from another country"
+          "no": "No"
+          studying: "I'm studying for a degree"      
     hint:
       teacher_training_adviser_steps_what_subject_degree:
         degree_subject: "If your subject is not listed choose the option that is nearest to your degree."
@@ -164,9 +164,9 @@ en:
   have_a_degree:
     degree_options:
       "yes": "Yes"
+      equivalent: "I have an equivalent qualification from another country"
       "no": "No"
       studying: "I'm studying for a degree"
-      equivalent: "I have an equivalent qualification from another country"
   answers:
     identity:
       name: "Name"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,7 +141,7 @@ en:
       teacher_training_adviser_steps_have_a_degree:
         degree_options_options:
           "yes": "Yes"
-          equivalent: "I have an equivalent qualification from another country"
+          equivalent: "I have, or I'm studying for, an equivalent qualification from another country"
           "no": "No"
           studying: "I'm studying for a degree"      
     hint:
@@ -164,7 +164,7 @@ en:
   have_a_degree:
     degree_options:
       "yes": "Yes"
-      equivalent: "I have an equivalent qualification from another country"
+      equivalent: "I have, or I'm studying for, an equivalent qualification from another country"
       "no": "No"
       studying: "I'm studying for a degree"
   answers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,7 +62,7 @@ en:
       teacher_training_adviser_steps_gcse_maths_english:
         has_gcse_maths_and_english_id: "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?"
       teacher_training_adviser_steps_returning_teacher:
-        type_id: "Are you qualified to teaching the the UK?"
+        type_id: "Are you qualified to teach the the UK?"
       teacher_training_adviser_steps_has_teacher_id:
         has_id: "Do you have your previous teacher reference number?"
       teacher_training_adviser_steps_have_a_degree:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,8 +152,8 @@ en:
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:
-      teacher_training_adviser_steps_have_a_degree:
         type_id: "Select 'yes' if you have an overseas teaching qualification that's equivalent to <a href=\"https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa\" target=\"blank\">qualified teacher status</a> (QTS)."
+      teacher_training_adviser_steps_have_a_degree:
         degree_options: "To use this service your bachelor's degree or predicted grade needs to be a 2:2 class honours or above."
       teacher_training_adviser_steps_overseas_telephone:
         address_telephone_html: "We recommend you provide us with your phone number as this is the most effective way to talk to your adviser.<br /><br />For international numbers include the country code."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,7 +62,7 @@ en:
       teacher_training_adviser_steps_gcse_maths_english:
         has_gcse_maths_and_english_id: "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?"
       teacher_training_adviser_steps_returning_teacher:
-        type_id: "Are you returning to teaching?"
+        type_id: "Are you qualified to teaching the the UK?"
       teacher_training_adviser_steps_has_teacher_id:
         has_id: "Do you have your previous teacher reference number?"
       teacher_training_adviser_steps_have_a_degree:
@@ -198,7 +198,7 @@ en:
     retake_gcse_science:
       planning_to_retake_gcse_science_id: "Are you planning to retake your science GCSE?"
     returning_teacher:
-      returning_to_teaching: "Are you returning to teaching?"
+      returning_to_teaching: "Are you qualified to teach in the UK?"
     stage_interested_teaching:
       preferred_education_phase_id: "Which stage are you interested in teaching?"
     stage_of_degree:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,8 +152,8 @@ en:
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:
-        type_id: "Select 'yes' if you have an overseas teaching qualification that's equivalent to <a href="https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa" target=\"blank\">qualified teacher status</a> (QTS)."
       teacher_training_adviser_steps_have_a_degree:
+        type_id: "Select 'yes' if you have an overseas teaching qualification that's equivalent to <a href=\"https://www.gov.uk/guidance/qualified-teacher-status-qts#teachers-from-the-eu-iceland-liechtenstein-norway-switzerland-australia-canada-new-zealand-or-usa\" target=\"blank\">qualified teacher status</a> (QTS)."
         degree_options: "To use this service your bachelor's degree or predicted grade needs to be a 2:2 class honours or above."
       teacher_training_adviser_steps_overseas_telephone:
         address_telephone_html: "We recommend you provide us with your phone number as this is the most effective way to talk to your adviser.<br /><br />For international numbers include the country code."

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -104,7 +104,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Continue"
 
       expect(page).to have_css "h1", text: "Do you have a degree?"
-      choose "I have an equivalent qualification from another country"
+      choose "I have, or I'm studying for, an equivalent qualification from another country"
       click_on "Continue"
 
       expect(page).to have_css "h1", text: "Which stage are you interested in teaching?"
@@ -169,7 +169,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Continue"
 
       expect(page).to have_css "h1", text: "Do you have a degree?"
-      choose "I have an equivalent qualification from another country"
+      choose "I have, or I'm studying for, an equivalent qualification from another country"
       click_on "Continue"
 
       expect(page).to have_css "h1", text: "Which stage are you interested in teaching?"
@@ -578,7 +578,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Continue"
 
       expect(page).to have_css "h1", text: "Do you have a degree?"
-      choose "I have an equivalent qualification from another country"
+      choose "I have, or I'm studying for, an equivalent qualification from another country"
       click_on "Continue"
 
       expect(page).to have_css "h1", text: "Which stage are you interested in teaching?"

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in_identity_step
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Are you returning to teaching?"
+      expect(page).to have_css "h1", text: "Are you qualified to teach in the UK?"
       choose "Yes"
       click_on "Continue"
 
@@ -99,7 +99,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in_identity_step
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Are you returning to teaching?"
+      expect(page).to have_css "h1", text: "Are you qualified to teach in the UK?"
       choose "No"
       click_on "Continue"
 
@@ -164,7 +164,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in_identity_step
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Are you returning to teaching?"
+      expect(page).to have_css "h1", text: "Are you qualified to teach in the UK?"
       choose "No"
       click_on "Continue"
 
@@ -235,7 +235,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in_identity_step
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Are you returning to teaching?"
+      expect(page).to have_css "h1", text: "Are you qualified to teach in the UK?"
       choose "No"
       click_on "Continue"
 
@@ -319,7 +319,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in_identity_step
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Are you returning to teaching?"
+      expect(page).to have_css "h1", text: "Are you qualified to teach in the UK?"
       choose "Yes"
       click_on "Continue"
 
@@ -361,7 +361,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in_identity_step
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Are you returning to teaching?"
+      expect(page).to have_css "h1", text: "Are you qualified to teach in the UK?"
       choose "No"
       click_on "Continue"
 
@@ -380,7 +380,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in_identity_step
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Are you returning to teaching?"
+      expect(page).to have_css "h1", text: "Are you qualified to teach in the UK?"
       choose "No"
       click_on "Continue"
 
@@ -427,7 +427,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in_identity_step
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Are you returning to teaching?"
+      expect(page).to have_css "h1", text: "Are you qualified to teach in the UK?"
       choose "No"
       click_on "Continue"
 
@@ -466,7 +466,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in_identity_step
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Are you returning to teaching?"
+      expect(page).to have_css "h1", text: "Are you qualified to teach in the UK?"
       choose "No"
       click_on "Continue"
 
@@ -505,7 +505,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in_identity_step
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Are you returning to teaching?"
+      expect(page).to have_css "h1", text: "Are you qualified to teach in the UK?"
       choose "Yes"
       click_on "Continue"
 
@@ -573,7 +573,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in "wizard-steps-authenticate-timed-one-time-password-field-error", with: valid_code
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Are you returning to teaching?"
+      expect(page).to have_css "h1", text: "Are you qualified to teach in the UK?"
       choose "No"
       click_on "Continue"
 
@@ -652,7 +652,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in "wizard-steps-authenticate-timed-one-time-password-field", with: valid_code
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Are you returning to teaching?"
+      expect(page).to have_css "h1", text: "Are you qualified to teach in the UK?"
       choose "Yes"
       click_on "Continue"
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/SS8BgX7s/1611-get-an-adviser-copy-suggestions-to-review

### Context
We've had a variety of requests from Candidate Experience around how we could improve our Get an Adviser flow. This comes off the back of feedback that many users are going down the 'returners' route when they should be going down the standard, teacher training adviser, route. Some of these copy changes aim to help rectify that issue, which is having a knock on effect on TPUK.

### Changes proposed in this pull request

### Guidance to review

