### PR TITLE
Skip steps the candidate has seen/submitted already

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe_wizard.git
-  revision: 68278550c0a4771300d697e845ed213e58921009
+  revision: ba7ec290f046c9abb7361a159ff296afa053f69b
   specs:
     dfe_wizard (1.0.0)
       activemodel (>= 6.0.3.4)

--- a/app/models/teacher_training_adviser/steps/review_answers.rb
+++ b/app/models/teacher_training_adviser/steps/review_answers.rb
@@ -8,6 +8,11 @@ module TeacherTrainingAdviser::Steps
       answers_by_step.reject { |k| k.contains_personal_details? } # rubocop:disable Style/SymbolProc
     end
 
+    def seen?
+      # ensure this step is always shown to the candidate
+      false
+    end
+
   private
 
     def answers_by_step

--- a/app/models/teacher_training_adviser/steps/uk_or_overseas.rb
+++ b/app/models/teacher_training_adviser/steps/uk_or_overseas.rb
@@ -1,9 +1,7 @@
 module TeacherTrainingAdviser::Steps
   class UkOrOverseas < DFEWizard::Step
     attribute :uk_or_overseas, :string
-    attribute :country_id, :string
 
-    UK_COUNTRY_ID = "72f5c2e6-74f9-e811-a97a-000d3a2760f2".freeze
     OPTIONS = { uk: "UK", overseas: "Overseas" }.freeze
 
     validates :uk_or_overseas, inclusion: { in: OPTIONS.values }
@@ -12,11 +10,6 @@ module TeacherTrainingAdviser::Steps
       {
         "uk_or_overseas" => uk_or_overseas,
       }
-    end
-
-    def uk_or_overseas=(value)
-      super
-      self.country_id = UK_COUNTRY_ID if value == OPTIONS[:uk]
     end
   end
 end

--- a/app/models/teacher_training_adviser/wizard.rb
+++ b/app/models/teacher_training_adviser/wizard.rb
@@ -1,5 +1,7 @@
 module TeacherTrainingAdviser
   class Wizard < ::DFEWizard::Base
