### PR TITLE
International and returning teachers content updates to Get an adviser

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -6,7 +6,7 @@
           <h1 class="govuk-heading-l">Get an adviser</h1>
 
           <p>If you want to become a teacher or return to teaching in England, a teacher training adviser can guide you through the process with free one-to-one support.</p>
-          <p>Your adviser will help you with:</p>
+          <p>A teacher training adviser can help with:</p>
           <ul>
             <li>getting school experience</li>
             <li>funding your course</li>
@@ -14,16 +14,51 @@
             <li>writing your personal statement</li>
             <li>interview tips</li>
           </ul>
+          <p>A teaching adviser can help with:</p>
+          <ul>
+            <li>writing job applications</li>
+            <li>preparing for an interview</li>
+            <li>accessing courses to improve your subject knowledge</li>
+            <li>writing your personal statement</li>
+            <li>finding teaching vacancies</li>
+          </ul>
           <h2 class="govuk-heading-m">Who can get an adviser?</h2>
-          <p>You’ll need a bachelor’s degree class 2:2 (honours) or higher, or an overseas qualification that is equivalent.</p>
-          <p>You can get an adviser if you’re still studying for your degree. Before your final year, you can get advice for when you're ready to apply. If you're in your final year, you’ll need a predicted class 2:2 (honours) or higher.</p>
-          <p>If you’ve worked as a teacher before, and you’re thinking of returning to the profession to teach maths, physics or modern languages, you’ll need qualified teacher status (QTS)</a>.</p>
+          <p>If you are thinking about teacher training, to get an adviser you will need to be<p>
+          <ul>
+          <li>a UK student studying for a bachelor’s degree (if you are in your final year, you will need a predicted grade of 2.2 or higher)</li>
+          <li>a UK postgraduate with a bachelor’s degree of grade 2.2 or higher</li>
+          <li>a non-UK student studying for a bachelor’s degree (in the UK or another country)</li>
+          <li>a non-UK postgraduate with a bachelor’s degree (from the UK or another country)</li>
+        </ul>
+        <p>If you are already a teacher, trained in England, Scotland, Wales, Northern Ireland or outside the UK, to get an adviser you will need:<p>
+        <ul>
+          <li><a href="https://www.gov.uk/guidance/qualified-teacher-status-qts">qualified teacher status</a>(QTS)</li>
+          <li>to intend to teach maths, physics or modern foreign languages (Spanish, French or German)</li>
+        </ul>
+        <h3 class="govuk-heading-m">Help with international qualifications for teachers and trainees from outside the UK</h3>
+        <p>Before you register for an adviser, call us on 0800 389 2500 to check your qualifications make you eligible to use this service.</p>
+
           <a href="<%= teacher_training_adviser_step_path(:identity, params.to_unsafe_h.slice(:channel)) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
           </svg>
         </a>
+        <h2 class="govuk-heading-m">Where else you can go for help</h2>
+        
+        <p>International trainees can find more info at <a href="https://getintoteaching.education.gov.uk/train-to-teach-in-england-as-an-international-student">Train to teach in England as an international candidate</a></p>
+
+        <p>International teachers can find info about qualified teacher status, visas and immigration at <a href="https://getintoteaching.education.gov.uk/come-to-england-to-teach-if-you-are-a-teacher-from-outside-the-uk">Come to England to teach if you are a teacher from outside the UK</a></p>
+
+        <p>Teachers trained in England can find info about coming home to teach at <a href=" https://getintoteaching.education.gov.uk/international-returners">Return to teaching from overseas.</a></p>
+        
+        <p>Teachers coming back to the profession after a break can find info at <a href="https://getintoteaching.education.gov.uk/returning-to-teaching">Return to teaching.</a></p>
+
+        <p>UK and non-UK teachers now living and working outside the UK can also email with questions about the information on the Get into Teaching website on international.teacherrecruitment@education.gov.uk</p>
+        
+
+      
+    
           <p>Find teacher training options if you live in:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li><a href="https://teachinscotland.scot">Scotland</a></li>

--- a/app/views/teacher_training_adviser/steps/_subject_not_found.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_not_found.html.erb
@@ -2,17 +2,25 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Get support</h1>
+        <h1 class="govuk-heading-l">We’re sorry, but to be eligible for this service, you must be planning to teach maths, physics or modern foreign languages (MFL).</h1>
 
-        <p>Teacher training advisers can support you if you're returning to teach maths, physics or languages.</p>
+        <p>However, Get into Teaching’s <%= link_to_git_events("online Q&A webinars", events_path: "category/online-events") %> are open to returning and international teachers in all subjects and age groups. 
 
