### PR TITLE
Updating QTS hint text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,7 +164,7 @@ en:
       teacher_training_adviser_steps_stage_interested_teaching:
         preferred_education_phase_id: "Select a stage even if you're not sure yet, as this will not affect the sign up process."
       teacher_training_adviser_steps_returning_teacher:
-        type_id: "Select 'yes' if you are a returning teacher and have qualified teacher status (QTS), or have an overseas teaching qualification."
+        type_id: "Only select 'yes' if you have qualified teacher status (QTS)."
       teacher_training_adviser_steps_have_a_degree:
         degree_options: "To use this service your bachelor's degree or predicted grade needs to be a 2:2 class honours or above."
       teacher_training_adviser_steps_overseas_telephone:


### PR DESCRIPTION
Changing hint text for question 'are you qualified to teach?' from:

> Select 'yes' if you are a returning teacher and have qualified teacher status (QTS), or have an overseas teaching qualification.

to:

> Only select 'yes' if you have qualified teacher status (QTS).

### Trello card

https://trello.com/c/4bSp8yzy/2943-get-an-adviser-question-change

### Context

### Changes proposed in this pull request

### Guidance to review