+    UK_COUNTRY_ID = "72f5c2e6-74f9-e811-a97a-000d3a2760f2".freeze
+
     self.steps = [
       Steps::Identity,
       DFEWizard::Steps::Authenticate,
@@ -55,6 +57,13 @@ module TeacherTrainingAdviser
     def exchange_access_token(timed_one_time_password, request)
       @api ||= GetIntoTeachingApiClient::TeacherTrainingAdviserApi.new
       @api.exchange_access_token_for_teacher_training_adviser_sign_up(timed_one_time_password, request)
+    end
+
+    def export_data
+      super.tap do |export|
+        # Default country_id to be UK if applicable
+        export["country_id"] = UK_COUNTRY_ID if @store[:uk_or_overseas] == Steps::UkOrOverseas::OPTIONS[:uk]
+      end
     end
 
   private

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -394,6 +394,76 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       expect(page).to have_css "h1", text: "Sign up complete"
     end
 
+    scenario "candidate changes an answer" do
+      visit teacher_training_adviser_steps_path
+
+      expect(page).to have_css "h1", text: "About you"
+      fill_in_identity_step
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Are you qualified to teach?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Do you have your previous teacher reference number?"
+      choose "Yes"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "What is your previous teacher reference number?"
+      fill_in "Teacher reference number (optional)", with: "1234"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Which main subject did you previously teach?"
+      select "Psychology"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Which subject would you like to teach if you return to teaching?"
+      choose "Physics"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Enter your date of birth"
+      fill_in_date_of_birth_step
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Where do you live?"
+      choose "UK"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "What is your address?"
+      fill_in_address_step
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "What is your telephone number?"
+      fill_in "UK telephone number (optional)", with: "123456789"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Check your answers before you continue"
+      click_on "Change your previous teacher reference number"
+
+      expect(page).to have_css "h1", text: "What is your previous teacher reference number?"
+      fill_in "Teacher reference number (optional)", with: "5678"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Check your answers before you continue"
+      click_on "Continue"
+
+      expect(page).to have_css "h1", text: "Read and accept the privacy policy"
+      check "Accept the privacy policy"
+
+      request_attributes = uk_candidate_request_attributes({
+        type_id: RETURNING_TO_TEACHING,
+        subject_taught_id: SUBJECT_PSYCHOLOGY,
+        preferred_teaching_subject_id: SUBJECT_PHYSICS,
+        teacher_id: "5678",
+      })
+      expect_sign_up_with_attributes(request_attributes)
+
+      click_on "Complete"
+
+      expect(page).to have_css "h1", text: "Thank you"
+      expect(page).to have_css "h1", text: "Sign up complete"
+    end
+
     scenario "candidate tries to skip past an exit step" do
       visit teacher_training_adviser_steps_path
 

--- a/spec/models/teacher_training_adviser/steps/review_answers_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/review_answers_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe TeacherTrainingAdviser::Steps::ReviewAnswers do
 
   it_behaves_like "a wizard step"
 
+  describe "#seen?" do
+    it { is_expected.not_to be_seen }
+  end
+
   describe "#personal_detail_answers_by_step" do
     subject { instance.personal_detail_answers_by_step }
 

--- a/spec/models/teacher_training_adviser/steps/uk_or_overseas_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_or_overseas_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkOrOverseas do
 
   describe "attributes" do
     it { is_expected.to respond_to :uk_or_overseas }
-    it { is_expected.to respond_to :country_id }
   end
 
   describe "#uk_or_overseas" do
@@ -14,18 +13,6 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkOrOverseas do
     it { is_expected.not_to allow_value(nil).for :uk_or_overseas }
     it { is_expected.not_to allow_value("Denmark").for :uk_or_overseas }
     it { is_expected.to allow_values(*TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS.values).for :uk_or_overseas }
-  end
-
-  describe "#uk_or_overseas=" do
-    it "sets country_id when UK" do
-      subject.uk_or_overseas = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
-      expect(subject.country_id).to eq(TeacherTrainingAdviser::Steps::UkOrOverseas::UK_COUNTRY_ID)
-    end
-
-    it "does nothing when overseas" do
-      subject.uk_or_overseas = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
-      expect(subject.country_id).to be_nil
-    end
   end
 
   describe "#reviewable_answers" do

--- a/spec/models/teacher_training_adviser/wizard_spec.rb
+++ b/spec/models/teacher_training_adviser/wizard_spec.rb
@@ -68,6 +68,20 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
       end
     end
 
+    describe "#export_data" do
+      it "sets country_id when uk_or_overseas is UK" do
+        wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:uk]
+        wizardstore["country_id"] = "abc-123"
+        expect(subject.export_data).to include({ "country_id" => described_class::UK_COUNTRY_ID })
+      end
+
+      it "does nothing when uk_or_overseas is not UK" do
+        wizardstore["uk_or_overseas"] = TeacherTrainingAdviser::Steps::UkOrOverseas::OPTIONS[:overseas]
+        wizardstore["country_id"] = "abc-123"
+        expect(subject.export_data).to include({ "country_id" => wizardstore["country_id"] })
+      end
+    end
+
     describe "#complete!" do
       let(:request) do
         GetIntoTeachingApiClient::TeacherTrainingAdviserSignUp.new({


### PR DESCRIPTION
### Trello card

[Trello-3250](https://trello.com/c/lAuxvW5N/3250-dac-audit-gov-check-answers)

### Context

At the moment the candidate will have to go through the remainder of the wizard steps when they change an answer from the check answers page.

Instead, we want to jump them straight back to the check answers page if they have already completed the form.

### Changes proposed in this pull request

- Skip steps the candidate has seen/submitted already

Pull in updated `dfe_wizard` gem which has this behaviour. Ensure the check answers step is always displayed to the user by overriding `#seen?`.

Default country to UK during data export instead of within the `uk_or_overseas` step; if we do it in the step it ends up setting the `country_id` and so the `overseas_country` step will be skipped if pre-filled when it shouldn't be (as its not optional).

### Guidance to review

[Corresponding dfe_wizard PR](https://github.com/DFE-Digital/dfe_wizard/pull/7)

Things to check:

- The various TTA wizard flows still work
- Pre-filled optional steps are still skipped
- Exit steps (e.g. no degree) still behave
- Check answers and change works inline with the GDS guidance
- Check answers then change to get a new flow works correctly