### PR TITLE
(Hopefully) fix flakey rate limit specs

### DIFF
--- a/spec/support/shared_examples/rate_limiting_support.rb
+++ b/spec/support/shared_examples/rate_limiting_support.rb
@@ -4,6 +4,7 @@ RSpec.shared_examples "an IP-based rate limited endpoint" do |desc, limit, perio
 
     before do
       allow(Rack::Attack.cache).to receive(:store) { memory_store }
+      freeze_time
       request_count.times { perform_request }
     end
 
@@ -12,7 +13,7 @@ RSpec.shared_examples "an IP-based rate limited endpoint" do |desc, limit, perio
     context "when fewer than rate limit" do
       let(:request_count) { limit - 1 }
 
-      it { is_expected.to_not eq(429) }
+      it { is_expected.not_to eq(429) }
     end
 
     context "when more than rate limit" do
@@ -22,9 +23,9 @@ RSpec.shared_examples "an IP-based rate limited endpoint" do |desc, limit, perio
 
       context "when time restriction has passed" do
         it "allows another request" do
-          travel period + 1.second
+          travel period + 10.seconds
           perform_request
-          expect(response.status).to_not eq(429)
+          expect(response.status).not_to eq(429)
         end
       end
     end


### PR DESCRIPTION
### Trello card

[Trello-1682](https://trello.com/c/G58c4oz0/1682-investigate-flakey-rate-limit-specs-in-the-app-tta)

### Context

These appear to fail completely at random - an rspec bisect results in a test sequence that subsequently passes.

My theory is that `Rack::Attack` works on time boundaries rather than a rolling window; so I expect if the test runs across a minute boundary and the period is also 1 minute then it will fail because it expects a 429 and gets a 200. To avoid this I am freezing time at the start of the test. I've also added more padding to the travel time to check the rate limit doesn't apply after the period has elapsed (10 seconds up from 1 second) incase there's something iffy going on there as well.

### Changes proposed in this pull request

- (Hopefully) fix flakey rate limit specs

### Guidance to review

