### PR TITLE
Allow some candidates to re-subscribe for a TTA

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 3ed0a85103fd8ba51b120076314f511d0dcfb4dd
+  revision: 268033a9e88dcbbf8bba1a5deb40f92a243e9c71
   specs:
     get_into_teaching_api_client (1.1.17)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.40)
+    get_into_teaching_api_client_faraday (0.1.42)
       activesupport
       faraday
       faraday-encoding
@@ -121,7 +121,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.5.1)
+    faraday (1.6.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -129,6 +129,7 @@ GEM
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
       faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
@@ -142,7 +143,8 @@ GEM
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
-    faraday_middleware (1.0.0)
+    faraday-rack (1.0.0)
+    faraday_middleware (1.1.0)
       faraday (~> 1.0)
     faraday_middleware-circuit_breaker (0.4.1)
       faraday (>= 0.9, < 2.0)

--- a/app/models/teacher_training_adviser/steps/already_signed_up.rb
+++ b/app/models/teacher_training_adviser/steps/already_signed_up.rb
@@ -1,7 +1,8 @@
 module TeacherTrainingAdviser::Steps
   class AlreadySignedUp < Wizard::Step
     def skipped?
-      !@store["already_subscribed_to_teacher_training_adviser"]
+      can_subscribe = @store["can_subscribe_to_teacher_training_adviser"]
+      can_subscribe.nil? || can_subscribe
     end
 
     def can_proceed?

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -7,7 +7,7 @@ module Wizard
       ACCESS_TOKEN = 0
     end
 
-    MATCHBACK_ATTRS = %i[candidate_id qualification_id].freeze
+    MATCHBACK_ATTRS = %i[candidate_id qualification_id adviser_status_id].freeze
 
     class_attribute :steps
 

--- a/spec/contracts/data/teacher_training_adviser/candidates.json
+++ b/spec/contracts/data/teacher_training_adviser/candidates.json
@@ -14,6 +14,6 @@
     "addressCity": "St Andrews",
     "addressPostcode": "KY9 6NJ",
     "addressTelephone": "987654321",
-    "alreadySubscribedToTeacherTrainingAdviser": false
+    "canSubscribeToTeacherTrainingAdviser": true
   }
 ]

--- a/spec/models/teacher_training_adviser/steps/already_signed_up_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/already_signed_up_spec.rb
@@ -7,17 +7,17 @@ RSpec.describe TeacherTrainingAdviser::Steps::AlreadySignedUp do
   it { is_expected.to_not be_can_proceed }
 
   describe "#skipped?" do
-    it "returns true if already_subscribed_to_teacher_training_adviser is false/nil/undefined" do
-      expect(subject).to be_skipped
-      wizardstore["already_subscribed_to_teacher_training_adviser"] = nil
-      expect(subject).to be_skipped
-      wizardstore["already_subscribed_to_teacher_training_adviser"] = false
-      expect(subject).to be_skipped
+    it "returns false if can_subscribe_to_teacher_training_adviser is false" do
+      wizardstore["can_subscribe_to_teacher_training_adviser"] = false
+      expect(subject).not_to be_skipped
     end
 
-    it "returns false if already_subscribed_to_teacher_training_adviser is true" do
-      wizardstore["already_subscribed_to_teacher_training_adviser"] = true
-      expect(subject).to_not be_skipped
+    it "returns true if can_subscribe_to_teacher_training_adviser is true/nil/undefined" do
+      expect(subject).to be_skipped
+      wizardstore["can_subscribe_to_teacher_training_adviser"] = nil
+      expect(subject).to be_skipped
+      wizardstore["can_subscribe_to_teacher_training_adviser"] = true
+      expect(subject).to be_skipped
     end
   end
 end

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -351,10 +351,12 @@ RSpec.describe Wizard::Base do
       before do
         wizardstore["candidate_id"] = "abc-123"
         wizardstore["qualification_id"] = "def-456"
+        wizardstore["adviser_status_id"] = 123
       end
 
       it { is_expected.to include "candidate_id" => "abc-123" }
       it { is_expected.to include "qualification_id" => "def-456" }
+      it { is_expected.to include "adviser_status_id" => 123 }
     end
   end
 end


### PR DESCRIPTION
> :warning: **Do not merge until CRM team have tested on the review instance**

### Trello card

[Trello-1698](https://trello.com/c/yG3hzAuh/1698-development-unblock-get-an-adviser-applicants-who-have-previously-had-an-adviser)

### Context

Previously we were using the `already_subscribed_to_teacher_training_adviser` field to determine if we prevent the user from continuing with their sign up. Instead, we want to use the `can_subscribe_to_teacher_training_adviser` field which will allow some candidates that have already subscribed to re-subscribe (depending on their adviser status as determined by the
API).

### Changes proposed in this pull request

- Bump API Client version
- Allow some candidates to re-sign up for a TTA

### Guidance to review

