### PR TITLE
Track cookie opt-in rates

### DIFF
--- a/app/controllers/client_metrics_controller.rb
+++ b/app/controllers/client_metrics_controller.rb
@@ -1,0 +1,11 @@
+class ClientMetricsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    metric_json = JSON.parse(request.body.read)
+
+    ActiveSupport::Notifications.instrument("tta.client_metric", metric_json)
+
+    head :ok
+  end
+end

--- a/app/webpacker/controllers/cookie_preferences_controller.js
+++ b/app/webpacker/controllers/cookie_preferences_controller.js
@@ -1,49 +1,53 @@
-import CookiePreferences from "../javascript/cookie_preferences"
-import { Controller } from "stimulus"
+import CookiePreferences from '../javascript/cookie_preferences';
+import { Controller } from 'stimulus';
 
 export default class extends Controller {
-  static targets = [ 'category' ]
-  static values = { saveState: String }
+  static targets = ['category'];
 
   connect() {
-    this.cookiePreferences = new CookiePreferences ;
-    this.assignRadios() ;
+    this.cookiePreferences = new CookiePreferences();
+    this.assignRadios();
   }
 
   assignRadios() {
-    for(const category of this.categoryTargets) {
-      const categoryName = category.getAttribute("data-category") ;
-      const allowed = this.cookiePreferences.allowed(categoryName) ;
-      const value = allowed ? '1' : '0' ;
-      const radio = category.querySelector('input[type="radio"][value="' + value + '"]') ;
+    for (const category of this.categoryTargets) {
+      const categoryName = category.getAttribute('data-category');
+      const allowed = this.cookiePreferences.allowed(categoryName);
+      const value = allowed ? '1' : '0';
+      const radio = category.querySelector(
+        'input[type="radio"][value="' + value + '"]'
+      );
 
-      if (radio)
-        radio.checked = true ;
+      if (radio) radio.checked = true;
     }
   }
 
-  toggle(event) {
-    this.saveStateValue = 'unsaved'
+  toggle(_event) {
+    this.data.set('save-state', 'unsaved');
   }
 
   save(event) {
-    event.preventDefault() ;
+    event.preventDefault();
 
-    for (const categoryFieldset of this.categoryTargets) {
-      const category = categoryFieldset.getAttribute('data-category')
-      const field = categoryFieldset.querySelector('input[type="radio"]:checked')
+    const categories = this.categoryTargets.reduce((acc, fieldset) => {
+      const category = fieldset.getAttribute('data-category');
+      const field = fieldset.querySelector('input[type="radio"]:checked');
 
       if (field) {
-        this.cookiePreferences.setCategory(category, field.value)
+        return { ...acc, [category]: field.value };
+      } else {
+        return acc;
       }
-    }
+    }, {});
 
-    this.saveStateValue = 'saving'
-    window.setTimeout(this.finishSave.bind(this), 300)
+    this.cookiePreferences.setCategories(categories);
+
+    this.data.set('save-state', 'saving');
+    window.setTimeout(this.finishSave.bind(this), 600);
   }
 
   finishSave() {
-    if (this.saveStateValue == 'saving')
-      this.saveStateValue = 'saved'
+    if (this.data.get('save-state') === 'saving')
+      this.data.set('save-state', 'saved');
   }
 }

--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -90,6 +90,7 @@ export default class CookiePreferences {
     );
 
     this.emitEvent(newlyAllowed);
+    this.sendMetric();
   }
 
   clearNonEssentialCookies() {
@@ -124,6 +125,21 @@ export default class CookiePreferences {
   boolValue(value) {
     const strValue = value.toString();
     return strValue === '1' || strValue === 'true' || strValue === 'yes';
+  }
+
+  sendMetric() {
+    const xhr = new XMLHttpRequest();
+    const data = JSON.stringify({
+      key: 'tta_client_cookie_consent_total',
+      labels: {
+        non_functional: this.allowed('non-functional'),
+        marketing: this.allowed('marketing'),
+      },
+    });
+
+    xhr.open('POST', '/client_metrics', true);
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    xhr.send(data);
   }
 
   emitEvent(newCategories) {

--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -1,117 +1,140 @@
-const Cookies = require('js-cookie') ;
+const Cookies = require('js-cookie');
 
 export default class CookiePreferences {
-  static cookieBaseName = "gta-cookie-preferences" ;
-  static cookieVersion = 1 ;
-  static cookieLifetimeInDays = 90 ;
-  static alwaysOnCategory = 'functional' ;
+  static cookieBaseName = 'gta-cookie-preferences';
+  static cookieVersion = 1;
+  static cookieLifetimeInDays = 90;
+  static alwaysOnCategory = 'functional';
   static allCategories = {
-    'functional' : true,
-    'non-functional' : true,
-    'marketing' : true
-  } ;
+    functional: true,
+    'non-functional': true,
+    marketing: true,
+  };
+
   static functionalCookies = [
-    'git-cookie-preferences-v1',
+    'gta-cookie-preferences-v1',
     '_dfe_session',
     'GiTBetaBannerCovid',
   ];
 
-  settings = null ;
-  cookieSet = false ;
+  settings = null;
+  cookieSet = false;
 
   constructor() {
-    this.readCookie() ;
+    this.readCookie();
   }
 
   static get cookieName() {
-    return CookiePreferences.cookieBaseName + "-v" + CookiePreferences.cookieVersion ;
+    return (
+      CookiePreferences.cookieBaseName + '-v' + CookiePreferences.cookieVersion
+    );
+  }
+
+  static get cookieDomains() {
+    const hostname = window.location.hostname;
+    const rootDomain = hostname.replace(/(.*?)\./, '');
+
+    return [hostname, `.${hostname}`, rootDomain, `.${rootDomain}`];
+  }
+
+  static clearCookie(key) {
+    CookiePreferences.cookieDomains.forEach((domain) =>
+      Cookies.remove(key, { domain })
+    );
   }
 
   readCookie() {
     const cookie = Cookies.get(CookiePreferences.cookieName);
-    if (typeof(cookie) == 'undefined' || !cookie) {
-      this.settings = {} ;
+    if (typeof cookie === 'undefined' || !cookie) {
+      this.settings = {};
     } else {
-      this.settings = JSON.parse(cookie) ;
-      this.cookieSet = true ;
+      this.settings = JSON.parse(cookie);
+      this.cookieSet = true;
     }
 
-    this.settings[CookiePreferences.alwaysOnCategory] = true ;
+    this.settings[CookiePreferences.alwaysOnCategory] = true;
   }
 
   writeCookie(categories) {
-    categories[CookiePreferences.alwaysOnCategory] = true ;
-    const serialized = JSON.stringify(categories)
+    categories[CookiePreferences.alwaysOnCategory] = true;
+    const serialized = JSON.stringify(categories);
     Cookies.set(CookiePreferences.cookieName, serialized, {
-      expires: CookiePreferences.cookieLifetimeInDays
-    }) ;
+      expires: CookiePreferences.cookieLifetimeInDays,
+      sameSite: 'Lax',
+    });
 
-    this.cookieSet = true ;
+    this.cookieSet = true;
   }
 
   get all() {
-    return this.settings ;
+    return this.settings;
   }
 
   allowed(category) {
-    return this.settings[category] || false ;
+    return this.settings[category] || false;
   }
 
   get categories() {
-    if (this.settings)
-      return Object.keys(this.settings) ;
-    else
-      return new Array ;
+    if (this.settings) return Object.keys(this.settings);
+    else return [];
   }
 
   set all(categories) {
-    const existingAllowed = this.allowedCategories ;
+    const existingAllowed = this.allowedCategories;
 
-    this.writeCookie(categories) ;
-    this.readCookie() ;
+    this.writeCookie(categories);
+    this.readCookie();
 
-    const newlyAllowed = this.allowedCategories.filter(category => !existingAllowed.includes(category))
+    const newlyAllowed = this.allowedCategories.filter(
+      (category) => !existingAllowed.includes(category)
+    );
 
-    this.emitEvent(newlyAllowed) ;
+    this.emitEvent(newlyAllowed);
   }
 
   clearNonEssentialCookies() {
     Object.keys(Cookies.get()).forEach((key) => {
-      if (!CookiePreferences.functionalCookies.includes(key))
-        Cookies.remove(key);
+      if (!CookiePreferences.functionalCookies.includes(key)) {
+        CookiePreferences.clearCookie(key);
+      }
     });
   }
 
-  setCategory(category, value) {
-    const strValue = value.toString() ;
-    const boolValue =
-      (strValue == "1" || strValue == "true" || strValue == "yes") ;
+  setCategories(categories) {
+    for (const [key, value] of Object.entries(categories)) {
+      categories[key] = this.boolValue(value);
+    }
 
-    let newSettings = Object.assign({}, this.settings) ;
-    const optingOut = newSettings[category] === true && !boolValue;
+    const newSettings = { ...this.settings, ...categories };
+    const optingOut = Object.keys(categories).some((category) => {
+      return !categories[category] && this.settings[category];
+    });
 
     if (optingOut) {
       this.clearNonEssentialCookies();
     }
 
-    newSettings[category] = boolValue ;
-
-    this.all = newSettings ;
+    this.all = newSettings;
   }
 
   get allowedCategories() {
-    return this.categories.filter(category => this.allowed(category))
+    return this.categories.filter((category) => this.allowed(category));
+  }
+
+  boolValue(value) {
+    const strValue = value.toString();
+    return strValue === '1' || strValue === 'true' || strValue === 'yes';
   }
 
   emitEvent(newCategories) {
-    let acceptedCookies = new CustomEvent("cookies:accepted", {
-      detail: { cookies: newCategories }
-    }) ;
+    const acceptedCookies = new CustomEvent('cookies:accepted', {
+      detail: { cookies: newCategories },
+    });
 
-    document.dispatchEvent(acceptedCookies) ;
+    document.dispatchEvent(acceptedCookies);
   }
 
   allowAll() {
-    this.all = CookiePreferences.allCategories ;
+    this.all = CookiePreferences.allCategories;
   }
 }

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -15,6 +15,11 @@ module Rack
       req.ip if req.path == "/csp_reports"
     end
 
+    # Throttle /client_metrics requests by IP (5rpm)
+    throttle("client_metrics req/ip", limit: 5, period: 1.minute) do |req|
+      req.ip if req.path == "/client_metrics"
+    end
+
     unless ENV["SKIP_REQ_LIMITS"].to_s.in? %w[true yes 1]
       # Throttle requests that issue a verification code by IP (5rpm)
       throttle("issue_verification_code req/ip", limit: 5, period: 1.minute) do |req|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
 
   get "/robots.txt", to: "robots#show"
 
+  resource :client_metrics, only: %i[create]
+
   namespace :teacher_training_adviser, path: "/teacher_training_adviser" do
     resources :feedbacks, only: %i[new create index] do
       collection do

--- a/lib/prometheus/metrics.rb
+++ b/lib/prometheus/metrics.rb
@@ -73,5 +73,12 @@ module Prometheus
       labels: %i[rating] + preset_labels.keys,
       preset_labels: preset_labels,
     )
+
+    prometheus.counter(
+      :tta_client_cookie_consent_total,
+      docstring: "A counter of cookie consent",
+      labels: %i[non_functional marketing] + preset_labels.keys,
+      preset_labels: preset_labels,
+    )
   end
 end

--- a/spec/javascript/controllers/cookie-acceptance_controller_spec.js
+++ b/spec/javascript/controllers/cookie-acceptance_controller_spec.js
@@ -4,8 +4,6 @@ import { Application } from 'stimulus' ;
 import CookieAcceptanceController from 'cookie-acceptance_controller.js' ;
 
 describe('CookieAcceptanceController', () => {
-  let cookieName = "gta-cookie-preferences-v1" ;
-
   document.body.innerHTML =
   `<div data-controller="cookie-acceptance" class="hide">
       <div data-cookie-acceptance-target="banner">

--- a/spec/javascript/controllers/cookie_preferences_controller_spec.js
+++ b/spec/javascript/controllers/cookie_preferences_controller_spec.js
@@ -1,17 +1,15 @@
-import { Application } from 'stimulus' ;
-import CookiePreferencesController from 'cookie_preferences_controller.js' ;
-
-const Cookies = require('js-cookie') ;
-import CookiePreferences from 'cookie_preferences' ;
+import { Application } from 'stimulus';
+import CookiePreferencesController from 'cookie_preferences_controller.js';
+import Cookies from 'js-cookie';
+import CookiePreferences from 'cookie_preferences';
 
 describe('CookiePreferencesController', () => {
   function clearPage() {
-    document.body.innerHTML = '' ;
+    document.body.innerHTML = '';
   }
 
   function initPage() {
-    document.body.innerHTML =
-    `<form data-controller="cookie-preferences">
+    document.body.innerHTML = `<form data-controller="cookie-preferences">
       <fieldset data-cookie-preferences-target="category" data-category="first">
         <input type="radio" value="0" id="first-no" name="cookies-first" data-action="cookie-preferences#toggle" />
         <input type="radio" value="1" id="first-yes" name="cookies-first" data-action="cookie-preferences#toggle" />
@@ -23,88 +21,105 @@ describe('CookiePreferencesController', () => {
       </fieldset>
 
       <button type="submit" data-action="cookie-preferences#save">Save</save>
-    </form>` ;
+    </form>`;
   }
 
   function getCookie() {
-    return Cookies.get(CookiePreferences.cookieName) ;
+    return Cookies.get(CookiePreferences.cookieName);
   }
 
   function setCookie(content) {
-    Cookies.set(CookiePreferences.cookieName, content) ;
+    Cookies.set(CookiePreferences.cookieName, content);
   }
 
   function getJsonCookie() {
-    return JSON.parse(getCookie()) ;
+    return JSON.parse(getCookie());
   }
 
   function setJsonCookie(data) {
-    setCookie(JSON.stringify(data)) ;
+    setCookie(JSON.stringify(data));
   }
 
   function initCookie() {
-    setJsonCookie({ first: true, second: false })
+    setJsonCookie({ first: true, second: false });
   }
 
   function getState() {
-    const form = document.querySelector('form[data-controller="cookie-preferences"]')
-    return form.getAttribute('data-cookie-preferences-save-state-value') ;
+    const form = document.querySelector(
+      'form[data-controller="cookie-preferences"]'
+    );
+    return form.getAttribute('data-cookie-preferences-save-state');
   }
 
-  const application = Application.start() ;
+  const application = Application.start();
   application.register('cookie-preferences', CookiePreferencesController);
 
-  beforeEach(clearPage) ;
+  beforeEach(clearPage);
 
-  describe("on page load", () => {
-    beforeEach(() => { initCookie(); initPage() })
+  describe('on page load', () => {
+    beforeEach(() => {
+      initCookie();
+      initPage();
+    });
 
     it('radios should be assigned', () => {
-      expect(document.getElementById('first-yes').checked).toBe(true) ;
-      expect(document.getElementById('first-no').checked).toBe(false) ;
-      expect(document.getElementById('second-yes').checked).toBe(false) ;
-      expect(document.getElementById('second-no').checked).toBe(true) ;
-    })
-  }) ;
+      expect(document.getElementById('first-yes').checked).toBe(true);
+      expect(document.getElementById('first-no').checked).toBe(false);
+      expect(document.getElementById('second-yes').checked).toBe(false);
+      expect(document.getElementById('second-no').checked).toBe(true);
+    });
+  });
 
-  describe("on page load without cookie", () => {
-    beforeEach(() => { initPage() })
+  describe('on page load without cookie', () => {
+    beforeEach(() => {
+      initPage();
+    });
 
     it('should save cookie', () => {
-      const data = getJsonCookie() ;
-      expect(data['functional']).toBe(undefined) ;
-    })
-  })
+      const data = getJsonCookie();
+      expect(data.functional).toBe(undefined);
+    });
+  });
 
-  describe("when changing radios", () => {
-    beforeEach(() => { initCookie(); initPage() })
+  describe('when changing radios', () => {
+    beforeEach(() => {
+      initCookie();
+      initPage();
+    });
 
-    it("cookie should only be updated when they click save", () => {
-      expect(getJsonCookie()).toEqual({ first: true, second: false })
-      document.getElementById('first-no').click()
-      expect(getJsonCookie()).toEqual({ first: true, second: false })
-      document.getElementById('second-yes').click()
-      expect(getJsonCookie()).toEqual({ first: true, second: false })
+    it('cookie should only be updated when they click save', () => {
+      expect(getJsonCookie()).toEqual({ first: true, second: false });
+      document.getElementById('first-no').click();
+      expect(getJsonCookie()).toEqual({ first: true, second: false });
+      document.getElementById('second-yes').click();
+      expect(getJsonCookie()).toEqual({ first: true, second: false });
 
-      document.querySelector('button').click()
-      expect(getJsonCookie()).toEqual({ first: false, functional: true, second: true })
-    })
-  }) ;
+      document.querySelector('button').click();
+      expect(getJsonCookie()).toEqual({
+        first: false,
+        functional: true,
+        second: true,
+      });
+    });
+  });
 
-  describe("save state", () => {
-    beforeEach(() => { initCookie(); initPage() })
+  describe('save state', () => {
+    beforeEach(() => {
+      initCookie();
+      initPage();
+    });
 
-    it("should change state when clicking save", () => {
-      expect(getState()).toEqual(null) ;
+    it('should change state when clicking save', () => {
+      expect(getState()).toEqual(null);
 
-      document.getElementById('first-no').click()
-      expect(getState()).toEqual('unsaved')
+      document.getElementById('first-no').click();
+      expect(getState()).toEqual('unsaved');
 
-      document.querySelector('button').click()
-      expect(getState()).toEqual('saving')
+      document.querySelector('button').click();
+      expect(getState()).toEqual('saving');
 
-      document.getElementById('second-yes').click()
-      expect(getState()).toEqual('unsaved')
-    })
-  })
-}) ;
+      document.getElementById('second-yes').click();
+      expect(getState()).toEqual('unsaved');
+    });
+  });
+});

--- a/spec/javascript/cookie_preferences_spec.js
+++ b/spec/javascript/cookie_preferences_spec.js
@@ -4,6 +4,7 @@ import CookiePreferences from 'cookie_preferences';
 describe('CookiePreferences', () => {
   let prefs = null;
   let newCategoriesEvent = null;
+  let xhrMock = null;
 
   function setCookie(name, content) {
     Cookies.set(name, content);
@@ -13,6 +14,29 @@ describe('CookiePreferences', () => {
     setCookie(name, JSON.stringify(data));
   }
 
+  function mockXMLHttpRequest() {
+    xhrMock = {
+      open: jest.fn(),
+      send: jest.fn(),
+      setRequestHeader: jest.fn(),
+    };
+    window.XMLHttpRequest = jest.fn().mockImplementation(() => xhrMock);
+  }
+
+  function expectMetric(labels) {
+    expect(xhrMock.open).toHaveBeenCalledWith('POST', '/client_metrics', true);
+    expect(xhrMock.setRequestHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'application/json'
+    );
+    expect(xhrMock.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        key: 'tta_client_cookie_consent_total',
+        labels: labels,
+      })
+    );
+  }
+
   document.addEventListener('cookies:accepted', (event) => {
     newCategoriesEvent = event.detail.cookies;
   });
@@ -20,6 +44,7 @@ describe('CookiePreferences', () => {
   beforeEach(() => {
     Cookies.remove(CookiePreferences.cookieName);
     newCategoriesEvent = null;
+    mockXMLHttpRequest();
   });
 
   describe('cookieName', () => {
@@ -132,6 +157,10 @@ describe('CookiePreferences', () => {
       it('emits event', () => {
         expect(newCategoriesEvent).toEqual(['features']);
       });
+
+      it('sends a metric', () => {
+        expectMetric({ non_functional: false, marketing: false });
+      });
     });
 
     describe('assigning existing category', () => {
@@ -169,6 +198,10 @@ describe('CookiePreferences', () => {
 
       it('emits event', () => {
         expect(newCategoriesEvent).toEqual(['marketing']);
+      });
+
+      it('sends a metric', () => {
+        expectMetric({ non_functional: false, marketing: true });
       });
     });
 
@@ -228,6 +261,10 @@ describe('CookiePreferences', () => {
       it('emits event', () => {
         expect(newCategoriesEvent).toEqual(['features']);
       });
+
+      it('sends a metric', () => {
+        expectMetric({ non_functional: false, marketing: false });
+      });
     });
 
     describe('allowAll', () => {
@@ -282,25 +319,42 @@ describe('CookiePreferences', () => {
 
     describe('assigning #all', () => {
       beforeEach(() => {
-        prefs.all = { required: false, functional: true };
+        prefs.all = {
+          required: false,
+          functional: true,
+          'non-functional': true,
+        };
       });
 
       it('should update', () => {
-        expect(prefs.all).toEqual({ required: false, functional: true });
+        expect(prefs.all).toEqual({
+          required: false,
+          functional: true,
+          'non-functional': true,
+        });
       });
 
       it('should return new values for #allowed', () => {
         expect(prefs.allowed('required')).toBe(false);
         expect(prefs.allowed('functional')).toBe(true);
+        expect(prefs.allowed('non-functional')).toBe(true);
         expect(prefs.allowed('marketing')).toBe(false);
       });
 
       it('should update #categories list', () => {
-        expect(prefs.categories).toEqual(['required', 'functional']);
+        expect(prefs.categories).toEqual([
+          'required',
+          'functional',
+          'non-functional',
+        ]);
       });
 
       it('emits event', () => {
-        expect(newCategoriesEvent).toEqual([]);
+        expect(newCategoriesEvent).toEqual(['non-functional']);
+      });
+
+      it('sends a metric', () => {
+        expectMetric({ non_functional: true, marketing: false });
       });
     });
 
@@ -323,6 +377,10 @@ describe('CookiePreferences', () => {
 
       it('emits event', () => {
         expect(newCategoriesEvent).toEqual([]);
+      });
+
+      it('sends a metric', () => {
+        expectMetric({ non_functional: false, marketing: false });
       });
     });
 

--- a/spec/javascript/cookie_preferences_spec.js
+++ b/spec/javascript/cookie_preferences_spec.js
@@ -1,161 +1,334 @@
-const Cookies = require('js-cookie') ;
-import CookiePreferences from 'cookie_preferences' ;
+import Cookies from 'js-cookie';
+import CookiePreferences from 'cookie_preferences';
 
 describe('CookiePreferences', () => {
-  let prefs = null ;
-  let newCategoriesEvent = null ;
+  let prefs = null;
+  let newCategoriesEvent = null;
 
   function setCookie(name, content) {
-    Cookies.set(name, content) ;
+    Cookies.set(name, content);
   }
 
   function setJsonCookie(name, data) {
-    setCookie(name, JSON.stringify(data)) ;
+    setCookie(name, JSON.stringify(data));
   }
 
-  document.addEventListener("cookies:accepted", (event) => {
-    newCategoriesEvent = event.detail.cookies ;
-  })
+  document.addEventListener('cookies:accepted', (event) => {
+    newCategoriesEvent = event.detail.cookies;
+  });
 
   beforeEach(() => {
-    Cookies.remove(CookiePreferences.cookieName)
-    newCategoriesEvent = null ;
-  })
+    Cookies.remove(CookiePreferences.cookieName);
+    newCategoriesEvent = null;
+  });
 
-  describe("cookieName", () => {
-    it("should include version number", () => {
-      expect(CookiePreferences.cookieName).toBe("gta-cookie-preferences-v1")
-    })
-  })
+  describe('cookieName', () => {
+    it('should include version number', () => {
+      expect(CookiePreferences.cookieName).toBe('gta-cookie-preferences-v1');
+    });
+  });
 
-  describe("with cookie set", () => {
+  describe('with cookie set', () => {
     beforeEach(() => {
-      setJsonCookie(CookiePreferences.cookieName, { required: true, marketing: false }) ;
-      prefs = new CookiePreferences ;
-    }) ;
+      setJsonCookie(CookiePreferences.cookieName, {
+        required: true,
+        marketing: false,
+      });
+      prefs = new CookiePreferences();
+    });
 
-    it("#all should load settings from cookie", () => {
-      expect(prefs.all).toEqual({functional: true, required: true, marketing: false}) ;
-    }) ;
+    it('#all should load settings from cookie', () => {
+      expect(prefs.all).toEqual({
+        functional: true,
+        required: true,
+        marketing: false,
+      });
+    });
 
-    it("should mark cookie as set", () => {
-      expect(prefs.cookieSet).toBe(true) ;
-    })
+    it('should mark cookie as set', () => {
+      expect(prefs.cookieSet).toBe(true);
+    });
 
-    describe("#allowed", () => {
-      it("should return per category values",() => {
-        expect(prefs.allowed('required')).toBe(true) ;
-        expect(prefs.allowed('marketing')).toBe(false) ;
-        expect(prefs.allowed('functional')).toBe(true) ;
-      })
+    describe('#allowed', () => {
+      it('should return per category values', () => {
+        expect(prefs.allowed('required')).toBe(true);
+        expect(prefs.allowed('marketing')).toBe(false);
+        expect(prefs.allowed('functional')).toBe(true);
+      });
 
-      it("should return false for unknown categories", () => {
-        expect(prefs.allowed('unknown')).toBe(false) ;
-      })
-    })
+      it('should return false for unknown categories', () => {
+        expect(prefs.allowed('unknown')).toBe(false);
+      });
+    });
 
-    describe("#categories", () => {
-      it("should return the categories held in the cookie", () => {
-        expect(prefs.categories).toEqual(["required", "marketing", "functional"]) ;
-      }) ;
-    }) ;
+    describe('#categories', () => {
+      it('should return the categories held in the cookie', () => {
+        expect(prefs.categories).toEqual([
+          'required',
+          'marketing',
+          'functional',
+        ]);
+      });
+    });
 
-    describe("#allowedCategories", () => {
-      it("should return categories set to true", () => {
-        expect(prefs.allowedCategories).toEqual(['required', 'functional'])
-      })
-    })
+    describe('#allowedCategories', () => {
+      it('should return categories set to true', () => {
+        expect(prefs.allowedCategories).toEqual(['required', 'functional']);
+      });
+    });
 
-    describe("assigning #all", () => {
-      beforeEach(() => { prefs.all = {required: false, features: true} })
+    describe('#setCategories', () => {
+      it('casts values to boolean', () => {
+        prefs.setCategories({
+          marketing: 'yes',
+          test: 1,
+          other: 'true',
+        });
 
-      it("should update", () => {
-        expect(prefs.all).toEqual({required: false, features: true, functional: true})
-      })
+        expect(prefs.allowed('marketing')).toBe(true);
+        expect(prefs.allowed('test')).toBe(true);
+        expect(prefs.allowed('other')).toBe(true);
 
-      it("should return new values for #allowed", () => {
-        expect(prefs.allowed('required')).toBe(false)
-        expect(prefs.allowed('features')).toBe(true)
-        expect(prefs.allowed('marketing')).toBe(false)
-        expect(prefs.allowed('functional')).toBe(true)
-      })
+        prefs.setCategories({
+          marketing: 'no',
+          test: 0,
+          other: 'false',
+        });
 
-      it("should update #categories list", () => {
-        expect(prefs.categories).toEqual(['required', 'features', 'functional'])
-      }) ;
+        expect(prefs.allowed('marketing')).toBe(false);
+        expect(prefs.allowed('test')).toBe(false);
+        expect(prefs.allowed('other')).toBe(false);
+      });
+    });
 
-      it("emits event", () => {
-        expect(newCategoriesEvent).toEqual(['features'])
-      })
-    }) ;
+    describe('assigning #all', () => {
+      beforeEach(() => {
+        prefs.all = { required: false, features: true };
+      });
 
-    describe("assigning existing category", () => {
-      beforeEach(() => { prefs.setCategory('marketing', true) })
+      it('should update', () => {
+        expect(prefs.all).toEqual({
+          required: false,
+          features: true,
+          functional: true,
+        });
+      });
 
-      it("updates allowed value", () => {
-        expect(prefs.allowed('marketing')).toBe(true)
-      })
+      it('should return new values for #allowed', () => {
+        expect(prefs.allowed('required')).toBe(false);
+        expect(prefs.allowed('features')).toBe(true);
+        expect(prefs.allowed('marketing')).toBe(false);
+        expect(prefs.allowed('functional')).toBe(true);
+      });
 
-      it("updates #all", () => {
-        expect(prefs.all).toEqual({required: true, marketing: true, functional: true})
-      })
+      it('should update #categories list', () => {
+        expect(prefs.categories).toEqual([
+          'required',
+          'features',
+          'functional',
+        ]);
+      });
 
-      it("does not update category list", () => {
-        expect(prefs.categories).toEqual(['required', 'marketing', 'functional'])
-      })
+      it('emits event', () => {
+        expect(newCategoriesEvent).toEqual(['features']);
+      });
+    });
 
-      it("does update allowed categories", () => {
-        expect(prefs.allowedCategories).toEqual(['required', 'marketing', 'functional'])
-      })
+    describe('assigning existing category', () => {
+      beforeEach(() => {
+        prefs.setCategories({ marketing: true });
+      });
 
-      it("emits event", () => {
-        expect(newCategoriesEvent).toEqual(['marketing'])
-      })
-    })
+      it('updates allowed value', () => {
+        expect(prefs.allowed('marketing')).toBe(true);
+      });
 
-    describe("assigning functional to false", () => {
-      beforeEach(() => { prefs.setCategory('functional', false) })
+      it('updates #all', () => {
+        expect(prefs.all).toEqual({
+          required: true,
+          marketing: true,
+          functional: true,
+        });
+      });
 
-      it("leaves the value as true", () => {
-        expect(prefs.allowed('functional')).toBe(true)
-      })
+      it('does not update category list', () => {
+        expect(prefs.categories).toEqual([
+          'required',
+          'marketing',
+          'functional',
+        ]);
+      });
 
-      it("is included in category list", () => {
-        expect(prefs.categories.includes('functional')).toBe(true)
-      })
+      it('does update allowed categories', () => {
+        expect(prefs.allowedCategories).toEqual([
+          'required',
+          'marketing',
+          'functional',
+        ]);
+      });
 
-      it("is included in the allowedCategories list", () => {
-        expect(prefs.allowedCategories.includes('functional')).toBe(true)
-      }) ;
-    }) ;
+      it('emits event', () => {
+        expect(newCategoriesEvent).toEqual(['marketing']);
+      });
+    });
 
-    describe("assigning new category", () => {
-      beforeEach(() => { prefs.setCategory('features', true) })
+    describe('assigning functional to false', () => {
+      beforeEach(() => {
+        prefs.setCategories({ functional: false });
+      });
 
-      it("updates allowed value", () => {
-        expect(prefs.allowed('features')).toBe(true)
-      })
+      it('leaves the value as true', () => {
+        expect(prefs.allowed('functional')).toBe(true);
+      });
 
-      it("updates #all", () => {
-        expect(prefs.all).toEqual({required: true, marketing: false, features: true, functional: true})
-      })
+      it('is included in category list', () => {
+        expect(prefs.categories.includes('functional')).toBe(true);
+      });
 
-      it("does not update category list", () => {
-        expect(prefs.categories).toEqual(['required', 'marketing', 'functional', 'features'])
-      })
+      it('is included in the allowedCategories list', () => {
+        expect(prefs.allowedCategories.includes('functional')).toBe(true);
+      });
+    });
 
-      it("does update allowed categories", () => {
-        expect(prefs.allowedCategories).toEqual(['required', 'functional', 'features'])
-      })
+    describe('assigning new category', () => {
+      beforeEach(() => {
+        prefs.setCategories({ features: true });
+      });
 
-      it("emits event", () => {
-        expect(newCategoriesEvent).toEqual(['features'])
-      })
-    })
+      it('updates allowed value', () => {
+        expect(prefs.allowed('features')).toBe(true);
+      });
+
+      it('updates #all', () => {
+        expect(prefs.all).toEqual({
+          required: true,
+          marketing: false,
+          features: true,
+          functional: true,
+        });
+      });
+
+      it('does not update category list', () => {
+        expect(prefs.categories).toEqual([
+          'required',
+          'marketing',
+          'functional',
+          'features',
+        ]);
+      });
+
+      it('does update allowed categories', () => {
+        expect(prefs.allowedCategories).toEqual([
+          'required',
+          'functional',
+          'features',
+        ]);
+      });
+
+      it('emits event', () => {
+        expect(newCategoriesEvent).toEqual(['features']);
+      });
+    });
+
+    describe('allowAll', () => {
+      beforeEach(() => {
+        prefs.allowAll();
+      });
+
+      it('sets all to true', () => {
+        expect(prefs.allowedCategories).toEqual([
+          'functional',
+          'non-functional',
+          'marketing',
+        ]);
+      });
+    });
+  });
+
+  describe('without cookie set', () => {
+    beforeEach(() => {
+      prefs = new CookiePreferences();
+    });
+
+    it('should mark cookie as set', () => {
+      expect(prefs.cookieSet).toBe(false);
+    });
+
+    describe('#all', () => {
+      it('should still include functional', () => {
+        expect(prefs.all).toEqual({ functional: true });
+      });
+    });
+
+    describe('#allowed', () => {
+      it('should return false for all categories', () => {
+        expect(prefs.allowed('functional')).toBe(true);
+        expect(prefs.allowed('required')).toBe(false);
+        expect(prefs.allowed('marketing')).toBe(false);
+      });
+    });
+
+    describe('#categories', () => {
+      it('should be functional only', () => {
+        expect(prefs.categories).toEqual(['functional']);
+      });
+    });
+
+    describe('#allowedCategories', () => {
+      it('should be functional only', () => {
+        expect(prefs.allowedCategories).toEqual(['functional']);
+      });
+    });
+
+    describe('assigning #all', () => {
+      beforeEach(() => {
+        prefs.all = { required: false, functional: true };
+      });
+
+      it('should update', () => {
+        expect(prefs.all).toEqual({ required: false, functional: true });
+      });
+
+      it('should return new values for #allowed', () => {
+        expect(prefs.allowed('required')).toBe(false);
+        expect(prefs.allowed('functional')).toBe(true);
+        expect(prefs.allowed('marketing')).toBe(false);
+      });
+
+      it('should update #categories list', () => {
+        expect(prefs.categories).toEqual(['required', 'functional']);
+      });
+
+      it('emits event', () => {
+        expect(newCategoriesEvent).toEqual([]);
+      });
+    });
+
+    describe('assigning new category', () => {
+      beforeEach(() => {
+        prefs.setCategories({ functional: true });
+      });
+
+      it('updates allowed value', () => {
+        expect(prefs.allowed('functional')).toBe(true);
+      });
+
+      it('updates #all', () => {
+        expect(prefs.all).toEqual({ functional: true });
+      });
+
+      it('does not update category list', () => {
+        expect(prefs.categories).toEqual(['functional']);
+      });
+
+      it('emits event', () => {
+        expect(newCategoriesEvent).toEqual([]);
+      });
+    });
 
     describe('opting out of a category', () => {
       beforeEach(() => {
-        prefs.setCategory('marketing', true);
+        prefs.setCategories({ marketing: true });
       });
 
       it('retains essential cookies and clears non-essential cookies', () => {
@@ -164,101 +337,47 @@ describe('CookiePreferences', () => {
         const essentialCookieKey = CookiePreferences.functionalCookies[2];
         Cookies.set(essentialCookieKey, 'essential');
 
-        prefs.setCategory('marketing', false);
+        prefs.setCategories({ marketing: false });
 
         expect(Cookies.get('non-essential')).toBeUndefined();
         expect(Cookies.get(essentialCookieKey)).toEqual('essential');
       });
     });
 
-    describe("allowAll", () => {
-      beforeEach(() => { prefs.allowAll() }) ;
+    describe('allowAll', () => {
+      beforeEach(() => {
+        prefs.allowAll();
+      });
 
-      it("sets all to true", () => {
-        expect(prefs.allowedCategories).toEqual(
-          ['functional', 'non-functional', 'marketing']
-        ) ;
-      }) ;
-    }) ;
-  })
+      it('sets all to true', () => {
+        expect(prefs.allowedCategories).toEqual([
+          'functional',
+          'non-functional',
+          'marketing',
+        ]);
+      });
+    });
+  });
 
-  describe("without cookie set", () => {
-    beforeEach(() => { prefs = new CookiePreferences })
+  describe('clearCookie', () => {
+    it('clears the cookie from all domains', () => {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: new URL('https://getintoteaching.education.gov.uk/'),
+      });
 
-    it("should mark cookie as set", () => {
-      expect(prefs.cookieSet).toBe(false) ;
-    })
+      const spy = jest.spyOn(Cookies, 'remove');
 
-    describe("#all", () => {
-      it("should still include functional", () => { expect(prefs.all).toEqual({'functional' : true}) })
-    })
+      CookiePreferences.clearCookie('key');
 
-    describe("#allowed", () => {
-      it("should return false for all categories", () => {
-        expect(prefs.allowed('functional')).toBe(true)
-        expect(prefs.allowed('required')).toBe(false)
-        expect(prefs.allowed('marketing')).toBe(false)
-      })
-    })
-
-    describe("#categories", () => {
-      it("should be functional only", () => { expect(prefs.categories).toEqual(['functional']) })
-    })
-
-    describe("#allowedCategories", () => {
-      it("should be functional only", () => { expect(prefs.allowedCategories).toEqual(['functional']) })
-    })
-
-    describe("assigning #all", () => {
-      beforeEach(() => { prefs.all = {required: false, functional: true} })
-
-      it("should update", () => {
-        expect(prefs.all).toEqual({required: false, functional: true})
-      })
-
-      it("should return new values for #allowed", () => {
-        expect(prefs.allowed('required')).toBe(false)
-        expect(prefs.allowed('functional')).toBe(true)
-        expect(prefs.allowed('marketing')).toBe(false)
-      })
-
-      it("should update #categories list", () => {
-        expect(prefs.categories).toEqual(['required', 'functional'])
-      }) ;
-
-      it("emits event", () => {
-        expect(newCategoriesEvent).toEqual([])
-      })
-    }) ;
-
-    describe("assigning new category", () => {
-      beforeEach(() => { prefs.setCategory('functional', true) })
-
-      it("updates allowed value", () => {
-        expect(prefs.allowed('functional')).toBe(true)
-      })
-
-      it("updates #all", () => {
-        expect(prefs.all).toEqual({functional: true})
-      })
-
-      it("does not update category list", () => {
-        expect(prefs.categories).toEqual(['functional'])
-      })
-
-      it("emits event", () => {
-        expect(newCategoriesEvent).toEqual([])
-      })
-    })
-
-    describe("allowAll", () => {
-      beforeEach(() => { prefs.allowAll() }) ;
-
-      it("sets all to true", () => {
-        expect(prefs.allowedCategories).toEqual(
-          ['functional', 'non-functional', 'marketing']
-        ) ;
-      }) ;
-    }) ;
-  }) ;
-})
+      expect(spy).toHaveBeenCalledWith('key', {
+        domain: 'getintoteaching.education.gov.uk',
+      });
+      expect(spy).toHaveBeenCalledWith('key', {
+        domain: '.getintoteaching.education.gov.uk',
+      });
+      expect(spy).toHaveBeenCalledWith('key', { domain: 'education.gov.uk' });
+      expect(spy).toHaveBeenCalledWith('key', { domain: '.education.gov.uk' });
+    });
+  });
+});

--- a/spec/javascript/gtm_spec.js
+++ b/spec/javascript/gtm_spec.js
@@ -100,7 +100,7 @@ describe('Google Tag Manager', () => {
 
     describe('when cookies are accepted', () => {
       it('updates GTM of all cookie preferences', () => {
-        new CookiePreferences().setCategory('marketing', true);
+        new CookiePreferences().setCategories({ marketing: true });
         expect(window.gtag).toHaveBeenCalledWith('consent', 'update', {
           analytics_storage: 'denied',
           ad_storage: 'granted',
@@ -111,7 +111,7 @@ describe('Google Tag Manager', () => {
 
   describe('when cookies have already been accepted', () => {
     beforeEach(() => {
-      new CookiePreferences().setCategory('non-functional', true);
+      new CookiePreferences().setCategories({ 'non-functional': true });
       mockGtag();
       run();
     });

--- a/spec/lib/prometheus/metrics_spec.rb
+++ b/spec/lib/prometheus/metrics_spec.rb
@@ -3,6 +3,15 @@ require "rails_helper"
 RSpec.describe Prometheus::Metrics do
   let(:registry) { Prometheus::Client.registry }
 
+  describe "tta_client_cookie_consent_total" do
+    subject { registry.get(:tta_client_cookie_consent_total) }
+
+    it { is_expected.not_to be_nil }
+    it { is_expected.to have_attributes(docstring: "A counter of cookie consent") }
+    it { expect { subject.get(labels: %i[non_functional marketing]) }.not_to raise_error }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
+  end
+
   describe "tta_request_total" do
     subject { registry.get(:tta_requests_total) }
 

--- a/spec/requests/client_metrics_spec.rb
+++ b/spec/requests/client_metrics_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec::describe "Client metrics", type: :request do
+RSpec.describe "Client metrics", type: :request do
   subject { response }
 
   let(:params) { { "key" => "tta_client_cookie_consent_total", "labels" => { "non_functional" => true, "marketing" => false } } }

--- a/spec/requests/client_metrics_spec.rb
+++ b/spec/requests/client_metrics_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec::describe "Client metrics", type: :request do
+  subject { response }
+
+  let(:params) { { "key" => "tta_client_cookie_consent_total", "labels" => { "non_functional" => true, "marketing" => false } } }
+  let(:events) { [] }
+
+  before do
+    record_client_metric_events
+    post client_metrics_path, params: params.to_json
+  end
+
+  it { is_expected.to have_http_status(:success) }
+  it { expect(self).to have_recorded_metric(params) }
+
+  def has_recorded_metric?(metric = nil)
+    events.any? { |event| event.payload == metric }
+  end
+
+private
+
+  def record_client_metric_events
+    ActiveSupport::Notifications.subscribe("tta.client_metric") do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+  end
+end

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -103,4 +103,35 @@ RSpec.describe "Instrumentation" do
       expect(metric).to receive(:increment).with(labels: { rating: "satisfied" }).once
     end
   end
+
+  describe "tta.client_metrics" do
+    let(:params) do
+      {
+        key: "tta_client_cookie_consent_total",
+        labels: {
+          non_functional: true,
+          marketing: false,
+        },
+      }
+    end
+
+    it "increments the client metric" do
+      metric = registry.get(:tta_client_cookie_consent_total)
+      expect(metric).to receive(:increment).with(labels:
+        {
+          non_functional: true,
+          marketing: false,
+        }).once
+      post client_metrics_path, params: params.to_json
+    end
+
+    context "when attempting to increment a non-client tta metric" do
+      before { params[:key] = "tta_metric" }
+
+      it "raises an error" do
+        expect { post client_metrics_path, params: params.to_json }.to \
+          raise_error(ArgumentError, "attempted to increment non-client metric")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Trello card

[Trello-3253](https://trello.com/c/8nYhdlGL/3253-enable-monitoring-of-cookie-opt-in-rate-on-the-tta-funnel)

### Context

We want to be able to track some metrics that trigger from the client-side. As all our metrics go via Prometheus we will need to send the information to Rails from the client in order to track it.

### Changes proposed in this pull request

- Add ability to track client-side metrics

Add `ClientMetricsController` to accept incoming client metric information from Javascript.

Add `tta_client_cookie_consent_total` metric as the first client-side metric to track the opt-in success rate.

- Update interface to accept setting multiple categories

We want to be able to emit an event when cookies change; currently we use a `setCategory` method that is called multiple times, so the `CookiePreference` class doesn't know when all the cookies have finished changing. By changing this to `setCategories` we encourage callers to set all cookie categories in one go and can emit an event thereafter.

- Send metric when opt-in status changes

When a user updates their opt-in status we want to increment a metric so that we can track the success rate of opting-in to cookies.

When a user changes their cookie preferences (either manually or via 'allow all') emit a `tta_client_cookie_consent_total` metric with the respective labels.

### Guidance to review

In an ideal world we would want to track opt-in rate per user, so that if a user opts-out but subsequently opts-in we have their latest status reflected in the metric. Given we are tracking even if they don't accept cookies we have to make sure its completely anonymous, so the best we can do is track the various opt-in/out events to give a decent indication of what portion of users are allowing the different cookie categories.