### PR TITLE
Ensure all pages have correct titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 1. Run `bundle install` to install the gem dependencies
 2. Run `yarn` to install node dependencies
 3. Run `rails db:setup` to setup the database.
-4. Run `az login` and then `make local set-local-env` to populate development secrets
+4. Run `az login` and then `make local setup-local-env` to populate development secrets
 5. Run `bundle exec rails server` to launch the app on http://localhost:3000
 6. (optional) Run `./bin/webpack-dev-server` in a separate shell for faster compilation of assets
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,12 +9,10 @@ class PagesController < ApplicationController
   end
 
   def session_expired
-    @page_title = "session expired"
     render template: "pages/session_expired"
   end
 
   def privacy_policy
-    @page_title = "privacy policy"
     policy_id = params[:id]
 
     @privacy_policy = if policy_id

--- a/app/controllers/teacher_training_adviser/feedbacks_controller.rb
+++ b/app/controllers/teacher_training_adviser/feedbacks_controller.rb
@@ -10,7 +10,6 @@ module TeacherTrainingAdviser
     before_action :restrict_access, if: :authenticate?
 
     def new
-      @page_title = "Give feedback on this service"
       @feedback = Feedback.new
     end
 
@@ -25,17 +24,13 @@ module TeacherTrainingAdviser
       end
     end
 
-    def thank_you
-      @page_title = "Thank you for your feedback"
-    end
+    def thank_you; end
 
     def index
-      @page_title = "Service feedback"
       @search = FeedbackSearch.new
     end
 
     def export
-      @page_title = "Export feedback"
       @search = FeedbackSearch.new(feedback_search_params)
 
       if @search.valid?

--- a/app/controllers/teacher_training_adviser/steps_controller.rb
+++ b/app/controllers/teacher_training_adviser/steps_controller.rb
@@ -5,7 +5,6 @@ module TeacherTrainingAdviser
     self.wizard_class = TeacherTrainingAdviser::Wizard
 
     around_action :set_time_zone, only: %i[show update] # rubocop:disable Rails/LexicallyScopedActionFilter
-    before_action :set_page_title, only: [:show] # rubocop:disable Rails/LexicallyScopedActionFilter
 
     def completed
       super
@@ -45,10 +44,6 @@ module TeacherTrainingAdviser
 
     def crm_store
       session[:sign_up_crm] ||= {}
-    end
-
-    def set_page_title
-      @page_title = "#{@current_step.title.downcase} step"
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,12 +10,11 @@ module ApplicationHelper
     ENV["GTM_ID"].present?
   end
 
-  def prefix_title(title)
-    if title
-      "Get an adviser: #{title}"
-    else
-      "Get an adviser"
-    end
+  def format_page_title(title, status)
+    prefix = status == 422 ? "Error: " : ""
+    title = [title, "Get an adviser", "GOV.UK"].compact.join(" - ")
+
+    "#{prefix}#{title}"
   end
 
   def govuk_form_for(*args, **options, &block)

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Cookies on Get into Teaching" %>
+
 <main class="govuk-main-wrapper no-margin" id="main-content" role="main">
   <div class="govuk-width-container">
     <%= back_link internal_referer || root_path %>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Forbidden" %>
+
 <main class="govuk-main-wrapper" id="main-content" role="main">
   <div class="govuk-width-container">
     <h1 class="govuk-heading-xl">Forbidden</h1>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "We're sorry, but something went wrong" %>
+
 <main class="govuk-main-wrapper" id="main-content" role="main">
   <div class="govuk-width-container">
     <h1 class="govuk-heading-xl">We're sorry, but something went wrong.</h1>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "The page you were looking for doesn't exist" %>
+
 <main class="govuk-main-wrapper" id="main-content" role="main">
   <div class="govuk-width-container">
     <h1 class="govuk-heading-xl">The page you were looking for doesn't exist.</h1>

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Too many requests" %>
+
 <main class="govuk-main-wrapper" id="main-content" role="main">
   <div class="govuk-width-container">
     <h1 class="govuk-heading-xl">Too many requests</h1>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "The change you wanted was rejected" %>
