### PR TITLE
Use default Prometheus client data store

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,22 +15,9 @@ require "action_view/railtie"
 # require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
-require "prometheus/client/data_stores/direct_file_store"
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-
-PROMETHEUS_DIR = "/tmp/prometheus".freeze
-
-# Needs to clear before initializing.
-Dir["#{PROMETHEUS_DIR}/*.bin"].each do |file_path|
-  File.unlink(file_path)
-end
-
-# The DirectFileStore is the only way to aggregate metrics across processes.
-file_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: PROMETHEUS_DIR)
-Prometheus::Client.config.data_store = file_store
 
 module GetIntoTeachingRegister
   class Application < Rails::Application


### PR DESCRIPTION
We don't need to use the `DataFileStore` as we only run a single Puma process.
