### PR TITLE
Terraform Statuscake Provider Change

### DIFF
--- a/terraform/paas/provider.tf
+++ b/terraform/paas/provider.tf
@@ -31,8 +31,8 @@ terraform {
       version = "0.14.2"
     }
     statuscake = {
-      source  = "thde/statuscake"
-      version = "1.1.4"
+      source = "StatusCakeDev/statuscake"
+      version = "1.0.1"
     }
   }
 }


### PR DESCRIPTION
The statuscake provider we have been using for months now has suddenly stopped working, I have read the documents and it looks like terraform suggest a different provider, so changing to that.