+
 <main class="govuk-main-wrapper" id="main-content" role="main">
   <div class="govuk-width-container">
     <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
-    <title><%= prefix_title(@page_title) %></title>
+    <title><%= format_page_title(@page_title, response.status) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%#= canonical_tag %>

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Accessibility information" %>
+
 <main class="govuk-main-wrapper no-margin" id="main-content" role="main">
     <div class="govuk-width-container">
         <div class="content__left">
@@ -41,7 +43,7 @@
                 <ul>
                     <li>accessible PDF</li>
                     <li>audio recording</li>
-                    <li>braille, easy read or large print format email</li> 
+                    <li>braille, easy read or large print format email</li>
                 </ul>
             </p>
             <p>
@@ -53,7 +55,7 @@
             </p>
             <p>
                 If you find any problems that are not listed on this page or think we're
-                not meeting accessibility requirements email 
+                not meeting accessibility requirements email
                 <a href="mailto:getintoteaching.helpdesk@education.gov.uk">getintoteaching.helpdesk@education.gov.uk</a>
             </p>
             <h2 class="govuk-heading-m">Enforcement procedure</h2>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Cookies" %>
+
 <main class="govuk-main-wrapper no-margin" id="main-content" role="main">
     <div class="govuk-width-container">
         <div class="content__left">

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Privacy Policy" %>
+
 <main class="govuk-main-wrapper no-margin" id="main-content" role="main">
   <div class="govuk-width-container">
     <div class="content__left">

--- a/app/views/pages/session_expired.html.erb
+++ b/app/views/pages/session_expired.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Session Expired" %>
+
 <main class="govuk-main-wrapper no-margin" id="main-content" role="main">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">

--- a/app/views/teacher_training_adviser/feedbacks/index.html.erb
+++ b/app/views/teacher_training_adviser/feedbacks/index.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Service feedback" %>
+
 <main class="govuk-main-wrapper no-margin" id="main-content" role="main">
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper">

--- a/app/views/teacher_training_adviser/feedbacks/new.html.erb
+++ b/app/views/teacher_training_adviser/feedbacks/new.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Give feedback on this service" %>
+
 <main class="govuk-main-wrapper no-margin" id="main-content" role="main">
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper">

--- a/app/views/teacher_training_adviser/feedbacks/thank_you.erb
+++ b/app/views/teacher_training_adviser/feedbacks/thank_you.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Thank you for your feedback" %>
+
 <main class="govuk-main-wrapper no-margin" id="main-content" role="main">
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper">

--- a/app/views/teacher_training_adviser/not_available.html.erb
+++ b/app/views/teacher_training_adviser/not_available.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Sorry, the adviser service is currently unavailable" %>
+
 <div class="govuk-width-container">
   <h1>Sorry, the adviser service is currently unavailable</h1>
   <p>To sign up whilst this service is unavailable, you can call us on

--- a/app/views/teacher_training_adviser/steps/_accept_privacy_policy.html.erb
+++ b/app/views/teacher_training_adviser/steps/_accept_privacy_policy.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Read and accept the privacy policy" %>
+
 <% policy_id = session[:privacy_policy_id].presence || GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy.id %>
 
 <%= f.govuk_check_boxes_fieldset :accepted_policy_id, legend: { text: "Read and accept the privacy policy"} do %>

--- a/app/views/teacher_training_adviser/steps/_already_signed_up.html.erb
+++ b/app/views/teacher_training_adviser/steps/_already_signed_up.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "You have already signed up to this service" %>
+
 <div class="govuk-form-group">
   <h1 class="govuk-heading-l">You have already signed up to this service</h1>
 

