### PR TITLE
Remove default Prometheus Collector middleware

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,11 +2,9 @@
 
 require_relative 'config/environment'
 
-require 'prometheus/middleware/collector'
 require 'prometheus/middleware/exporter'
 
 use Rack::Deflater
-use Prometheus::Middleware::Collector
 use Prometheus::Middleware::Exporter
 
 run Rails.application


### PR DESCRIPTION
### Trello card

[Trello-2896](https://trello.com/c/dHyE1XU0/2896-rework-labels-sent-with-prometheus-metrics-in-the-app-tta-service)

### Context

The middleware collects HTTP request duration/count, but we have our own custom metrics for this and don't actually reference them in any of our dashboards and they don't have the standard set of app/instance/etc labels.

### Changes proposed in this pull request

- Remove default Prometheus Collector middleware

### Guidance to review

