### PR TITLE
[557] Skip dependabot review app deletion

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   destroy:
     name: Destroy
+    if: startsWith(github.head_ref, 'dependabot/') == false
     environment:
        name: Review
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Trello card
https://trello.com/c/GduNhcDq

### Context
Failure to delete dependabot related review apps: https://github.com/DFE-Digital/get-teacher-training-adviser-service/runs/5867150170?check_suite_focus=true

### Changes proposed in this pull request
The creation of review app for dependabot PRs is skipped. So we shouldn't try to delete the review app.

### Guidance to review