--- a/app/views/teacher_training_adviser/steps/_authenticate.html.erb
+++ b/app/views/teacher_training_adviser/steps/_authenticate.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "You've already registered with us" %>
+
 <%= f.govuk_fieldset legend: { text: "You're already registered with us" } do %>
   <%= render "wizard/steps/authenticate", f: f, resend_verification_path: resend_verification_teacher_training_adviser_steps_path %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_date_of_birth.html.erb
+++ b/app/views/teacher_training_adviser/steps/_date_of_birth.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Enter your date of birth" %>
+
 <%= f.govuk_date_field(:date_of_birth, date_of_birth: true) do %>
   <p class="govuk-body">
     We ask for your date of birth to check you're over 18. We also use it to

--- a/app/views/teacher_training_adviser/steps/_gcse_maths_english.html.erb
+++ b/app/views/teacher_training_adviser/steps/_gcse_maths_english.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?" %>
+
 <%= f.govuk_collection_radio_buttons :has_gcse_maths_and_english_id, f.object.class::OPTIONS, :last, nil, inline: true %>
 
 <details class="govuk-details" data-module="govuk-details">

--- a/app/views/teacher_training_adviser/steps/_gcse_science.html.erb
+++ b/app/views/teacher_training_adviser/steps/_gcse_science.html.erb
@@ -1,1 +1,3 @@
+<% @page_title = "Do you have grade 4 (C) or above in GCSE science, or equivalent?" %>
+
 <%= f.govuk_collection_radio_buttons :has_gcse_science_id, f.object.class::OPTIONS, :last, nil, inline: true %>

--- a/app/views/teacher_training_adviser/steps/_has_teacher_id.html.erb
+++ b/app/views/teacher_training_adviser/steps/_has_teacher_id.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Do you have your previous teacher reference number?" %>
+
 <%= f.govuk_radio_buttons_fieldset(:has_id, inline: true ) do %>
   <%= f.govuk_radio_button :has_id, true, label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :has_id, false, label: { text: 'No' }, link_errors: true %>

--- a/app/views/teacher_training_adviser/steps/_have_a_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_have_a_degree.html.erb
@@ -1,1 +1,3 @@
+<% @page_title = "Do you have a degree?" %>
+
 <%= f.govuk_collection_radio_buttons :degree_options, f.object.class::DEGREE_OPTIONS, :last, nil %>

--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "About you" %>
+
 <%= f.govuk_fieldset legend: { text: 'About you' } do %>
 
   <%= f.govuk_text_field :first_name, width: 20 %>

--- a/app/views/teacher_training_adviser/steps/_no_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_no_degree.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "We're sorry, but you need a degree to be eligible for this service" %>
+
 <div class="govuk-form-group">
   <h1 class="govuk-heading-l">We're sorry, but you need a degree to be eligible for this service</h1>
 

--- a/app/views/teacher_training_adviser/steps/_overseas_callback.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_callback.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Choose a time" %>
+
 <%= f.govuk_fieldset legend: { text: 'Choose a time' } do %>
 <%= f.govuk_select :phone_call_scheduled_at, callback_options(f.object.class.callback_booking_quotas), {} %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_overseas_country.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_country.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Which country do you live in?" %>
+
 <%= f.govuk_collection_select :country_id,
   f.object.class.options,
   :last,

--- a/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "What is your telephone number?" %>
+
 <%= f.govuk_fieldset legend: { text: 'What is your telephone number?' } do %>
   <%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+", value: f.object.address_telephone_value %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "You told us you have an equivalent degree and live overseas" %>
+
 <%= f.govuk_fieldset legend: { text: 'You told us you have an equivalent degree and live overseas' } do %>
 
 <p>We need to call you to check your degree. When we call, our adviser will ask for more details about the qualification you have.</p>

--- a/app/views/teacher_training_adviser/steps/_previous_teacher_id.html.erb
+++ b/app/views/teacher_training_adviser/steps/_previous_teacher_id.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "What is your previous teacher reference number?" %>
+
 <%= f.govuk_fieldset legend: { text: 'What is your previous teacher reference number?' } do %>
   <%= f.govuk_text_field :teacher_id, width: 20 %>
