### PR TITLE
Revert "Upgrade to Turbo"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,7 @@ RUN bundle install --jobs=$(nproc --all) && \
 
 # Add code and compile assets
 COPY . .
-# See https://github.com/rails/rails/issues/32947 for why we
-# bypass the credentials here.
-RUN SECRET_KEY_BASE=1 RAILS_BUILD=1 bundle exec rake assets:precompile
+RUN bundle exec rake assets:precompile
 
 ARG APP_SHA
 RUN echo "${APP_SHA}" > /etc/get-teacher-training-adviser-service-sha

--- a/Gemfile
+++ b/Gemfile
@@ -55,8 +55,6 @@ gem "invisible_captcha"
 
 gem "iso_country_codes"
 
-gem "turbo-rails"
-
 gem "dfe_wizard", github: "DFE-Digital/dfe_wizard"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,9 +355,6 @@ GEM
     stoplight (2.2.1)
     thor (1.2.1)
     timeliness (0.4.4)
-    turbo-rails (1.0.1)
-      actionpack (>= 6.0.0)
-      railties (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
@@ -428,7 +425,6 @@ DEPENDENCIES
   simplecov (~> 0.21.2)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbo-rails
   tzinfo-data
   validates_timeliness
   vcr

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,9 +14,9 @@
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
-    <%= javascript_pack_tag 'gtm', 'data-turbo-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] }, async: true if gtm_enabled? %>
-    <%= stylesheet_pack_tag 'application', 'data-turbo-track': 'reload', media: 'all' %>
-    <%= javascript_pack_tag 'application', 'data-turbo-track': 'reload', defer: true %>
+    <%= javascript_pack_tag 'gtm', 'data-turbolinks-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] }, async: true if gtm_enabled? %>
+    <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
   </head>
 
   <%= analytics_body_tag class: "govuk-template__body govuk-body" do %>

--- a/app/webpacker/javascript/gtm.js
+++ b/app/webpacker/javascript/gtm.js
@@ -18,7 +18,7 @@ export default class Gtm {
 
     // We use this to retain Google Ads tracking parameters in the
     // URL of the landing page (or they are subsequently lost when
-    // Turbo transitions).
+    // Turbolinks transitions).
     window.dataLayer.push({ originalLocation: this.originalLocation });
 
     function gtag() {
@@ -48,7 +48,7 @@ export default class Gtm {
   }
 
   listenForHistoryChange() {
-    document.addEventListener('turbo:load', () => {
+    document.addEventListener('turbolinks:load', () => {
       window.gtag('set', 'page_path', window.location.pathname);
       window.gtag('event', 'page_view');
     });

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -2,13 +2,14 @@ require.context("govuk-frontend/govuk/assets");
 
 import "../styles/application.scss";
 import Rails from "@rails/ujs";
-import '@hotwired/turbo-rails'
+import Turbolinks from "turbolinks";
 import { initAll } from "govuk-frontend";
 
 // Required by GOV.UK front-end
 document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 
 Rails.start();
+Turbolinks.start();
 initAll();
 
 import "controllers"

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -35,7 +35,7 @@ $govuk-global-styles: true;
   width: 1px;
 }
 
-.turbo-progress-bar {
+.turbolinks-progress-bar {
   height: 5px;
   background-color: #0076bd;
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "dependencies": {
-    "@hotwired/turbo-rails": "^7.0.1",
     "@rails/ujs": "^7.0.1",
     "@rails/webpacker": "^5.4.0",
     "govuk-frontend": "^4.0.0",
     "js-cookie": "^3.0.1",
     "serialize-javascript": "^6.0.0",
     "set-value": "^4.0.1",
-    "stimulus": "^2.0.0"
+    "stimulus": "^2.0.0",
+    "turbolinks": "^5.2.0"
   },
   "devDependencies": {
     "@stimulus/test": "^2.0.0",

--- a/spec/javascript/gtm_spec.js
+++ b/spec/javascript/gtm_spec.js
@@ -69,7 +69,7 @@ describe('Google Tag Manager', () => {
     });
   });
 
-  describe('on Turbo page changes', () => {
+  describe('on Turbolinks page changes', () => {
     beforeEach(() => {
       mockGtag();
       run();
@@ -78,7 +78,7 @@ describe('Google Tag Manager', () => {
     it('updates the page_path in GTM', () => {
       window.location.pathname = '/new-path';
 
-      document.dispatchEvent(new Event('turbo:load'));
+      document.dispatchEvent(new Event('turbolinks:load'));
 
       expect(window.gtag).toHaveBeenCalledWith('set', 'page_path', '/new-path');
       expect(window.gtag).toHaveBeenCalledWith('event', 'page_view');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1102,19 +1102,6 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
-"@hotwired/turbo-rails@^7.0.1":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.1.1.tgz#35c03b92b5c86f0137ed08bef843d955ec9bbe83"
-  integrity sha512-ZXpxUjCfkdbuXfoGrsFK80qsVzACs8xCfie9rt2jMTSN6o1olXVA0Nrk8u02yNEwSiVJm/4QSOa8cUcMj6VQjg==
-  dependencies:
-    "@hotwired/turbo" "^7.1.0"
-    "@rails/actioncable" "^7.0"
-
-"@hotwired/turbo@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.1.0.tgz#27e44e0e3dc5bd1d4bda0766d579cf5a14091cd7"
-  integrity sha512-Q8kGjqwPqER+CtpQudbH+3Zgs2X4zb6pBAlr6NsKTXadg45pAOvxI9i4QpuHbwSzR2+x87HUm+rot9F/Pe8rxA==
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1315,11 +1302,6 @@
   dependencies:
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
-
-"@rails/actioncable@^7.0":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.1.tgz#8f383b672e142d009f89b725d49b0832d99da74a"
-  integrity sha512-lbGc1z2RXdiWZJE/8o2GSe2gek82EoKd2YvjRrqV//0J3/JImONUYwZ2XPmS1R9R2oth1XlIG0YidqdeTty0TA==
 
 "@rails/ujs@^7.0.1":
   version "7.0.1"
@@ -8244,6 +8226,11 @@ tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
+
+turbolinks@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
+  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
 
 type-check@~0.3.2:
   version "0.3.2"


### PR DESCRIPTION
Reverts DFE-Digital/get-teacher-training-adviser-service#908

Turbo was having a negative knock-on effect to our PPC campaigns on the GiT website; we're not sure why, but we should revert to Turbolinks here in case it causes the same issues on the TTA service.