### PR TITLE
Show next year on 7th September instead of 18th

### DIFF
--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -52,8 +52,8 @@ module TeacherTrainingAdviser::Steps
     end
 
     def first_year
-      # After 17th September you can no longer start teacher training for that year.
-      include_current_year = Time.zone.today < Date.new(current_year, 9, 18)
+      # After 6th September you can no longer start teacher training for that year.
+      include_current_year = Time.zone.today < Date.new(current_year, 9, 7)
       include_current_year ? current_year : current_year + 1
     end
 

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
 
     let(:years) { subject.years }
 
-    context "when its on or before 17th September of the current year" do
+    context "when its on or before 6th September of the current year" do
       around do |example|
-        travel_to(Date.new(2020, 9, 17)) { example.run }
+        travel_to(Date.new(2020, 9, 6)) { example.run }
       end
 
       it "returns 'Not sure', and the current year plus next 2 years" do
@@ -51,9 +51,9 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
       end
     end
 
-    context "when its after 17th September of the current year" do
+    context "when its after 6th September of the current year" do
       around do |example|
-        travel_to(Date.new(2020, 9, 18)) { example.run }
+        travel_to(Date.new(2020, 9, 7)) { example.run }
       end
 
       it "returns 'Not sure', and the next 3 years" do


### PR DESCRIPTION
The marketing team have asked for us to display the next teacher training year on the 7th September instead of the 18th.