### PR TITLE
Rework the enter verification code step

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,0 +1,11 @@
+module FormHelper
+  def timed_one_time_password_label(code_resent)
+    text = t("helpers.hint.wizard_steps_authenticate.timed_one_time_password.text")
+
+    if code_resent
+      text += "<br><b>#{t('helpers.hint.wizard_steps_authenticate.timed_one_time_password.resent')}</b>"
+    end
+
+    safe_html_format(text)
+  end
+end

--- a/app/views/teacher_training_adviser/steps/_authenticate.html.erb
+++ b/app/views/teacher_training_adviser/steps/_authenticate.html.erb
@@ -1,4 +1,3 @@
-<%= f.govuk_fieldset legend: { text: 'Verify your email address' } do %>
-
-<%= render "wizard/steps/authenticate", f: f, email: session["sign_up"]["email"], resend_verification_path: resend_verification_teacher_training_adviser_steps_path %>
+<%= f.govuk_fieldset legend: { text: "You're already registered with us" } do %>
+  <%= render "wizard/steps/authenticate", f: f, resend_verification_path: resend_verification_teacher_training_adviser_steps_path %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_form.html.erb
+++ b/app/views/teacher_training_adviser/steps/_form.html.erb
@@ -16,6 +16,10 @@
       <% if wizard.step_can_proceed? %>
         <%= f.govuk_submit(wizard.last_step? ? "Complete" : "Continue") %>
       <% end %>
+
+      <% if content_for?(:form_help) %>
+        <div class="form-help"><%= yield(:form_help) %></div>
+      <% end %>
     <% end %>
   </div>
 </main>

--- a/app/views/wizard/steps/_authenticate.html.erb
+++ b/app/views/wizard/steps/_authenticate.html.erb
@@ -1,15 +1,10 @@
-<%
-  hint_text = t("helpers.hint.wizard_steps_authenticate.timed_one_time_password.text")
-  hint_text += "<br><b>#{t('helpers.hint.wizard_steps_authenticate.timed_one_time_password.resent')}</b>" if params[:verification_resent]
-%>
-
 <p class="govuk-hint">
   <%= t('helpers.label.wizard_steps_authenticate.timed_one_time_password') %>
 </p>
 
 <%= f.govuk_text_field :timed_one_time_password,
 autocomplete: "off",
-label: { text: safe_html_format(hint_text) }
+label: { text: timed_one_time_password_label(params[:verification_resent]) }
 %>
 <% content_for(:form_help) do %>
   <p>The code expires in 15 minutes.</p>

--- a/app/views/wizard/steps/_authenticate.html.erb
+++ b/app/views/wizard/steps/_authenticate.html.erb
@@ -1,9 +1,18 @@
 <%
-  link = link_to("resend verification", resend_verification_path)
-  hint_text = "Check your junk mail folder or #{link}."
-  hint_text += "<br /><b>We've sent you another email.</b>" if params[:verification_resent]
+  hint_text = t("helpers.hint.wizard_steps_authenticate.timed_one_time_password.text")
+  hint_text += "<br><b>#{t('helpers.hint.wizard_steps_authenticate.timed_one_time_password.resent')}</b>" if params[:verification_resent]
 %>
 
+<p class="govuk-hint">
+  <%= t('helpers.label.wizard_steps_authenticate.timed_one_time_password') %>
+</p>
+
 <%= f.govuk_text_field :timed_one_time_password,
-label: { text: "Check your email and enter the verification code sent to #{email}" },
-hint: { text: safe_html_format(hint_text) } %>
+autocomplete: "off",
+label: { text: safe_html_format(hint_text) }
+%>
+<% content_for(:form_help) do %>
+  <p>The code expires in 15 minutes.</p>
+  <p>Check your spam or junk folder if you cannot find the email.</p>
+  <p><%= link_to("Send another code to verify my details.", resend_verification_path) %></p>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,8 @@ en:
       teacher_training_adviser_steps_have_a_degree:
         degree_options: "Do you have a degree?"
     label:
+      wizard_steps_authenticate:
+        timed_one_time_password: "To verify your details, we've sent a code to your email address."
       teacher_training_adviser_feedback:
         unsuccessful_visit_explanation: "Give details"
         improvements: "How could we improve the service? (optional)"
@@ -146,6 +148,10 @@ en:
           "no": "No"
           studying: "I'm studying for a degree"
     hint:
+      wizard_steps_authenticate:
+        timed_one_time_password:
+          text: "Enter your code here:"
+          resent: We've sent you another email
       teacher_training_adviser_steps_what_subject_degree:
         degree_subject: "If your subject is not listed choose the option that is nearest to your degree."
       teacher_training_adviser_steps_uk_telephone:

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -574,11 +574,11 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in_identity_step
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Verify your email address"
-      expect(page).to have_text "Check your email and enter the verification code sent to john@doe.com"
-      click_on "resend verification"
+      expect(page).to have_css "h1", text: "You're already registered with us"
+      expect(page).to have_text "To verify your details, we've sent a code to your email address."
+      click_on "Send another code to verify my details."
 
-      expect(page).to have_text "We've sent you another email."
+      expect(page).to have_text "We've sent you another email"
       fill_in "dfe-wizard-steps-authenticate-timed-one-time-password-field", with: invalid_code
       click_on "Continue"
 
@@ -667,7 +667,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in_identity_step
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Verify your email address"
+      expect(page).to have_css "h1", text: "You're already registered with us"
       fill_in "dfe-wizard-steps-authenticate-timed-one-time-password-field", with: valid_code
       click_on "Continue"
 

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe FormHelper, type: :helper do
+  include TextFormatHelper
+
+  describe ".timed_one_time_password_label" do
+    subject { timed_one_time_password_label(code_resent) }
+
+    context "when code has not been resent" do
+      let(:code_resent) { false }
+
+      it { is_expected.to eq("Enter your code here:") }
+    end
+
+    context "when code has been resent" do
+      let(:code_resent) { true }
+
+      it { is_expected.to start_with("Enter your code here:") }
+      it { is_expected.to end_with("<br><b>We've sent you another email</b>") }
+    end
+  end
+end

--- a/spec/support/spec_helpers/contract_helper.rb
+++ b/spec/support/spec_helpers/contract_helper.rb
@@ -249,7 +249,7 @@ module SpecHelpers
     end
 
     def submit_verification_code(candidate_identity)
-      fill_in "Check your email and enter the verification code sent to #{candidate_identity[:email]}", with: "123456"
+      fill_in "Enter your code here:", with: "123456"
       mock_exchange_code_for_candidate(candidate_identity)
       click_on_continue
     end


### PR DESCRIPTION
### Trello card

[Trello-2902](https://trello.com/c/KGD3HyIm/2902-improve-content-of-verification-code-step-in-the-get-an-adviser-funnel)

### Context

This step doesn't perform all that well and we see roughly 1/5 users drop off/don't successfully enter their verification code and progress to the next step.

In an effort to tackle this we are making the copy clearer/reworking the layout of the step (this will bring it inline with the GiT website transactions).

### Changes proposed in this pull request

- Rework the enter verification code step

### Guidance to review

The Cypress tests will need to be updated when this is shipped.