### PR TITLE
Enable new GTM container in production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -4,3 +4,4 @@ GIT_URL=https://beta-getintoteaching.education.gov.uk/
 LID_ID=1
 FAIL2BAN=5
 BAM_ID=1
+GTM_ID=GTM-5ZQLL9K

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,6 +7,10 @@ module ApplicationHelper
     end
   end
 
+  def new_gtm_enabled?
+    ENV["GTM_ID"].present? && !Rails.application.config.x.legacy_tracking_pixels
+  end
+
   def legacy_analytics_body_tag(attributes = {}, &block)
     attributes = attributes.symbolize_keys
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,13 +14,13 @@
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
-    <%= javascript_pack_tag 'gtm', 'data-turbolinks-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] }, async: true unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= javascript_pack_tag 'gtm', 'data-turbolinks-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] }, async: true if new_gtm_enabled? %>
     <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
   </head>
 
   <%= analytics_body_tag class: "govuk-template__body govuk-body" do %>
-    <%= render(partial: "shared/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "shared/gtm_fallback") if new_gtm_enabled? %>
     <header class="govuk-header" role="banner" data-module="govuk-header">
     <%= render partial: 'shared/cookie_banner' %>
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>

--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -4,4 +4,5 @@ require File.expand_path("production.rb", __dir__)
 Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-test.london.cloudapps.digital"
   config.x.enable_beta_redirects = false
+  config.x.legacy_tracking_pixels = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,7 +101,7 @@ Rails.application.configure do
   config.x.api_client_cache_store = ActiveSupport::Cache::RedisCacheStore.new(namespace: "TTA-HTTP")
   config.x.basic_auth = ENV["BASIC_AUTH"]
 
-  config.x.legacy_tracking_pixels = true
+  config.x.legacy_tracking_pixels = false
 
   config.session_store :cache_store,
                        key: "_dfe_session",

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -4,4 +4,5 @@ require File.expand_path("production.rb", __dir__)
 Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
   config.x.enable_beta_redirects = false
+  config.x.legacy_tracking_pixels = true
 end

--- a/config/environments/userresearch.rb
+++ b/config/environments/userresearch.rb
@@ -4,6 +4,7 @@ require File.expand_path("production.rb", __dir__)
 Rails.application.configure do
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital"
   config.x.enable_beta_redirects = false
+  config.x.legacy_tracking_pixels = true
 
   Rack::Attack.enabled = false
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -149,6 +149,27 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe "#new_gtm_enabled?" do
+    it "returns true when GTM_ID is present and legacy_tracking_pixels is false" do
+      allow(ENV).to receive(:[]).with("GTM_ID").and_return("ABC-123")
+      allow(Rails.application.config.x).to receive(:legacy_tracking_pixels).and_return(false)
+
+      expect(helper).to be_new_gtm_enabled
+    end
+
+    it "returns false when GTM_ID is blank or legacy_tracking_pixels is true" do
+      allow(ENV).to receive(:[]).with("GTM_ID").and_return("ABC-123")
+      allow(Rails.application.config.x).to receive(:legacy_tracking_pixels).and_return(true)
+
+      expect(helper).not_to be_new_gtm_enabled
+
+      allow(ENV).to receive(:[]).with("GTM_ID").and_return(nil)
+      allow(Rails.application.config.x).to receive(:legacy_tracking_pixels).and_return(false)
+
+      expect(helper).not_to be_new_gtm_enabled
+    end
+  end
+
   describe "#link_to_git" do
     subject { link_to_git_site }
 

--- a/spec/requests/gtm_spec.rb
+++ b/spec/requests/gtm_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe "Google Tag Manager", type: :request do
       expect(response.body).to include("data-gtm-id=\"123-ABC\"")
       expect(response.body).to include("https://www.googletagmanager.com/ns.html")
     end
+
+    context "when the GTM_ID is not set" do
+      before do
+        allow(ENV).to receive(:[]).with("GTM_ID").and_return(nil)
+      end
+
+      it "does not have the GTM and fallback scripts" do
+        get root_path
+        expect(response.body).not_to include("data-gtm-id")
+        expect(response.body).not_to include("https://www.googletagmanager.com/ns.html")
+      end
+    end
   end
 
   context "when legacy tracking pixels are enabled" do


### PR DESCRIPTION
> :warning: Update GA ID in GTM to prod before merging this

Switch to using the new GTM container in production. Switches non-prod environments back to the legacy tracking method so we don't pollute the prod GA account with traffic from non-prod environments.