-        <p>
-          If you want to teach a different subject you can still get support by <%= link_to_git_events("attending an online return to teaching event", events_path: "category/online-events") %>
-        </p>
+        <p>You can also search for teaching jobs in England at<a href="https://teaching-vacancies.service.gov.uk">Teaching Vacancies.</a></p>
+        
+        Dedicated pages on the Get into Teaching website offer help and advice:
+        
+        <p>Teachers trained in England can find info about coming home to teach at <a href=" https://getintoteaching.education.gov.uk/international-returners">Return to teaching from overseas.</a></p>
+        
+        <p>Teachers coming back to the profession after a break can find info at <a href="https://getintoteaching.education.gov.uk/returning-to-teaching">Return to teaching.</a></p>
 
-        <p>
-          You can also <%= link_to("search for a teaching role in England", "https://teaching-vacancies.service.gov.uk/") %> and set up job alerts so that you do not miss out on any opportunities.
-        </p>
+        <p>Teachers who qualified outside the UK can find info at <a href="https://getintoteaching.education.gov.uk/come-to-england-to-teach-if-you-are-a-teacher-from-outside-the-uk">Return to teaching.</a></p>
+        
+
+        
+
+       
+       
         
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,7 +63,7 @@ en:
       teacher_training_adviser_steps_gcse_maths_english:
         has_gcse_maths_and_english_id: "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?"
       teacher_training_adviser_steps_returning_teacher:
-        type_id: "Are you qualified to teach in the UK?"
+        type_id: "Do you have qualified teacher status?"
       teacher_training_adviser_steps_has_teacher_id:
         has_id: "Do you have your previous teacher reference number?"
       teacher_training_adviser_steps_have_a_degree:
@@ -105,7 +105,7 @@ en:
         address_telephone: "Contact telephone number"
         phone_call_scheduled_at: "Select your preferred day and time for a callback"
       teacher_training_adviser_steps_overseas_country:
-        country_id: "Which country do you live in?"
+        country_id: "Are you a non-UK citizen? Please select your country"
       teacher_training_adviser_steps_uk_address:
         address_line1: "Address line 1"
         address_line2: "Address line 2 (optional)"
@@ -158,7 +158,7 @@ en:
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:
-        type_id_html: "Select 'yes' if you are a returning teacher and have qualified teacher status (QTS), or have an overseas teaching qualification that's <a href=\"https://www.gov.uk/government/publications/qualified-teacher-status-routes-to-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk/qualified-teacher-status-routes-to-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#apply-for-qualified-teacher-status-qts\" target=\"blank\">equivalent to QTS</a>."
+        type_id_html: "You need qualified teacher status to be eligible for this service. Learn how to <a href=\"https://www.gov.uk/guidance/qualified-teacher-status-qts\" target=\"blank\">apply for QTS</a>."
       teacher_training_adviser_steps_have_a_degree:
         degree_options: "To use this service your bachelor's degree or predicted grade needs to be a 2:2 class honours or above."
       teacher_training_adviser_steps_overseas_telephone:
@@ -166,7 +166,7 @@ en:
       teacher_training_adviser_steps_date_of_birth:
         date_of_birth: "For example, 31 3 1980"
       teacher_training_adviser_steps_overseas_country:
-        country_id_html: "If you’re not from the UK, <a href=\"https://www.gov.uk/check-uk-visa\" target=\"blank\">check if you need a visa</a> to study or work in the UK and whether you can meet the visa requirements. For example, for a <a href=\"https://www.gov.uk/student-visa\" target=\"blank\">student visa</a> you need to show your knowledge of English and provide certain documents."
+        country_id_html: "You can apply to train or teach from any country in the world, but you may need a visa. Our guidance for <a href=\"https://getintoteaching.education.gov.uk/come-to-england-to-teach-if-you-are-a-teacher-from-outside-the-uk\" target=\"blank\">international teachers</a> and <a href=\"https://getintoteaching.education.gov.uk/train-to-teach-in-england-as-an-international-student\" target=\"blank\">international trainees</a> explains how to apply for the correct visa or immigration status for your employment or study in the UK."
   have_a_degree:
     degree_options:
       "yes": "Yes"


### PR DESCRIPTION
International and returning teachers content updates to Get an adviser

### Trello card

### Context
Hi @gemmadallmandfe @peteryates, as agreed with Gaye I've made some content changes to the part of the Get an adviser service relating to ITRU user groups (international teachers, international trainees and teachers returning from overseas.

### Changes proposed in this pull request
Home page:
I have:
clarified the difference between the guidance offered by TTAs and RTTAs
clarified who is and is not eligible
Added a call to action to contact the intl quals helpline to filter out users who are not eligible for the service
Added signposting below the start button for users who are not eligible for the service

Qualified to teach page:
I have clarified the 'qualification equivalent to QTS' hint text as this is not a thing (there is no equivalent qualification). I have replaced it with a link to QTS guidance

Eligible subjects page:
I have added more helpful text and signposting for users who are not eligible due to their subject specialism

What country do you live in:
I have updated with the latest guidance on visa sponsorship


### Guidance to review

