### PR TITLE
Prevent loss of Google Ads tracking parameters

### DIFF
--- a/app/webpacker/javascript/gtm.js
+++ b/app/webpacker/javascript/gtm.js
@@ -15,9 +15,16 @@ export default class Gtm {
 
   initWindow() {
     window.dataLayer = window.dataLayer || [];
+
+    // We use this to retain Google Ads tracking parameters in the
+    // URL of the landing page (or they are subsequently lost when
+    // Turbolinks transitions).
+    window.dataLayer.push({ originalLocation: this.originalLocation });
+
     function gtag() {
       window.dataLayer.push(arguments);
     }
+
     window.gtag = window.gtag || gtag;
   }
 
@@ -42,7 +49,7 @@ export default class Gtm {
 
   listenForHistoryChange() {
     document.addEventListener('turbolinks:load', () => {
-      window.gtag('set', 'page_path', window.location.path);
+      window.gtag('set', 'page_path', window.location.pathname);
       window.gtag('event', 'page_view');
     });
   }
@@ -62,5 +69,10 @@ export default class Gtm {
     return new CookiePreferences().allowedCategories.includes(category)
       ? 'granted'
       : 'denied';
+  }
+
+  get originalLocation() {
+    const l = window.location;
+    return `${l.protocol}://${l.hostname}${l.pathname}${l.search}`;
   }
 }

--- a/spec/javascript/gtm_spec.js
+++ b/spec/javascript/gtm_spec.js
@@ -20,13 +20,28 @@ describe('Google Tag Manager', () => {
     gtm.init();
   };
 
+  const mockWindowLocation = () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        protocol: 'https',
+        hostname: 'localhost',
+        pathname: '/path',
+        search: '?utm=tag',
+      },
+    });
+  };
+
   beforeEach(() => {
+    mockWindowLocation();
     clearCookies();
     setupHtml();
   });
 
   describe('initialisation', () => {
-    beforeEach(() => run());
+    beforeEach(() => {
+      run();
+    });
 
     it('defines window.dataLayer', () => {
       expect(window.gtag).toBeDefined();
@@ -34,6 +49,16 @@ describe('Google Tag Manager', () => {
 
     it('defines window.gtag', () => {
       expect(window.dataLayer).toBeDefined();
+    });
+
+    it('pushes the original location onto the dataLayer', () => {
+      expect(window.dataLayer).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            originalLocation: 'https://localhost/path?utm=tag',
+          }),
+        ])
+      );
     });
 
     it('appends the GTM script', () => {
@@ -51,7 +76,7 @@ describe('Google Tag Manager', () => {
     });
 
     it('updates the page_path in GTM', () => {
-      window.location.path = '/new-path';
+      window.location.pathname = '/new-path';
 
       document.dispatchEvent(new Event('turbolinks:load'));
 


### PR DESCRIPTION
This is a lift and shift of the changes in https://github.com/DFE-Digital/get-into-teaching-app/pull/2108 (as the GTM container is shared by both services).
