### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Assign the following team as codeowners for this repository
-*       @gemmadallmandfe 


### PR DESCRIPTION
As a codeowner you get a request for review even when a PR is raised in a draft state, which can be frequent/irritating. Review requests are also issued when there's a change that has no impact on the end user, blocking a PR until we can get a review needlessly. Instead, we're going to manually request a review if necessary for a PR.