### PR TITLE
Remove service account token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,7 +298,7 @@ jobs:
         with:
           keyvault: ${{ secrets.KEY_VAULT}}
           secret: INFRA-KEYS
-          key: ACTIONS-API-ACCESS-TOKEN, SLACK-WEBHOOK
+          key: SLACK-WEBHOOK
 
       - name: Deploy to Review
         uses: ./.github/workflows/actions/deploy
@@ -325,7 +325,6 @@ jobs:
         if: contains(github.event.pull_request.user.login, 'dependabot') == false
         uses: actions-ecosystem/action-add-labels@v1.1.3
         with:
-          github_token: ${{ steps.keyvault-yaml-secret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           labels: Review
 
   development:
@@ -524,14 +523,14 @@ jobs:
         with:
           keyvault: ${{ secrets.KEY_VAULT}}
           secret: INFRA-KEYS
-          key: ACTIONS-API-ACCESS-TOKEN, SLACK-WEBHOOK, SLACK-RELEASE-NOTE-WEBHOOK
+          key: SLACK-WEBHOOK, SLACK-RELEASE-NOTE-WEBHOOK
 
       - name: Get Release Id from Tag
         id: tag_id
         uses: DFE-Digital/github-actions/DraftReleaseByTag@master
         with:
           TAG: ${{needs.development.outputs.release_tag}}
-          TOKEN: ${{steps.keyvault-yaml-secret.outputs.ACTIONS-API-ACCESS-TOKEN}}
+          TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Publish Release
         if: steps.tag_id.outputs.release_id

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -37,14 +37,14 @@ jobs:
         with:
           keyvault: ${{ secrets.KEY_VAULT}}
           secret: INFRA-KEYS
-          key: ACTIONS-API-ACCESS-TOKEN, SLACK-WEBHOOK, SLACK-RELEASE-NOTE-WEBHOOK
+          key: SLACK-WEBHOOK, SLACK-RELEASE-NOTE-WEBHOOK
 
       - name: Get Release Id from Tag
         id: tag_id
         uses: DFE-Digital/github-actions/DraftReleaseByTag@master
         with:
           TAG: ${{ github.event.inputs.tag }}
-          TOKEN: ${{ steps.keyvault-yaml-secret.outputs.ACTIONS-API-ACCESS-TOKEN }}
+          TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Check if found
         if: steps.tag_id.outputs.release_id == ''


### PR DESCRIPTION
### Trello card
https://trello.com/c/JKv5aLRr

### Context
Maintaining a Github PAT is a maintenance burden

### Changes proposed in this pull request
Replace with default Github actions token

### Guidance to review
Check the actions don't need a specific PAT