### PR TITLE
Removing year end messaging

### DIFF
--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -37,11 +37,13 @@
           <li>find out about <%= link_to_git_site "funding", "funding-your-training" %></li>
           <li><%= link_to_git_site "search for events", "events" %> that might interest you</li>
           <% if @returner %>
-          <li>read further information on our dedicated <%= link_to_git_site "return to teaching page", "returning-to-teaching" %></li>
-          
-          <p> You can also search for courses on <%= link_to("Find postgraduate teacher training", "https://www.gov.uk/find-postgraduate-teacher-training-courses") %></li>
+            <li>read further information on our dedicated <%= link_to_git_site "return to teaching page", "returning-to-teaching" %></li>
           <% end %>
         </ul>
+
+        <% if @returner %>
+          <p> You can also search for courses on <%= link_to("Find postgraduate teacher training", "https://www.gov.uk/find-postgraduate-teacher-training-courses") %></p>
+        <% end %>
 
         <p>
           If you have any questions or you need to update any of the information you provided, call <a href="tel:08003892500">0800 389 2500</a> for free between 8.30am and 5.30pm Monday to Friday.

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -28,27 +28,18 @@
 
         <% end %>
 
-        <p>If you’re planning to start teacher training this September, you can speed things up by:</p>
-
-        <ul>
-          <li>searching for courses on <%= link_to("Find postgraduate teacher training", "https://www.gov.uk/find-postgraduate-teacher-training-courses") %></li>
-          <li>Start an application at <%= link_to("Apply for teacher training", "https://www.gov.uk/apply-for-teacher-training") %></li>
-          <li>Start writing your <%= link_to("personal statement", "https://getintoteaching.education.gov.uk/tips-on-applying-for-teacher-training") %></li>
-        </ul>
-
-        <p>Places fill up quickly at this time of year, but courses are still available.</p>
-
         <h2 class="govuk-heading-m">Understanding your options</h2>
 
         <p>As well as an adviser, you can find help and guidance on the Get Into Teaching website. There, you can:</p>
 
         <ul>
-          <li>ask any immediate questions using the <%= link_to_git_site "online chat", "#talk-to-us" %></li>
           <li>discover the different <%= link_to_git_site "ways to train", "ways-to-train" %> to become a teacher</li>
           <li>find out about <%= link_to_git_site "funding", "funding-your-training" %></li>
           <li><%= link_to_git_site "search for events", "events" %> that might interest you</li>
           <% if @returner %>
-            <li>read further information on our dedicated <%= link_to_git_site "return to teaching page", "returning-to-teaching" %></li>
+          <li>read further information on our dedicated <%= link_to_git_site "return to teaching page", "returning-to-teaching" %></li>
+          
+          <p> You can also searching for courses on <%= link_to("Find postgraduate teacher training", "https://www.gov.uk/find-postgraduate-teacher-training-courses") %></li>
           <% end %>
         </ul>
 

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -39,7 +39,7 @@
           <% if @returner %>
           <li>read further information on our dedicated <%= link_to_git_site "return to teaching page", "returning-to-teaching" %></li>
           
-          <p> You can also searching for courses on <%= link_to("Find postgraduate teacher training", "https://www.gov.uk/find-postgraduate-teacher-training-courses") %></li>
+          <p> You can also search for courses on <%= link_to("Find postgraduate teacher training", "https://www.gov.uk/find-postgraduate-teacher-training-courses") %></li>
           <% end %>
         </ul>
 

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -42,7 +42,7 @@
         </ul>
 
         <% if @returner %>
-          <p> You can also search for courses on <%= link_to("Find postgraduate teacher training", "https://www.gov.uk/find-postgraduate-teacher-training-courses") %></p>
+          <p>You can also search for courses on <%= link_to("Find postgraduate teacher training", "https://www.gov.uk/find-postgraduate-teacher-training-courses") %>.</p>
         <% end %>
 
         <p>


### PR DESCRIPTION
Removing messaging that encouraged candidates to act speedily to make sure they could get their application in before the September deadline.

### Trello card

https://trello.com/c/vViTOgMo/1904-update-years-and-confirmation-page-on-get-an-adviser-form


