### PR TITLE
Fix bug on pre-filling country dial-in code

### DIFF
--- a/app/models/teacher_training_adviser/steps/overseas_country.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_country.rb
@@ -16,6 +16,8 @@ module TeacherTrainingAdviser::Steps
     end
 
     def dial_in_code
+      return nil if country_name.blank?
+
       codes = IsoCountryCodes.search_by_name(country_name)
       codes.first.calling[1..-1]
     rescue IsoCountryCodes::UnknownCodeError

--- a/spec/models/teacher_training_adviser/steps/overseas_country_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_country_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasCountry do
       it { is_expected.to eq("39") }
     end
 
+    context "when the country has not been selected (the user skipped ahead)" do
+      let(:country_id) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
     context "when the country dial-in code is not known" do
       let(:country_id) { "unknown-id" }
 


### PR DESCRIPTION
If the user gets to the step asking them for their overseas telephone number before they have specified their country of residence we get an exception due to the `country_name` being `nil`. This should only be possible if someone skips ahead by manually entering the URL of a future step or if their session expires part way through, perhaps.

Default to no country-code being pre-filled if the country of residence is not yet known.
