### PR TITLE
Add helptext for Year of Start

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,7 +153,7 @@ en:
           Your adviser can talk to you by text and WhatsApp, as well as by
           phone call. Giving your phone number is the easiest way to talk to an
           adviser.
-      start_teacher_training:
+      teacher_training_adviser_steps_start_teacher_training:
         initial_teacher_training_year_id: "Most initial teacher training courses in 2021 start in September. If you are planning to apply before this, select 2021."
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,6 +153,8 @@ en:
           Your adviser can talk to you by text and WhatsApp, as well as by
           phone call. Giving your phone number is the easiest way to talk to an
           adviser.
+      start_teacher_training:
+        initial_teacher_training_year_id: "Most initial teacher training courses in 2021 start in September. If you are planning to apply before this, select 2021."
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,7 +154,7 @@ en:
           phone call. Giving your phone number is the easiest way to talk to an
           adviser.
       teacher_training_adviser_steps_start_teacher_training:
-        initial_teacher_training_year_id: "Most initial teacher training courses in 2021 start in September. If you are planning to apply before this, select 2021."
+        initial_teacher_training_year_id: "Most initial teacher training courses for 2021 start in September. If you are planning to apply before this, select 2021."
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,7 +154,7 @@ en:
           phone call. Giving your phone number is the easiest way to talk to an
           adviser.
       teacher_training_adviser_steps_start_teacher_training:
-        initial_teacher_training_year_id: "Most initial teacher training courses for 2021 start in September. If you are planning to apply before this, select 2021."
+        initial_teacher_training_year_id: "Only select 2021 if you want to start your teacher training this September."
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:


### PR DESCRIPTION
We're seeing many people click 2021 when actually they want to apply in 2022. Adding some suggested help text to see if this helps.

This is the first of 2 changes. The other (changing drop down options) will be done in a separate PR.
