### PR TITLE
Fix integration tests not running

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -462,7 +462,7 @@ jobs:
           SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK-WEBHOOK }}
 
   integration:
-    name: Run Integration Tests on QA
+    name: Integration Tests
     runs-on: ubuntu-latest
     needs: [ build, qa ]
     services:
@@ -498,10 +498,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+      - name: Prepare DB
+        run: |-
+          docker run --net=host -t --rm -e RAILS_ENV=test -e DATABASE_URL="postgresql://postgres:postgres@localhost" ${{ needs.build.outputs.DOCKER_IMAGE }} rails db:prepare
+
       - name: Run Integration Tests
         run: |-
-          docker run -t --rm -e RAILS_ENV=test -e HTTP_USERNAME -e HTTP_PASSWORD -e MAILSAC_API_KEY \
-            ${{needs.build.outputs.DOCKER_IMAGE}} "bundle exec rspec --tag integration"
+          docker run --net=host -t --rm -e RAILS_ENV=test -e HTTP_USERNAME -e HTTP_PASSWORD -e MAILSAC_API_KEY \
+            -e DATABASE_URL="postgresql://postgres:postgres@localhost" ${{needs.build.outputs.DOCKER_IMAGE}} "bundle exec rspec --tag integration"
         env:
           HTTP_USERNAME: ${{ steps.keyvault-yaml-secret.outputs.HTTP-USERNAME }}
           HTTP_PASSWORD: ${{ steps.keyvault-yaml-secret.outputs.HTTP-PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,11 @@ ENTRYPOINT ["bundle", "exec"]
 CMD ["rails db:migrate && rails server"]
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache build-base tzdata shared-mime-info git nodejs yarn postgresql-libs postgresql-dev
+RUN apk add --no-cache build-base tzdata shared-mime-info git nodejs yarn postgresql-libs postgresql-dev chromium chromium-chromedriver
 
 # security patch for apline3.15
 # hadolint ignore=DL3019
 RUN apk add --upgrade gmp=6.2.1-r1
-
-# security patch for apline3.15-EXPAT
-# hadolint ignore=DL3019
-RUN apk add --upgrade expat=2.4.5-r0 
-
 
 # install NPM packages removign artifacts
 COPY package.json yarn.lock ./

--- a/Gemfile
+++ b/Gemfile
@@ -92,9 +92,9 @@ group :development do
 end
 
 group :test do
+  gem "selenium-webdriver"
   gem "shoulda-matchers"
   gem "vcr"
-  gem "webdrivers", "~> 5.0", ">= 5.0.0"
   # Used when VCR is turned off to block HTTP requests.
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    childprocess (4.1.0)
+    childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crack (0.4.5)
@@ -316,9 +316,8 @@ GEM
     scss_lint-govuk (0.2.0)
       scss_lint
     secure_headers (6.3.3)
-    selenium-webdriver (4.0.3)
-      childprocess (>= 0.5, < 5.0)
-      rexml (~> 3.2, >= 3.2.5)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_logger (4.10.0)
       concurrent-ruby (~> 1.0)
@@ -364,10 +363,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.0.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -417,6 +412,7 @@ DEPENDENCIES
   rubocop-govuk
   scss_lint-govuk
   secure_headers
+  selenium-webdriver
   sentry-rails
   sentry-ruby
   shoulda-matchers
@@ -427,7 +423,6 @@ DEPENDENCIES
   validates_timeliness
   vcr
   web-console (>= 4.2.0)
-  webdrivers (~> 5.0, >= 5.0.0)
   webmock
   webpacker
 

--- a/spec/capybara_driver_helper.rb
+++ b/spec/capybara_driver_helper.rb
@@ -1,0 +1,32 @@
+require "capybara/rspec"
+
+JS_DRIVER = :selenium_chrome_headless
+
+Capybara.register_driver JS_DRIVER do |app|
+  options = ::Selenium::WebDriver::Chrome::Options.new
+
+  options.add_argument("--headless")
+  options.add_argument("--no-sandbox")
+  options.add_argument("--disable-dev-shm-usage")
+  options.add_argument("--window-size=1400,1400")
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.configure do |config|
+  config.default_driver = :rack_test
+  config.javascript_driver = JS_DRIVER
+  config.server = :puma, { Silent: true }
+end
+
+RSpec.configure do |config|
+  config.before do |example|
+    Capybara.current_driver = JS_DRIVER if example.metadata[:js]
+  end
+
+  config.after do
+    Capybara.use_default_driver
+  end
+end
+
+# WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
+require_relative "capybara_driver_helper"
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production

--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -11,6 +11,7 @@ resource "cloudfoundry_app" "adviser_application" {
   memory       = 1024
   timeout      = 1000
   instances    = var.instances
+  disk_quota   = 2048
 
   dynamic "service_binding" {
     for_each = data.cloudfoundry_service_instance.linked


### PR DESCRIPTION
The TTA service hadn't been setup with selenium so the tests were failing. The docker image is now also bigger as it includes chromium, so I've had to up the disk quota.

The chromium package isn't compatible with a previous security fix - I've removed the workaround for now; it may still get flagged by snky, in which case I'll need to find another way around it.