### PR TITLE
Remove userresearch environment

### DIFF
--- a/.env.userresearch
+++ b/.env.userresearch
@@ -1,3 +1,0 @@
-# Add public environment variables here for the User Research environment
-GIT_URL=https://get-into-teaching-app-ur.london.cloudapps.digital/
-GTM_ID=GTM-WSDJ5TZ

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,6 @@ Rails/UnknownEnv:
     - test
     - rolling
     - preprod
-    - userresearch
     - production
 
 Style/DateTime:

--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
-group :rolling, :preprod, :userresearch, :production, :pagespeed do
+group :rolling, :preprod, :production, :pagespeed do
   # loading the Gem monkey patches rails logger
   # only load in prod-like environments when we actually need it
   gem "amazing_print"

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,6 +21,3 @@ rolling:
 
 preprod:
   <<: *production
-
-userresearch:
-  <<: *production

--- a/config/environments/userresearch.rb
+++ b/config/environments/userresearch.rb
@@ -1,6 +1,0 @@
-# Use the preprod settings
-require File.expand_path("preprod.rb", __dir__)
-
-Rails.application.configure do
-  Rack::Attack.enabled = false
-end


### PR DESCRIPTION
### Trello card

[Trello-1660](https://trello.com/c/eRpJcktw/1660-migrate-all-secrets-from-rails-credentials-to-the-azure-keyvaults)

### Context

We currently store our secrets in a mixture of Rails credentials and Azure keyvaults; we want to store them all in the same place and Azure keyvaults is more secure, so we are migrating them to there.

### Changes proposed in this pull request

- Remove userresearch environment

As far as I can tell the user research environment in Cloud Foundry just uses the `test` Azure keyvault, which sets `RAILS_ENV=preprod` so the `userresearch` environment is never actually used.

### Guidance to review

