### PR TITLE
Fix flakey spec caused by Time.zone

### DIFF
--- a/spec/helpers/answer_helper_spec.rb
+++ b/spec/helpers/answer_helper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AnswerHelper, type: :helper do
   describe "#format_answer" do
     let(:time_zone) { "UTC" }
 
-    before { Time.zone = time_zone }
+    before { allow(Time).to receive(:zone) { time_zone } }
 
     it "correctly formats a date" do
       answer = Date.new(2011, 1, 24)


### PR DESCRIPTION
### Trello card

[Trello-1715](https://trello.com/c/y9CGlnNR/1715-investigate-flakey-tta-spec)

### Context

The `AnswerHelper` spec was modifying `Time.zone` directly; this effected the contract specs on occasion as the `StepsController` also sets `Time.zone` to the users locale. Instead, we should stub `Time.zone` so that it can be changed
in the scope of the test being ran.

### Changes proposed in this pull request

- Fix flakey spec caused by Time.zone

### Guidance to review

