### PR TITLE
Add postgres service to QA test step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -465,6 +465,19 @@ jobs:
     name: Run Integration Tests on QA
     runs-on: ubuntu-latest
     needs: [ build, qa ]
+    services:
+      postgres:
+        image: postgres:11.11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - name: Checkout
         uses: actions/checkout@v2.4.0


### PR DESCRIPTION
I missed this from the original PR; the deployment run failed as postgres isn't available.
