### PR TITLE
Add app_instance label to all metrics

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,3 @@
 VCAP_APPLICATION="{\"application_name\": \"app-name\",\"space_name\": \"space-name\",\"organization_name\": \"org-name\"}"
 GTM_ID=123-ABC
+CF_INSTANCE_INDEX=app-instance

--- a/lib/prometheus/metrics.rb
+++ b/lib/prometheus/metrics.rb
@@ -5,6 +5,7 @@ module Prometheus
         app: Rails.application.config.x.vcap_app["application_name"],
         organisation: Rails.application.config.x.vcap_app["organization_name"],
         space: Rails.application.config.x.vcap_app["space_name"],
+        app_instance: ENV["CF_INSTANCE_INDEX"],
       }
     end
 

--- a/spec/lib/prometheus/metrics_spec.rb
+++ b/spec/lib/prometheus/metrics_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe Prometheus::Metrics do
       app: "app-name",
       organisation: "org-name",
       space: "space-name",
+      app_instance: "app-instance",
     }
   end
 end


### PR DESCRIPTION
The metrics are not correctly aggregating due to multiple instances sending the same metric/labels. We need another label to differentiate between metrics so that Prometheus correctly aggregates them.

A change made to Prometheus also requires this label or it ends up stuck in a loop and forever incrementing the counter.
