### PR TITLE
Use env variable to control basic auth on/off

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,6 +54,7 @@ Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
   config.x.enable_beta_redirects = false
   config.x.api_client_cache_store = ActiveSupport::Cache::MemoryStore.new
+  config.x.basic_auth = ENV["BASIC_AUTH"]
 
   config.session_store :cache_store,
                        key: "_dfe_session",

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,6 +99,7 @@ Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-prod.london.cloudapps.digital"
   config.x.enable_beta_redirects = true
   config.x.api_client_cache_store = ActiveSupport::Cache::RedisCacheStore.new(namespace: "TTA-HTTP")
+  config.x.basic_auth = ENV["BASIC_AUTH"]
 
   config.session_store :cache_store,
                        key: "_dfe_session",

--- a/lib/basic_auth.rb
+++ b/lib/basic_auth.rb
@@ -18,9 +18,11 @@ class BasicAuth
     end
 
     def env_requires_auth?
-      # Site-wide authentication present in all production-like
-      # environments, but not in production itself.
-      !Rails.env.production? && !Rails.env.test? && !Rails.env.development?
+      basic_auth = Rails.application.config.x.basic_auth
+
+      return false if basic_auth.blank?
+
+      ActiveModel::Type::Boolean.new.cast(basic_auth)
     end
   end
 end

--- a/spec/lib/basic_auth_spec.rb
+++ b/spec/lib/basic_auth_spec.rb
@@ -12,21 +12,22 @@ RSpec.describe BasicAuth do
   end
 
   describe ".env_requires_auth?" do
-    before { allow(Rails).to receive(:env) { env.inquiry } }
+    before { allow(Rails.application.config.x).to receive(:basic_auth) { basic_auth } }
     subject { instance.env_requires_auth? }
 
-    ENV_AUTH = {
-      "production" => false,
-      "rolling" => true,
-      "preprod" => true,
-      "userresearch" => true,
-      "test" => false,
-      "development" => false,
+    basic_auth_values = {
+      nil => false,
+      0 => false,
+      "" => false,
+      "1" => true,
+      "true" => true,
+      true => true,
+      "enabled" => true,
     }.freeze
 
-    ENV_AUTH.each do |k, auth|
-      context "when #{k}" do
-        let(:env) { k }
+    basic_auth_values.each do |k, auth|
+      context "when basic_auth is #{k}" do
+        let(:basic_auth) { k }
 
         it { is_expected.to eq(auth) }
       end

--- a/spec/requests/basic_auth_spec.rb
+++ b/spec/requests/basic_auth_spec.rb
@@ -8,13 +8,8 @@ RSpec.describe "Basic auth", type: :request do
     allow_basic_auth_users([{ username: username, password: password }])
   end
 
-  it "is not enforced on non-production environments" do
-    get root_path
-    expect(response).to be_successful
-  end
-
-  context "when production" do
-    before { allow(Rails).to receive(:env) { "production".inquiry } }
+  context "when basic auth is disabled" do
+    before { allow(Rails.application.config.x).to receive(:basic_auth) { "0" } }
 
     it "is not enforced" do
       get root_path
@@ -22,8 +17,8 @@ RSpec.describe "Basic auth", type: :request do
     end
   end
 
-  context "when production-like (but not production)" do
-    before { allow(Rails).to receive(:env) { "rolling".inquiry } }
+  context "when basic auth is enabled" do
+    before { allow(Rails.application.config.x).to receive(:basic_auth) { "1" } }
 
     it "returns unauthorized if credentials do not match" do
       get root_path, params: {}, headers: basic_auth_headers(username, "wrong-password")

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -154,9 +154,10 @@ RSpec.describe "Feedback" do
       ])
     end
 
-    context "when in production" do
+    context "when in production and basic auth is disabled" do
       before do
         allow(Rails).to receive(:env) { "production".inquiry }
+        allow(Rails.application.config.x).to receive(:basic_auth) { "0" }
       end
 
       describe "#new" do
@@ -225,9 +226,10 @@ RSpec.describe "Feedback" do
       end
     end
 
-    context "when in a production-like environment (rolling/preprod)" do
+    context "when in a production-like environment (rolling/preprod) and basic auth is enabled" do
       before do
         allow(Rails).to receive(:env) { "rolling".inquiry }
+        allow(Rails.application.config.x).to receive(:basic_auth) { "1" }
       end
 
       describe "#new" do

--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -1,5 +1,5 @@
 locals {
-  environment_map = {}
+  environment_map = { BASIC_AUTH = var.basic_auth }
 }
 
 resource "cloudfoundry_app" "adviser_application" {

--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -5,6 +5,7 @@ paas_linked_services          = ["get-into-teaching-prod-redis-svc", "get-into-t
 paas_additional_route_names   = ["beta-adviser-getintoteaching", "adviser-getintoteaching"]
 logging                       = 1
 instances                     = 2
+basic_auth                    = 0
 azure_key_vault               = "s146p01-kv"
 azure_resource_group          = "s146p01-rg"
 alerts = {

--- a/terraform/paas/ur.env.tfvars
+++ b/terraform/paas/ur.env.tfvars
@@ -3,6 +3,7 @@ paas_adviser_application_name = "get-teacher-training-adviser-service-ur"
 paas_adviser_route_name       = "get-teacher-training-adviser-service-ur"
 paas_linked_services          = ["get-into-teaching-test-redis-svc", "get-into-teaching-api-test-pg-common-svc"]
 logging                       = 0
+basic_auth                    = 0
 alerts                        = {}
 azure_key_vault               = "s146t01-kv"
 azure_resource_group          = "s146t01-rg"

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -26,6 +26,10 @@ variable "instances" {
   default = 1
 }
 
+variable "basic_auth" {
+   default = 1
+}
+
 variable "paas_logging_name" {
   default = "logit-ssl-drain"
 }


### PR DESCRIPTION
- Use env variable to control basic auth on/off

Instead of controlling explicitly by the named environment we want to be able to toggle basic auth on/off with an env variable more easily.

- Add BASIC_AUTH env to infrastructure

Enabled by default, disabled in production and UR environments.