-  <% end %>
+<% end %>

--- a/app/views/teacher_training_adviser/steps/_qualification_required.html.erb
+++ b/app/views/teacher_training_adviser/steps/_qualification_required.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Get the right GCSEs or equivalent qualifications" %>
+
 <h1 class="govuk-heading-l">Get the right GCSEs or equivalent qualifications</h1>
 <div class="govuk-form-group">
     <p>You need to pass the required GCSEs or complete the equivalency test in order to train to teach in England.</p>

--- a/app/views/teacher_training_adviser/steps/_retake_gcse_maths_english.html.erb
+++ b/app/views/teacher_training_adviser/steps/_retake_gcse_maths_english.html.erb
@@ -1,1 +1,3 @@
+<% @page_title = "Are you planning to retake either English or maths (or both) GCSEs, or equivalent?" %>
+
 <%= f.govuk_collection_radio_buttons :planning_to_retake_gcse_maths_and_english_id, f.object.class::OPTIONS, :last, nil, inline: true %>

--- a/app/views/teacher_training_adviser/steps/_retake_gcse_science.html.erb
+++ b/app/views/teacher_training_adviser/steps/_retake_gcse_science.html.erb
@@ -1,1 +1,3 @@
+<% @page_title = "Are you planning to retake your science GCSE?" %>
+
 <%= f.govuk_collection_radio_buttons :planning_to_retake_gcse_science_id, f.object.class::OPTIONS, :last, nil, inline: true %>

--- a/app/views/teacher_training_adviser/steps/_returning_teacher.html.erb
+++ b/app/views/teacher_training_adviser/steps/_returning_teacher.html.erb
@@ -1,1 +1,3 @@
+<% @page_title = "Are you qualified to teach?" %>
+
 <%= f.govuk_collection_radio_buttons :type_id, f.object.class::OPTIONS, :last, nil, inline: true %>

--- a/app/views/teacher_training_adviser/steps/_review_answers.html.erb
+++ b/app/views/teacher_training_adviser/steps/_review_answers.html.erb
@@ -1,5 +1,6 @@
-<div class="govuk-width-container">
+<% @page_title = "Check your answers before you continue" %>
 
+<div class="govuk-width-container">
   <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/teacher_training_adviser/steps/_stage_interested_teaching.html.erb
+++ b/app/views/teacher_training_adviser/steps/_stage_interested_teaching.html.erb
@@ -1,1 +1,3 @@
+<% @page_title = "Which stage are you interested in teaching?" %>
+
 <%= f.govuk_collection_radio_buttons :preferred_education_phase_id, f.object.class::OPTIONS, :last, nil, inline: true %>

--- a/app/views/teacher_training_adviser/steps/_stage_of_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_stage_of_degree.html.erb
@@ -1,2 +1,4 @@
+<% @page_title = "In which year are you studying?" %>
+
 <% options = f.object.class::options %>
 <%= f.govuk_collection_radio_buttons :degree_status_id, options, :last, :first %>

--- a/app/views/teacher_training_adviser/steps/_start_teacher_training.html.erb
+++ b/app/views/teacher_training_adviser/steps/_start_teacher_training.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "When do you want to start your teacher training?" %>
+
 <%= f.govuk_collection_select :initial_teacher_training_year_id,
   f.object.years,
   :id,

--- a/app/views/teacher_training_adviser/steps/_subject_interested_teaching.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_interested_teaching.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Which subject would you like to teach?" %>
+
 <%= f.govuk_collection_select :preferred_teaching_subject_id,
   f.object.class.options,
   :last,

--- a/app/views/teacher_training_adviser/steps/_subject_like_to_teach.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_like_to_teach.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Which subject would you like to teach if you return to teaching?" %>
+
 <%= f.govuk_collection_radio_buttons :preferred_teaching_subject_id,
   f.object.class.sanitized_options,
   :last,

