### PR TITLE
Handle when invalid channel id is specified

### DIFF
--- a/app/models/teacher_training_adviser/steps/identity.rb
+++ b/app/models/teacher_training_adviser/steps/identity.rb
@@ -6,6 +6,7 @@ module TeacherTrainingAdviser::Steps
     attribute :last_name, :string
     attribute :email, :string
     attribute :channel_id, :integer
+    attribute :sub_channel_id
 
     validates :first_name, presence: true, length: { maximum: 256 }
     validates :last_name, presence: true, length: { maximum: 256 }
@@ -17,12 +18,16 @@ module TeacherTrainingAdviser::Steps
       true
     end
 
+    def export
+      super.except("sub_channel_id")
+    end
+
     def reviewable_answers
       super
         .tap { |answers|
           answers["name"] = "#{answers['first_name']} #{answers['last_name']}"
         }
-        .without("first_name", "last_name", "channel_id")
+        .without("first_name", "last_name", "channel_id", "sub_channel_id")
     end
 
     def channel_ids

--- a/app/models/teacher_training_adviser/steps/identity.rb
+++ b/app/models/teacher_training_adviser/steps/identity.rb
@@ -10,7 +10,6 @@ module TeacherTrainingAdviser::Steps
     validates :first_name, presence: true, length: { maximum: 256 }
     validates :last_name, presence: true, length: { maximum: 256 }
     validates :email, presence: true, email_format: true
-    validates :channel_id, inclusion: { in: :channel_ids, allow_nil: true }
 
     before_validation :sanitize_input
 
@@ -30,7 +29,17 @@ module TeacherTrainingAdviser::Steps
       query_channels.map { |channel| channel.id.to_i }
     end
 
+    def save
+      self.channel_id = nil if channel_invalid?
+
+      super
+    end
+
   private
+
+    def channel_invalid?
+      channel_id.present? && !channel_id.in?(channel_ids)
+    end
 
     def query_channels
       @query_channels ||= GetIntoTeachingApiClient::PickListItemsApi.new.get_candidate_teacher_training_adviser_subscription_channels

--- a/app/models/teacher_training_adviser/wizard.rb
+++ b/app/models/teacher_training_adviser/wizard.rb
@@ -49,7 +49,7 @@ module TeacherTrainingAdviser
 
       sign_up_candidate
 
-      @store.prune!(leave: %w[type_id degree_options])
+      @store.prune!(leave: %w[type_id degree_options sub_channel_id])
     end
 
     def exchange_access_token(timed_one_time_password, request)

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -28,7 +28,7 @@
 
           <p>Before you use this service as a non-UK citizen, you can check your qualifications by calling <%= link_to("0800 389 2500", "tel://08003892500") %>.</p>
 
-          <a href="<%= teacher_training_adviser_step_path(:identity, params.to_unsafe_h.slice(:channel)) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
+          <a href="<%= teacher_training_adviser_step_path(:identity, params.to_unsafe_h.slice(:channel, :sub_channel)) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -4,6 +4,7 @@
   <%= f.govuk_text_field :last_name, width: 20 %>
   <%= f.govuk_email_field :email, width: 20 %>
   <%= f.hidden_field :channel_id, value: f.object.channel_id || params[:channel] %>
+  <%= f.hidden_field :sub_channel_id, value: f.object.sub_channel_id || params[:sub_channel] %>
 
   <p>Your details are protected under the terms of our <%= link_to "privacy notice", privacy_policy_path(:id => session[:privacy_policy_id].presence || GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy.id) %>.</p>
 

--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -1,10 +1,9 @@
-
 <%= f.govuk_fieldset legend: { text: 'About you' } do %>
 
   <%= f.govuk_text_field :first_name, width: 20 %>
   <%= f.govuk_text_field :last_name, width: 20 %>
   <%= f.govuk_email_field :email, width: 20 %>
-  <%= f.hidden_field :channel_id, value: params[:channel] %>
+  <%= f.hidden_field :channel_id, value: f.object.channel_id || params[:channel] %>
 
   <p>Your details are protected under the terms of our <%= link_to "privacy notice", privacy_policy_path(:id => session[:privacy_policy_id].presence || GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy.id) %>.</p>
 

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-width-container">
+<div class="govuk-width-container" data-sub-channel-id="<%= session.dig("sign_up", "sub_channel_id") %>">
   <div class="govuk-main-wrapper govuk-main-wrapper--l">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -268,6 +268,8 @@ en:
               blank: "You need to enter your email address"
               invalid: "You need to enter your email address"
               too_long: "Your email address is too long - you need to enter a valid email address"
+            channel_id:
+              inclusion: The link you used to sign up is no longer valid.
         teacher_training_adviser/steps/subject_taught:
           attributes:
             subject_taught_id:

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -37,12 +37,13 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     end
 
     scenario "that is signing up at an on-campus event" do
+      sub_channel_id = "abcdef"
       channel = GetIntoTeachingApiClient::PickListItem.new({ id: 123_456, value: "On-campus event" })
 
       allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
         receive(:get_candidate_teacher_training_adviser_subscription_channels).and_return([channel])
 
