### PR TITLE
Support custom channel in TTA sign up

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 268033a9e88dcbbf8bba1a5deb40f92a243e9c71
+  revision: 1b33c1debd3914590d4873ec7d817e933304dc64
   specs:
     get_into_teaching_api_client (1.1.17)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.42)
+    get_into_teaching_api_client_faraday (0.1.44)
       activesupport
       faraday
       faraday-encoding
@@ -121,7 +121,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.7.2)
+    faraday (1.8.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -149,7 +149,7 @@ GEM
     faraday_middleware-circuit_breaker (0.4.1)
       faraday (>= 0.9, < 2.0)
       stoplight (~> 2.1)
-    ffi (1.15.3)
+    ffi (1.15.4)
     foreman (0.87.2)
     globalid (0.5.2)
       activesupport (>= 5.0)
@@ -429,4 +429,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.2.17
+   2.2.25

--- a/app/models/teacher_training_adviser/steps/identity.rb
+++ b/app/models/teacher_training_adviser/steps/identity.rb
@@ -5,10 +5,12 @@ module TeacherTrainingAdviser::Steps
     attribute :first_name, :string
     attribute :last_name, :string
     attribute :email, :string
+    attribute :channel_id, :integer
 
     validates :first_name, presence: true, length: { maximum: 256 }
     validates :last_name, presence: true, length: { maximum: 256 }
     validates :email, presence: true, email_format: true
+    validates :channel_id, inclusion: { in: :channel_ids, allow_nil: true }
 
     before_validation :sanitize_input
 
@@ -21,10 +23,18 @@ module TeacherTrainingAdviser::Steps
         .tap { |answers|
           answers["name"] = "#{answers['first_name']} #{answers['last_name']}"
         }
-        .without("first_name", "last_name")
+        .without("first_name", "last_name", "channel_id")
+    end
+
+    def channel_ids
+      query_channels.map { |channel| channel.id.to_i }
     end
 
   private
+
+    def query_channels
+      @query_channels ||= GetIntoTeachingApiClient::PickListItemsApi.new.get_candidate_teacher_training_adviser_subscription_channels
+    end
 
     def sanitize_input
       self.first_name = first_name.to_s.strip.presence if first_name

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -16,9 +16,9 @@
           </ul>
           <h2 class="govuk-heading-m">Who can get an adviser?</h2>
           <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, or an overseas qualification that is equivalent.</p>
-          <p>You can get an adviser if you’re still studying for your degree. Before your final year, you can get advice for when you're ready to apply. If you're in your final year, you’ll need a predicted class 2:2 (honours) or higher.</p> 
+          <p>You can get an adviser if you’re still studying for your degree. Before your final year, you can get advice for when you're ready to apply. If you're in your final year, you’ll need a predicted class 2:2 (honours) or higher.</p>
           <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession to teach maths, physics or modern languages, you’ll need qualified teacher status (QTS)</a>.</p>
-          <a href="<%= teacher_training_adviser_step_path(:identity) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
+          <a href="<%= teacher_training_adviser_step_path(:identity, params.to_unsafe_h.slice(:channel)) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -4,6 +4,7 @@
   <%= f.govuk_text_field :first_name, width: 20 %>
   <%= f.govuk_text_field :last_name, width: 20 %>
   <%= f.govuk_email_field :email, width: 20 %>
+  <%= f.hidden_field :channel_id, value: params[:channel] %>
 
   <p>Your details are protected under the terms of our <%= link_to "privacy notice", privacy_policy_path(:id => session[:privacy_policy_id].presence || GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy.id) %>.</p>
 

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -36,6 +36,70 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
         .and_raise(GetIntoTeachingApiClient::ApiError)
     end
 
+    scenario "that is signing up at an on-campus event" do
+      channel = GetIntoTeachingApiClient::PickListItem.new({ id: 123_456, value: "On-campus event" })
+
+      allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
+        receive(:get_candidate_teacher_training_adviser_subscription_channels).and_return([channel])
+
+      visit root_path(channel: channel.id)
+      click_on "Start now"
+
+      expect(page).to have_css "h1", text: "About you"
+      fill_in_identity_step
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Are you qualified to teach in the UK?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Do you have your previous teacher reference number?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Which main subject did you previously teach?"
+      select "Psychology"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Which subject would you like to teach if you return to teaching?"
+      choose "Physics"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Enter your date of birth"
+      fill_in_date_of_birth_step
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Where do you live?"
+      choose "UK"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "What is your address?"
+      fill_in_address_step
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "What is your telephone number?"
+      fill_in "UK telephone number (optional)", with: "123456789"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Check your answers before you continue"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Read and accept the privacy policy"
+      check "Accept the privacy policy"
+
+      request_attributes = uk_candidate_request_attributes({
+        type_id: RETURNING_TO_TEACHING,
+        subject_taught_id: SUBJECT_PSYCHOLOGY,
+        preferred_teaching_subject_id: SUBJECT_PHYSICS,
+        channel_id: channel.id,
+      })
+      expect_sign_up_with_attributes(request_attributes)
+
+      click_on "Complete"
+
+      expect(page).to have_css "h1", text: "Sign up complete"
+    end
+
     scenario "that is a returning teacher" do
       visit teacher_training_adviser_steps_path
 

--- a/spec/models/teacher_training_adviser/steps/identity_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/identity_spec.rb
@@ -2,6 +2,18 @@ require "rails_helper"
 
 RSpec.describe TeacherTrainingAdviser::Steps::Identity do
   include_context "wizard step"
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
+      receive(:get_candidate_teacher_training_adviser_subscription_channels).and_return(channels)
+  end
+
+  let(:channels) do
+    [
+      GetIntoTeachingApiClient::PickListItem.new({ id: 12_345, value: "Channel 1" }),
+      GetIntoTeachingApiClient::PickListItem.new({ id: 67_890, value: "Channel 2" }),
+    ]
+  end
+
   it_behaves_like "a wizard step"
   it_behaves_like "an issue verification code wizard step"
   include_context "sanitize fields", %i[first_name last_name email]
@@ -27,6 +39,14 @@ RSpec.describe TeacherTrainingAdviser::Steps::Identity do
   describe "email" do
     it { is_expected.not_to allow_values(nil, "", "a@#{'a' * 101}.com", "some@thing").for :email }
     it { is_expected.to allow_values("test@test.com", "test%.mctest@domain.co.uk").for :email }
+  end
+
+  describe "validations for channel_id" do
+    let(:options) { channels.map(&:id) }
+
+    it { is_expected.to allow_values(options).for :channel_id }
+    it { is_expected.to allow_value(nil, "").for :channel_id }
+    it { is_expected.not_to allow_value(11_233).for :channel_id }
   end
 
   describe "#reviewable_answers" do


### PR DESCRIPTION
### Trello card

[Trello-2498](https://trello.com/c/KKq8jc3M/2498-on-campus-channel-attribution-for-tta-sign-up)

### Context

The events team are pushing TTA sign ups at on-campus events and want to be able to attribute a successful sign up to a particular event. The API now accepts a `channe_id` in the TTA sign up request model, so this PR updates the TTA root URL to forward on a `channel` attribute, that will be used for the `channel_id` when signing up. It is persisted as part of the first (identity) step.

To sign up the URL format is:

```
/?channel=<channel_id>
```

### Changes proposed in this pull request

- Support custom channel in TTA sign up

### Guidance to review

