### PR TITLE
Show booking slots as available unless they are in the next hour

### DIFF
--- a/app/models/concerns/callback_booking_quotas.rb
+++ b/app/models/concerns/callback_booking_quotas.rb
@@ -2,7 +2,8 @@ module CallbackBookingQuotas
   def callback_booking_quotas
     quotas = GetIntoTeachingApiClient::CallbackBookingQuotasApi.new.get_callback_booking_quotas
     quotas.reject do |quota|
-      quota.start_at.in_time_zone.today?
+      time_away = quota.start_at.utc - DateTime.now.utc
+      time_away <= 1.hour
     end
   end
 end

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -15,6 +15,19 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
   SUBJECT_PHYSICS = "ac2655a1-2afa-e811-a981-000d3a276620".freeze
   SUBJECT_PSYCHOLOGY = "b22655a1-2afa-e811-a981-000d3a276620".freeze
 
+  let(:quota) do
+    GetIntoTeachingApiClient::CallbackBookingQuota.new(
+      startAt: DateTime.now.utc + 2.hours,
+      endAt: DateTime.now.utc + 3.hours,
+    )
+  end
+
+  before do
+    # Future callback booking slots (the VCR cassette contains outdated ones)
+    allow_any_instance_of(GetIntoTeachingApiClient::CallbackBookingQuotasApi).to \
+      receive(:get_callback_booking_quotas) { [quota] }
+  end
+
   context "a new candidate" do
     before do
       # Emulate an unsuccessful matchback response from the API.
@@ -629,7 +642,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
         degree_status_id: DEGREE_STATUS_HAS_DEGREE,
         degree_type_id: DEGREE_TYPE_EQUIVALENT,
         initial_teacher_training_year_id: TEACHER_TRAINING_YEAR_2022,
-        phone_call_scheduled_at: "2020-08-19T08:00:00.000Z",
+        phone_call_scheduled_at: "#{quota.start_at.strftime('%Y-%m-%dT%H:%M:%S')}.000Z",
         date_of_birth: "1999-04-27",
         address_line1: "7 Main Street",
         address_line2: nil,

--- a/spec/support/shared_examples/callback_booking_quotas.rb
+++ b/spec/support/shared_examples/callback_booking_quotas.rb
@@ -4,21 +4,20 @@ RSpec.shared_examples "exposes callback booking quotas" do
       receive(:get_callback_booking_quotas) { quotas }
   end
 
-  let(:utc_today) { DateTime.now.utc }
-  let(:utc_tomorrow) { Time.utc(2020, 4, 7, 10) }
-  let(:quota_today) do
+  let(:utc_now) { DateTime.now.utc }
+  let(:quota_in_30_minutes) do
     GetIntoTeachingApiClient::CallbackBookingQuota.new(
-      startAt: utc_today,
-      endAt: utc_today + 30.minutes,
+      startAt: utc_now + 30.minutes,
+      endAt: utc_now + 60.minutes,
     )
   end
-  let(:quota_tomorrow) do
+  let(:quota_in_90_minutes) do
     GetIntoTeachingApiClient::CallbackBookingQuota.new(
-      startAt: utc_tomorrow,
-      endAt: utc_tomorrow + 30.minutes,
+      startAt: utc_now + 90.minutes,
+      endAt: utc_now + 120.minutes,
     )
   end
-  let(:quotas) { [quota_today, quota_tomorrow] }
+  let(:quotas) { [quota_in_30_minutes, quota_in_90_minutes] }
 
   describe "#callback_booking_quotas" do
     let(:time_zone) { "UTC" }
@@ -29,6 +28,6 @@ RSpec.shared_examples "exposes callback booking quotas" do
       Time.use_zone(time_zone) { example.run }
     end
 
-    it { is_expected.to eq([quota_tomorrow]) }
+    it { is_expected.to contain_exactly(quota_in_90_minutes) }
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-1626](https://trello.com/c/SRdITVG8/1626-international-dialing-outstanding-issues)

### Context

We were previously limiting the earliest booking slots to the following day, however we now want to allow candidates to book a slot on the current day, but omit any in the next hour to give TPUK enough time to receive and process the
booking.

### Changes proposed in this pull request

- Show booking slots as available unless they are in the next hour

### Guidance to review