-      visit root_path(channel: channel.id)
+      visit root_path(channel: channel.id, sub_channel: sub_channel_id)
       click_on "Start now"
 
       expect(page).to have_css "h1", text: "About you"
@@ -101,6 +102,9 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Complete"
 
       expect(page).to have_css "h1", text: "Sign up complete"
+
+      # We pass this to the BAM tracking pixel in GTM.
+      expect(page).to have_selector("[data-sub-channel-id='#{sub_channel_id}']")
     end
 
     scenario "that is signing up at an on-campus event (invalid channel id)" do

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -46,6 +46,9 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Start now"
 
       expect(page).to have_css "h1", text: "About you"
+      # Simulate en error to ensure channel id is not lost
+      click_on "Continue"
+      expect(page).to have_text("You need to enter your first name")
       fill_in_identity_step
       click_on "Continue"
 
@@ -92,6 +95,68 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
         subject_taught_id: SUBJECT_PSYCHOLOGY,
         preferred_teaching_subject_id: SUBJECT_PHYSICS,
         channel_id: channel.id,
+      })
+      expect_sign_up_with_attributes(request_attributes)
+
+      click_on "Complete"
+
+      expect(page).to have_css "h1", text: "Sign up complete"
+    end
+
+    scenario "that is signing up at an on-campus event (invalid channel id)" do
+      allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
+        receive(:get_candidate_teacher_training_adviser_subscription_channels).and_return([])
+
+      visit root_path(channel: 123_456)
+      click_on "Start now"
+
+      expect(page).to have_css "h1", text: "About you"
+      fill_in_identity_step
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Are you qualified to teach?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Do you have your previous teacher reference number?"
+      choose "No"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Which main subject did you previously teach?"
+      select "Psychology"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Which subject would you like to teach if you return to teaching?"
+      choose "Physics"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Enter your date of birth"
+      fill_in_date_of_birth_step
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Where do you live?"
+      choose "UK"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "What is your address?"
+      fill_in_address_step
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "What is your telephone number?"
+      fill_in "UK telephone number (optional)", with: "123456789"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Check your answers before you continue"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Read and accept the privacy policy"
+      check "Accept the privacy policy"
+
+      request_attributes = uk_candidate_request_attributes({
+        type_id: RETURNING_TO_TEACHING,
+        subject_taught_id: SUBJECT_PSYCHOLOGY,
+        preferred_teaching_subject_id: SUBJECT_PHYSICS,
+        channel_id: nil,
       })
       expect_sign_up_with_attributes(request_attributes)
 

--- a/spec/models/teacher_training_adviser/steps/identity_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/identity_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe TeacherTrainingAdviser::Steps::Identity do
     it { is_expected.to allow_values("test@test.com", "test%.mctest@domain.co.uk").for :email }
   end
 
+  describe "#export" do
+    subject { instance.export }
+
+    %i[channel_id email first_name last_name].each do |key|
+      it { is_expected.to have_key(key.to_s) }
+    end
+
+    it { is_expected.not_to have_key("sub_channel_id") }
+  end
+
   describe "#save" do
     it "clears the channel_id on save when invalid" do
       subject.channel_id = "invalid"

--- a/spec/models/teacher_training_adviser/steps/identity_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/identity_spec.rb
@@ -42,12 +42,18 @@ RSpec.describe TeacherTrainingAdviser::Steps::Identity do
     it { is_expected.to allow_values("test@test.com", "test%.mctest@domain.co.uk").for :email }
   end
 
-  describe "validations for channel_id" do
-    let(:options) { channels.map(&:id) }
+  describe "#save" do
+    it "clears the channel_id on save when invalid" do
+      subject.channel_id = "invalid"
+      subject.save
+      expect(subject.channel_id).to be_nil
+    end
 
-    it { is_expected.to allow_values(options).for :channel_id }
-    it { is_expected.to allow_value(nil, "").for :channel_id }
-    it { is_expected.not_to allow_value(11_233).for :channel_id }
+    it "retains the channel_id on save when valid" do
+      subject.channel_id = channels.first.id
+      subject.save
+      expect(subject.channel_id).to eq(channels.first.id)
+    end
   end
 
   describe "#reviewable_answers" do


### PR DESCRIPTION
### Trello card

[Trello-3051](https://trello.com/c/oMCKU9xZ/3051-improve-error-message-when-channel-id-is-invalid)

### Context

Our on-campus events provide a `channel=` query string parameter (by way of a QR code/URL). If the channel is invalid we currently show an unhelpful error message.

Whilst it shouldn't be possible for users to encounter this scenario, if the QR code author makes a mistake it _could_ lead to
the user running into it. 

Handle the error more gracefully by clearing the channel and allowing the user to continue.

In addition to the `channel` we already record we want to allow BAM to send a `sub_channel` in the query string so that they can better attribute sign ups.

### Changes proposed in this pull request

- Handle when invalid channel id is specified

Also fixes a bug whereby the channel ID was dropped if the user hits a validation error on the identity step.

- Expose sub_channel for BAM tracking pixel

Store the `sub_channel` if present in the query string and expose it via the DOM so that we can retrieve it in GTM and include it in the magic pixel request.

### Guidance to review
