### PR TITLE
Fix skip to main content behaviour

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,9 +21,9 @@
 
   <%= analytics_body_tag class: "govuk-template__body govuk-body" do %>
     <%= render(partial: "shared/gtm_fallback") if gtm_enabled? %>
+    <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
     <header class="govuk-header" role="banner" data-module="govuk-header">
     <%= render partial: 'shared/cookie_banner' %>
-    <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">
           <%= link_to "/", class: "govuk-header__link govuk-header__link--homepage" do %>

--- a/app/webpacker/controllers/cookie-acceptance_controller.js
+++ b/app/webpacker/controllers/cookie-acceptance_controller.js
@@ -28,7 +28,6 @@ export default class extends Controller {
 
   showBanner() {
     this.element.classList.remove('hide') ;
-    this.acceptTarget.focus() ;
   }
 
   isPreferencesPage() {


### PR DESCRIPTION
### Trello card

[Trello-3259](https://trello.com/c/FIlbKkHq/3259-dac-audit-skip-links)

### Context

Currently the skip to main content link appears below the cookie banner. This means its not the first thing you get to when you hit tab after the page loads and it also means the focus goes to the accept cookies button after selecting the skip to main content link (when it should go to the first focusable item in the main content).

Move the cookie banner to be below the skip to main content link so that it doesn't steel the initial focus. Update the cookie banner JS to stop the auto-focus onto the accept cookies button (I'm not sure why we were doing this in the first place).

### Changes proposed in this pull request

- Fix skip to main content behaviour

### Guidance to review