--- a/app/views/teacher_training_adviser/steps/_subject_not_found.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_not_found.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "We're sorry, but you are not eligible for this service" %>
+
 <main class="govuk-main-wrapper no-margin" id="main-content" role="main">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">

--- a/app/views/teacher_training_adviser/steps/_subject_taught.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_taught.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Which main subject did you previously teach?" %>
+
 <%= f.govuk_collection_select :subject_taught_id,
   f.object.class.options,
   :last,

--- a/app/views/teacher_training_adviser/steps/_uk_address.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_address.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "What is your address?" %>
+
 <%= f.govuk_fieldset legend: { text: 'What is your address?' } do %>
   <%= f.govuk_text_field :address_line1, width: 20 %>
   <%= f.govuk_text_field :address_line2, width: 20 %>

--- a/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "You told us you have an equivalent degree and live in the United Kingdom" %>
+
 <%= f.govuk_fieldset legend: { text: 'You told us you have an equivalent degree and live in the United Kingdom' } do %>
 
 <p>You need to book a callback with us to check your degree. We will contact you once your call is booked.</p>

--- a/app/views/teacher_training_adviser/steps/_uk_or_overseas.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_or_overseas.html.erb
@@ -1,1 +1,3 @@
+<% @page_title = "Where do you live?" %>
+
 <%= f.govuk_collection_radio_buttons :uk_or_overseas, [["UK"], ["Overseas"]], :first, inline: true %>

--- a/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "What is your telephone number?" %>
+
 <%= f.govuk_fieldset legend: { text: 'What is your telephone number?' } do %>
   <%= f.govuk_phone_field :address_telephone, width: 20 %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_what_degree_class.html.erb
+++ b/app/views/teacher_training_adviser/steps/_what_degree_class.html.erb
@@ -6,6 +6,8 @@ else
 end
 %>
 
+<% @page_title = text %>
+
 <%= f.govuk_collection_select :uk_degree_grade_id,
   f.object.class.options,
   :last,

--- a/app/views/teacher_training_adviser/steps/_what_subject_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_what_subject_degree.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "What subject is your degree?" %>
+
 <%= f.govuk_collection_select :degree_subject,
   f.object.class.options,
   :first,

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -1,3 +1,5 @@
+<% @page_title = "Sign up complete" %>
+
 <div class="govuk-width-container" data-sub-channel-id="<%= session.dig("sign_up", "sub_channel_id") %>">
   <div class="govuk-main-wrapper govuk-main-wrapper--l">
     <div class="govuk-grid-row">

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -17,6 +17,27 @@ RSpec.describe ApplicationHelper do
     it { is_expected.to have_css "body hr" }
   end
 
+  describe "#format_page_title" do
+    subject { format_page_title(title, status) }
+
+    let(:title) { "Page title" }
+    let(:status) { 200 }
+
+    it { is_expected.to eq("Page title - Get an adviser - GOV.UK") }
+
+    context "when there is no title" do
+      let(:title) { nil }
+
+      it { is_expected.to eq("Get an adviser - GOV.UK") }
+    end
+
+    context "when there is an error" do
+      let(:status) { 422 }
+
+      it { is_expected.to eq("Error: Page title - Get an adviser - GOV.UK") }
+    end
+  end
+
   describe "#govuk_form_for" do
     it "renders a form with GOV.UK form builder" do
       expect(govuk_form_for(StubModel.new, url: "http://test.com") {}).to eq(


### PR DESCRIPTION
### Trello card

[Trello-3248](https://trello.com/c/npC4lx2i/3248-dac-audit-gov-page-title)
[Trello-3249](https://trello.com/c/73iRG3Do/3249-dac-audit-gov-error-title)

### Context

Make sure all pages have an appropriate page title in the format:

`Main heading - Service name - GOV.UK`

If there is an error on the page then the title should be prefixed with `Error:`.

### Changes proposed in this pull request

- Ensure all pages have a correct page title
- Correct typo in make command

### Guidance to review

Changes inline with [GDS guidance](http://hmrc.github.io/assets-frontend/components/page-title/index.html)