### PR TITLE
Update telephone validation

### DIFF
--- a/app/validators/telephone_validator.rb
+++ b/app/validators/telephone_validator.rb
@@ -1,6 +1,6 @@
 class TelephoneValidator < ActiveModel::EachValidator
   TELEPHONE_FORMAT = %r{\A[^a-zA-Z]+\z}.freeze
-  MINIMUM_LENGTH = 6
+  MINIMUM_LENGTH = 5
   MAXIMUM_LENGTH = 20
 
   def validate_each(record, attribute, value)
@@ -18,10 +18,10 @@ private
   end
 
   def too_short?(telephone)
-    telephone.to_s.length < MINIMUM_LENGTH
+    telephone.to_s.length <= MINIMUM_LENGTH
   end
 
   def too_long?(telephone)
-    telephone.to_s.length > MAXIMUM_LENGTH
+    telephone.to_s.length => MAXIMUM_LENGTH
   end
 end

--- a/spec/validators/telephone_validator_spec.rb
+++ b/spec/validators/telephone_validator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TelephoneValidator do
   subject { instance.errors.details[:telephone] }
 
   context "when too short" do
-    let(:instance) { TelephoneTestModel.new(telephone: "123") }
+    let(:instance) { TelephoneTestModel.new(telephone: "1234") }
     it { is_expected.to include error: :too_short }
   end
 


### PR DESCRIPTION
The API is checking 5-20 characters, inclusive whereas the app was checking 5-19, inclusive -- this aligns them to avoid a potential error.