### PR TITLE
Add permissions to build and deploy workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,18 @@
 name: Build Docker Image
+
 on:
   pull_request:
     types: [assigned, opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - master
+
+permissions:
+  contents: write
+  deployments: write
+  issues: write
+  packages: write
+  pull-requests: write
 
 jobs:
   build:
@@ -270,7 +278,7 @@ jobs:
   review:
     name: Review Deployment Process
     needs: [ unit-test , security-test, java-test ]
-    if: github.ref != 'refs/heads/master' && startsWith(github.head_ref, 'dependabot/') == false
+    if: github.ref != 'refs/heads/master'
     runs-on: ubuntu-latest
     concurrency: Review_${{github.event.number}}
     environment:


### PR DESCRIPTION
### Context
Dependabot by default has readonly permissions, some steps in the workflow require write permissions.

### Changes proposed in this pull request
This change sets workflow permissions for Actions and Dependabot.

### Guidance to review
Check that workflow is running as expected.

