### PR TITLE
Fix on_or_before validation

### DIFF
--- a/app/models/teacher_training_adviser/feedback_search.rb
+++ b/app/models/teacher_training_adviser/feedback_search.rb
@@ -17,7 +17,7 @@ module TeacherTrainingAdviser
       on_or_before: :created_on_or_before,
     }
     validates :created_on_or_before, timeliness: {
-      on_or_before: Time.zone.now.end_of_day.utc,
+      on_or_before: -> { Time.zone.now.end_of_day.utc.to_date },
     }
 
     def range


### PR DESCRIPTION
### Trello card

[Trello-1777](https://trello.com/c/4ZcdcnJs/1777-fix-bug-on-future-date-selection-of-feedback-exporter)

### Context

The validation for the FeedbackSearch `on_or_before` attribute was comparing a `Date` to a `Time` with some odd results. Ensuring we `to_date` the `Time` first corrects the behaviour.

### Changes proposed in this pull request

- Fix on_or_before validation

### Guidance to review

