### PR TITLE
Remove references to Rails credentials

### DIFF
--- a/config/initializers/get_into_teaching_api_client.rb
+++ b/config/initializers/get_into_teaching_api_client.rb
@@ -6,7 +6,7 @@ GetIntoTeachingApiClient.configure do |config|
     config.host = parsed.hostname
   end
 
-  config.api_key["apiKey"] = ENV["GIT_API_TOKEN"].presence || Rails.application.credentials.config[:api_key].presence
+  config.api_key["apiKey"] = ENV["GIT_API_TOKEN"].presence
 
   config.server_index = nil
   config.api_key_prefix["apiKey"] = "Bearer"

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,1 @@
-Sentry.init do |config|
-  if ENV["SENTRY_DSN"].blank? && Rails.application.credentials.sentry_dsn.present?
-    config.dsn = Rails.application.credentials.sentry_dsn
-  end
-end
+Sentry.init

--- a/lib/basic_auth.rb
+++ b/lib/basic_auth.rb
@@ -14,7 +14,7 @@ class BasicAuth
     end
 
     def http_auth
-      ENV["HTTP_AUTH"] || Rails.application.credentials.config[:http_auth] || ""
+      ENV["HTTP_AUTH"] || ""
     end
 
     def env_requires_auth?

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -9,8 +9,4 @@ VCR.configure do |config|
   config.around_http_request(->(req) { req.method == :get && VCR.turned_on? }) do |request|
     VCR.use_cassette(request.uri, &request)
   end
-
-  Rails.application.credentials.config.each do |k, v|
-    config.filter_sensitive_data("ENV[#{k}]") { v }
-  end
 end


### PR DESCRIPTION
### Trello card

[Trello-1660](https://trello.com/c/eRpJcktw/1660-migrate-all-secrets-from-rails-credentials-to-the-azure-keyvaults)

### Context

We no longer use Rails credentials but some of the code will default to the Rails creds if an ENV var is not set; we no longer need to do that.

### Changes proposed in this pull request

- Remove references to Rails credentials

### Guidance to review

