### PR TITLE
Update labels for teacher training years

### DIFF
--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -40,7 +40,7 @@ module TeacherTrainingAdviser::Steps
       if year == current_year
         "#{year} - start your training this September"
       else
-        "#{year}"
+        year.to_s
       end
     end
 

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -40,7 +40,7 @@ module TeacherTrainingAdviser::Steps
       if year == current_year
         "#{year} - start your training this September"
       else
-        "#{year} - start your training in September #{year}"
+        "#{year}"
       end
     end
 

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -14,8 +14,12 @@ module TeacherTrainingAdviser::Steps
     end
 
     def years
-      years = GetIntoTeachingApiClient::PickListItemsApi.new.get_candidate_initial_teacher_training_years
-      years.select { |year| year.id == NOT_SURE_ID || year.value.to_i.between?(first_year, first_year + (NUMBER_OF_YEARS - 1)) }
+      items = GetIntoTeachingApiClient::PickListItemsApi.new.get_candidate_initial_teacher_training_years
+
+      filter_items(items).map do |item|
+        item.value = formatted_value(item)
+        item
+      end
     end
 
     def year_ids
@@ -28,11 +32,33 @@ module TeacherTrainingAdviser::Steps
 
   private
 
+    def formatted_value(item)
+      return item.value if item.id == NOT_SURE_ID
+
+      year = item.value.to_i
+
+      if year == current_year
+        "#{year} - start your training this September"
+      else
+        "#{year} - start your training in September #{year}"
+      end
+    end
+
+    def filter_items(items)
+      items.select do |item|
+        item.id == NOT_SURE_ID ||
+          item.value.to_i.between?(first_year, first_year + (NUMBER_OF_YEARS - 1))
+      end
+    end
+
     def first_year
       # After 17th September you can no longer start teacher training for that year.
-      current_year = Time.zone.today.year
       include_current_year = Time.zone.today < Date.new(current_year, 9, 18)
       include_current_year ? current_year : current_year + 1
+    end
+
+    def current_year
+      Time.zone.today.year
     end
   end
 end

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
         expect(years.map(&:value)).to contain_exactly(
           "Not sure",
           "2020 - start your training this September",
-          "2021 - start your training in September 2021",
-          "2022 - start your training in September 2022",
+          "2021",
+          "2022",
         )
       end
     end
@@ -60,8 +60,8 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
         expect(years.map(&:value)).to contain_exactly(
           "Not sure",
           "2021 - start your training in September 2021",
-          "2022 - start your training in September 2022",
-          "2023 - start your training in September 2023",
+          "2022",
+          "2023",
         )
       end
     end

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -42,7 +42,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
       end
 
       it "returns 'Not sure', and the current year plus next 2 years" do
-        expect(years.map(&:value)).to eq(["Not sure", 2020, 2021, 2022])
+        expect(years.map(&:value)).to contain_exactly(
+          "Not sure",
+          "2020 - start your training this September",
+          "2021 - start your training in September 2021",
+          "2022 - start your training in September 2022",
+        )
       end
     end
 
@@ -52,7 +57,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
       end
 
       it "returns 'Not sure', and the next 3 years" do
-        expect(years.map(&:value)).to eq(["Not sure", 2021, 2022, 2023])
+        expect(years.map(&:value)).to contain_exactly(
+          "Not sure",
+          "2021 - start your training in September 2021",
+          "2022 - start your training in September 2022",
+          "2023 - start your training in September 2023",
+        )
       end
     end
   end

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
       it "returns 'Not sure', and the next 3 years" do
         expect(years.map(&:value)).to contain_exactly(
           "Not sure",
-          "2021 - start your training in September 2021",
+          "2021",
           "2022",
           "2023",
         )


### PR DESCRIPTION
### Trello card

[Trello-1725](https://trello.com/c/TgiZwDpw/1725-update-copy-for-tta-start-teacher-training-year-options)

### Context

We want to update the labels fo the teacher training years, which come back from the CRM as '2021', 2022', etc. Instead, if the year is the current year we want to show the format:

```
<year> - start your training this September
```

We only show the current year up until September. If the year is a future year we want to use the format:

```
<year> - start your training in September <year>
```

### Changes proposed in this pull request

- Update labels for teacher training years

### Guidance to review

https://review-teacher-training-adviser-760.london.cloudapps.digital/teacher_training_adviser/sign_up/start_teacher_training