### PR TITLE
Bump docker image to alpine3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.5-alpine3.14
+FROM ruby:2.7.5-alpine3.15
 
 ENV RAILS_ENV=production \
     NODE_ENV=production \


### PR DESCRIPTION
Address vulnerability in expat/expat, see: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2342148

