### PR TITLE
Rename accept cookies button id to bypass ad-blockers

### DIFF
--- a/app/views/shared/_cookie_banner.html.erb
+++ b/app/views/shared/_cookie_banner.html.erb
@@ -5,10 +5,14 @@
     data-cookie-acceptance-target="banner">
     <p><strong>Tell us whether you accept cookies</strong></p>
     <p>
-    We use <%= link_to "cookies to collect information", cookies_path %> about how you use this site. 
+    We use <%= link_to "cookies to collect information", cookies_path %> about how you use this site.
     We use this information to make the website work as well as possible and improve our services.
     </p>
-    <%= link_to "Accept all cookies", "#", id: "cookies-agree",
+    <!--
+      The id is `biscuits-agrees` instead of `cookies-agree`
+      to prevent ad blockers from removing the button.
+    -->
+    <%= link_to "Accept all cookies", "#", id: "biscuits-agree",
           class: "govuk-button", data: {
             action: "cookie-acceptance#allowAll",
             "cookie-acceptance-target": "accept"


### PR DESCRIPTION
### Trello card

[Trello-1623](https://trello.com/c/6yvBReQt/1623-investigate-the-impacts-of-privacy-software-on-the-usability-of-the-site)

### Context

It appears that AdBlockers in general allow our cookie modal to appear, however they hide the "Accept all cookies" button (seemingly targetting the `id` because it includes `cookie`).

A workaround is to rename the `id` to something else - I've left a note in the code to prevent this from being changed back in the future.

### Changes proposed in this pull request

- Rename accept cookies button id to bypass ad-blockers

### Guidance to review

The only way I was able to replicate this bug was to install uBlock and enable all of the 'annoyances' under filters:

<img width="269" alt="Screenshot 2021-06-10 at 10 52 20" src="https://user-images.githubusercontent.com/29867726/121504463-ef9c0d80-c9d9-11eb-841d-7bbb0992dfb9.png">
