### PR TITLE
Ensure all pages have a main landmark

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ EXPOSE 3000
 ENTRYPOINT ["bundle", "exec"]
 CMD ["rails db:migrate && rails server"]
 
+# fix vulnerabilities
+RUN apk update freetype=2.11.1-r2
+
 # hadolint ignore=DL3018
 RUN apk add --no-cache build-base tzdata shared-mime-info git nodejs yarn postgresql-libs postgresql-dev chromium chromium-chromedriver
 

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -1,201 +1,198 @@
 <% @page_title = "Cookies on Get into Teaching" %>
 
-<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <%= back_link internal_referer || root_path %>
+<div class="govuk-width-container">
+  <%= back_link internal_referer || root_path %>
 
-    <h1>Cookies on Get into Teaching</h1>
+  <h1>Cookies on Get into Teaching</h1>
+
+  <p>
+    <strong>
+      Cookies are files saved on your phone, tablet or computer when
+      you visit a website.
+    </strong>
+  </p>
+
+  <p>
+    We use cookies to store information about how you use the website, such
+    as the pages you visit.
+  </p>
+
+  <h2 class="govuk-heading-m">
+    Cookie settings
+  </h2>
+
+  <p>
+    We use 3 types of cookie. You can choose which cookies you're happy
+    for us to use.
+  </p>
+
+  <div id="cookie-preferences-form">
+    <form id="cookie-preferences-from" novalidate data-controller="cookie-preferences">
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset"
+          aria-describedby="cookies-non-functional-hint"
+          data-cookie-preferences-target="category"
+          data-category="non-functional">
+
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h3 class="govuk-fieldset__heading">
+              Cookies that measure website use
+            </h3>
+          </legend>
+          <div class="govuk-hint" id="cookies-non-functional-hint">
+            <p>
+              We use Google Analytics to measure how you use the website so
+              we can improve it based on user needs. We do not allow Google
+              to use or share the data about how you use this service.
+            </p>
+
+            <p>
+              Google Analytics sets cookies that store anonymised
+              information about:
+            </p>
+
+            <ul>
+              <li>how you got to the service</li>
+              <li>
+                the pages you visit on <a href="https://www.gov.uk">GOV.UK</a>
+                and government digital services, and how long you spend on
+                each page
+              </li>
+              <li>what you click on while you're visiting the service</li>
+            </ul>
+
+            <p>
+              Cookies may be set by other third-party services to do things
+              like measure how you view YouTube videos that are on the
+              service.
+            </p>
+
+            <p>
+              If you have an account with other services provided by the
+              Education and Skills Funding Agency, the information collected
+              using analytics cookies will be linked to your account. This
+              will help us make the service work better for you.
+            </p>
+          </div>
+          <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+            <div class="govuk-radios__item">
+              <input id="cookies-non-functional-yes" class="govuk-radios__input" type="radio" value="1" name="cookies-non-functional" data-action="cookie-preferences#toggle" />
+              <label for="cookies-non-functional-yes" class="govuk-label govuk-radios__label">
+                Yes
+              </label>
+            </div>
+            <div class="govuk-radios__item">
+              <input id="cookies-non-functional-no" class="govuk-radios__input" type="radio" value="0" name="cookies-non-functional" data-action="cookie-preferences#toggle" />
+              <label for="cookies-non-functional-no" class="govuk-label govuk-radios__label">
+                No
+              </label>
+            </div>
+          </div>
+        </fieldset>
+
+        <hr />
+
+        <fieldset class="govuk-fieldset"
+          aria-describedby="cookies-marketing-hint"
+          data-cookie-preferences-target="category"
+          data-category="marketing">
+
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h3 class="govuk-fieldset__heading">
+              Cookies that help with our communication and marketing
+            </h3>
+          </legend>
+          <div class="govuk-hint" id="cookies-marketing-hint">
+            <p>
+              These cookies help us to improve the relevency of advertising
+              campaigns you receive from us.
+            </p>
+
+            <p>
+              We also share information about your use of this service with
+              our social media, advertising and analytics partner. They
+              combine it with other information that they've collected from
+              your use of our services to guide the advertising that you
+              receive.
+            </p>
+          </div>
+          <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+            <div class="govuk-radios__item">
+              <input id="cookies-marketing-yes" class="govuk-radios__input" type="radio" value="1" name="cookies-marketing" data-action="cookie-preferences#toggle" />
+              <label for="cookies-marketing-yes" class="govuk-label govuk-radios__label">
+                Yes
+              </label>
+            </div>
+            <div class="govuk-radios__item">
+              <input id="cookies-marketing-no" class="govuk-radios__input" type="radio" value="0" name="cookies-marketing" data-action="cookie-preferences#toggle" />
+              <label for="cookies-marketing-no" class="govuk-label govuk-radios__label">
+                No
+              </label>
+            </div>
+          </div>
+        </fieldset>
+
+        <hr />
+
+        <fieldset class="govuk-fieldset"
+          aria-describedby="cookies-functional-hint"
+          data-cookie-preferences-target="category"
+          data-category="functional">
+
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h3 class="govuk-fieldset__heading">
+              Strictly necessary cookies
+            </h3>
+          </legend>
+          <div class="govuk-hint" id="cookies-functional-hint">
+            <p>
+              These essential cookies do things like:
+            </p>
+
+            <ul>
+              <li>
+                remember your progress through a form (for example a licence
+                application)
+              </li>
+              <li>
+                remember the notifications you've seen so we do not show them
+                to you again
+              </li>
+            </ul>
+
+            <p>They always need to be on.</p>
+
+
+          </div>
+        </fieldset>
+
+        <p class="save-with-confirmation">
+          <button type="button"
+            data-action="cookie-preferences#save"
+            class="govuk-button">
+            Save
+          </button>
+
+          <span data-cookie-preferences-target="flash" class="save-with-confirmation__message">
+            Your cookie preferences have been saved
+          </span>
+
+          <br />
+          <%= link_to "Back to page", internal_referer || root_path, class: "govuk-button govuk-button--secondary" %>
+        </p>
+
+        <p>
+          <%= link_to "Find out more", cookies_path %>
+          about cookies on this service
+        </p>
+      </div>
+    </form>
 
     <p>
-      <strong>
-        Cookies are files saved on your phone, tablet or computer when
-        you visit a website.
-      </strong>
+      You can find more about who we are, how you can contact us
+      and how we process personal data in our
+      <a href="/privacy-policy">privacy notice</a>
     </p>
-
-    <p>
-      We use cookies to store information about how you use the website, such
-      as the pages you visit.
-    </p>
-
-    <h2 class="govuk-heading-m">
-      Cookie settings
-    </h2>
-
-    <p>
-      We use 3 types of cookie. You can choose which cookies you're happy
-      for us to use.
-    </p>
-
-    <div id="cookie-preferences-form">
-      <form id="cookie-preferences-from" novalidate data-controller="cookie-preferences">
-        <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset"
-            aria-describedby="cookies-non-functional-hint"
-            data-cookie-preferences-target="category"
-            data-category="non-functional">
-
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-              <h3 class="govuk-fieldset__heading">
-                Cookies that measure website use
-              </h3>
-            </legend>
-            <div class="govuk-hint" id="cookies-non-functional-hint">
-              <p>
-                We use Google Analytics to measure how you use the website so
-                we can improve it based on user needs. We do not allow Google
-                to use or share the data about how you use this service.
-              </p>
-
-              <p>
-                Google Analytics sets cookies that store anonymised
-                information about:
-              </p>
-
-              <ul>
-                <li>how you got to the service</li>
-                <li>
-                  the pages you visit on <a href="https://www.gov.uk">GOV.UK</a>
-                  and government digital services, and how long you spend on
-                  each page
-                </li>
-                <li>what you click on while you're visiting the service</li>
-              </ul>
-
-              <p>
-                Cookies may be set by other third-party services to do things
-                like measure how you view YouTube videos that are on the
-                service.
-              </p>
-
-              <p>
-                If you have an account with other services provided by the
-                Education and Skills Funding Agency, the information collected
-                using analytics cookies will be linked to your account. This
-                will help us make the service work better for you.
-              </p>
-            </div>
-            <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
-              <div class="govuk-radios__item">
-                <input id="cookies-non-functional-yes" class="govuk-radios__input" type="radio" value="1" name="cookies-non-functional" data-action="cookie-preferences#toggle" />
-                <label for="cookies-non-functional-yes" class="govuk-label govuk-radios__label">
-                  Yes
-                </label>
-              </div>
-              <div class="govuk-radios__item">
-                <input id="cookies-non-functional-no" class="govuk-radios__input" type="radio" value="0" name="cookies-non-functional" data-action="cookie-preferences#toggle" />
-                <label for="cookies-non-functional-no" class="govuk-label govuk-radios__label">
-                  No
-                </label>
-              </div>
-            </div>
-          </fieldset>
-
-          <hr />
-
-          <fieldset class="govuk-fieldset"
-            aria-describedby="cookies-marketing-hint"
-            data-cookie-preferences-target="category"
-            data-category="marketing">
-
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-              <h3 class="govuk-fieldset__heading">
-                Cookies that help with our communication and marketing
-              </h3>
-            </legend>
-            <div class="govuk-hint" id="cookies-marketing-hint">
-              <p>
-                These cookies help us to improve the relevency of advertising
-                campaigns you receive from us.
-              </p>
-
-              <p>
-                We also share information about your use of this service with
-                our social media, advertising and analytics partner. They
-                combine it with other information that they've collected from
-                your use of our services to guide the advertising that you
-                receive.
-              </p>
-            </div>
-            <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
-              <div class="govuk-radios__item">
-                <input id="cookies-marketing-yes" class="govuk-radios__input" type="radio" value="1" name="cookies-marketing" data-action="cookie-preferences#toggle" />
-                <label for="cookies-marketing-yes" class="govuk-label govuk-radios__label">
-                  Yes
-                </label>
-              </div>
-              <div class="govuk-radios__item">
-                <input id="cookies-marketing-no" class="govuk-radios__input" type="radio" value="0" name="cookies-marketing" data-action="cookie-preferences#toggle" />
-                <label for="cookies-marketing-no" class="govuk-label govuk-radios__label">
-                  No
-                </label>
-              </div>
-            </div>
-          </fieldset>
-
-          <hr />
-
-          <fieldset class="govuk-fieldset"
-            aria-describedby="cookies-functional-hint"
-            data-cookie-preferences-target="category"
-            data-category="functional">
-
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-              <h3 class="govuk-fieldset__heading">
-                Strictly necessary cookies
-              </h3>
-            </legend>
-            <div class="govuk-hint" id="cookies-functional-hint">
-              <p>
-                These essential cookies do things like:
-              </p>
-
-              <ul>
-                <li>
-                  remember your progress through a form (for example a licence
-                  application)
-                </li>
-                <li>
-                  remember the notifications you've seen so we do not show them
-                  to you again
-                </li>
-              </ul>
-
-              <p>They always need to be on.</p>
-
-
-            </div>
-          </fieldset>
-
-          <p class="save-with-confirmation">
-            <button type="button"
-              data-action="cookie-preferences#save"
-              class="govuk-button">
-              Save
-            </button>
-
-            <span data-cookie-preferences-target="flash" class="save-with-confirmation__message">
-              Your cookie preferences have been saved
-            </span>
-
-            <br />
-            <%= link_to "Back to page", internal_referer || root_path, class: "govuk-button govuk-button--secondary" %>
-          </p>
-
-          <p>
-            <%= link_to "Find out more", cookies_path %>
-            about cookies on this service
-          </p>
-        </div>
-      </form>
-
-      <p>
-        You can find more about who we are, how you can contact us
-        and how we process personal data in our
-        <a href="/privacy-policy">privacy notice</a>
-      </p>
-    </div>
   </div>
-  </div>
-</main>
-
+</div>
+</div>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,8 +1,6 @@
 <% @page_title = "Forbidden" %>
 
-<main class="govuk-main-wrapper" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <h1 class="govuk-heading-xl">Forbidden</h1>
-    <p>You do not have permission to access this resource.</p>
-  </div>
-</main>
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-xl">Forbidden</h1>
+  <p>You do not have permission to access this resource.</p>
+</div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,8 +1,6 @@
 <% @page_title = "We're sorry, but something went wrong" %>
 
-<main class="govuk-main-wrapper" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <h1 class="govuk-heading-xl">We're sorry, but something went wrong.</h1>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-xl">We're sorry, but something went wrong.</h1>
+  <p>If you are the application owner check the logs for more information.</p>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,9 +1,7 @@
 <% @page_title = "The page you were looking for doesn't exist" %>
 
-<main class="govuk-main-wrapper" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <h1 class="govuk-heading-xl">The page you were looking for doesn't exist.</h1>
-    <p>You may have mistyped the address or the page may have moved.</p>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</main>
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-xl">The page you were looking for doesn't exist.</h1>
+  <p>You may have mistyped the address or the page may have moved.</p>
+  <p>If you are the application owner check the logs for more information.</p>
+</div>

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -1,9 +1,7 @@
 <% @page_title = "Too many requests" %>
 
-<main class="govuk-main-wrapper" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <h1 class="govuk-heading-xl">Too many requests</h1>
-    <p>You have tried to access a page too often in a short space of time.</p>
-    <p>You can go <%= link_to("back", :back) %> and try to access the page again in 1 minute.</p>
-  </div>
-</main>
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-xl">Too many requests</h1>
+  <p>You have tried to access a page too often in a short space of time.</p>
+  <p>You can go <%= link_to("back", :back) %> and try to access the page again in 1 minute.</p>
+</div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,9 +1,7 @@
 <% @page_title = "The change you wanted was rejected" %>
 
-<main class="govuk-main-wrapper" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>
-    <p>Maybe you tried to change something you didn't have access to.</p>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>
+  <p>Maybe you tried to change something you didn't have access to.</p>
+  <p>If you are the application owner check the logs for more information.</p>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,7 +57,13 @@
       </div>
     </div>
 
-    <%= yield %>
+    <% if content_for?(:above_main_content) %>
+      <%= yield(:above_main_content) %>
+    <% end %>
+
+    <main class="govuk-main-wrapper no-margin" id="main-content" role="main">
+      <%= yield %>
+    </main>
 
     <%= render "layouts/footer" %>
   <% end %>

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -1,104 +1,102 @@
 <% @page_title = "Accessibility information" %>
 
-<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
-    <div class="govuk-width-container">
-        <div class="content__left">
-            <%= link_to 'Back', 'javascript:history.go(-1);', class: "govuk-back-link hidden", id: "backlink" %>
-            <h1>
-                Accessibility information
-            </h1>
-            <p>
-                This service is run by the Department for Education (DfE).
-            </p>
-            <p>
-                We want as many people as possible to be able to use this service. For
-                example, that means you should be able to:
-            </p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>change colours, contrast levels and fonts</li>
-                <li>zoom in up to 300% without the text spilling off the screen</li>
-                <li>navigate most of the service using just a keyboard and speech recognition software</li>
-                <li>
-                    listen to most of the service using a screen reader (including the most
-                    recent versions of JAWS, NVDA and VoiceOver)
-                </li>
-            </ul>
-            <p>
-                We've also made the service text as simple as possible to understand.
-            </p>
-            <p>
-                For advice on making your device easier to use if you have a disability
-                visit <a href="https://mcmw.abilitynet.org.uk/">AbilityNet</a>.
-            </p>
-            <p>
-                You can also find advice on GOV.UK at <a href="https://www.gov.uk/help/accessibility">Accessibility</a>.
-            </p>
-            <h2 class="govuk-heading-m">Service accessibility</h2>
-            <p>
-                We are not aware of any parts of our service which are not accessible.
-            </p>
-            <h2 class="govuk-heading-m">What to do if you cannot access parts of this service</h2>
-            <p>
-                <a aria-label="Get into teaching support email address" href="mailto:getintoteaching.helpdesk@education.gov.uk">Email us</a> if you need information on this service in any of the following formats:
-                <ul>
-                    <li>accessible PDF</li>
-                    <li>audio recording</li>
-                    <li>braille, easy read or large print format email</li>
-                </ul>
-            </p>
-            <p>
-                We'll consider your request and get back to you within 5 working days.
-            </p>
-            <h2 class="govuk-heading-m">Reporting accessibility problems with this service</h2>
-            <p>
-                We're always looking to improve the accessibility of this service.
-            </p>
-            <p>
-                If you find any problems that are not listed on this page or think we're
-                not meeting accessibility requirements email
-                <a href="mailto:getintoteaching.helpdesk@education.gov.uk">getintoteaching.helpdesk@education.gov.uk</a>
-            </p>
-            <h2 class="govuk-heading-m">Enforcement procedure</h2>
-            <p>
-                The <a href="https://www.equalityhumanrights.com/en">Equality and Human Rights Commission (EHRC)</a>
-                is responsible for
-                enforcing the 'accessibility regulations' - officially known as the
-                <a href="http://www.legislation.gov.uk/uksi/2018/852/contents/made">Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</a>
-            </p>
-            <p>
-                If you're not happy with how we respond to your complaint, contact the
-                <a href="https://www.equalityadvisoryservice.com/">Equality Advisory and Support Service (EASS)</a>.
-            </p>
-            <h2 class="govuk-heading-m">Technical information about this service's accessibility</h2>
-            <p>
-                DfE is committed to making its service accessible, in accordance with the
-                Public Sector Bodies (Websites and Mobile Applications) (No. 2)
-                Accessibility Regulations 2018.
-            </p>
-            <p>
-                This service is fully compliant with the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1</a> AA standard.
-            </p>
-            <h3 class="govuk-heading-s">
-                Navigation and accessing information
-            </h3>
-            <p>
-                We have not identified any problems relating to interactive tools and
-                transactions.
-            </p>
-            <h2 class="govuk-heading-m">How we tested this service</h2>
-            <p>
-                This service was last tested on 01 September 2020. The test was carried out by
-                the <a href="https://digitalaccessibilitycentre.org/">Digital Accessibility Centre (DAC)</a>.
-            </p>
-            <p>
-                We tested our whole service platform.
-            </p>
-            <p>
-                You can read the full <a href="/assets/documents/dac_git_report.pdf">Digital Accessibility Centre Report</a>.
-            </p>
-            <p class="govuk-hint">
-                This statement was prepared on 01 September 2020.
-            </p>
-        </div>
-    </div>
-</main>
+<div class="govuk-width-container">
+  <div class="content__left">
+    <%= link_to 'Back', 'javascript:history.go(-1);', class: "govuk-back-link hidden", id: "backlink" %>
+    <h1>
+      Accessibility information
+    </h1>
+    <p>
+      This service is run by the Department for Education (DfE).
+    </p>
+    <p>
+      We want as many people as possible to be able to use this service. For
+      example, that means you should be able to:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>change colours, contrast levels and fonts</li>
+      <li>zoom in up to 300% without the text spilling off the screen</li>
+      <li>navigate most of the service using just a keyboard and speech recognition software</li>
+      <li>
+        listen to most of the service using a screen reader (including the most
+        recent versions of JAWS, NVDA and VoiceOver)
+      </li>
+    </ul>
+    <p>
+      We've also made the service text as simple as possible to understand.
+    </p>
+    <p>
+      For advice on making your device easier to use if you have a disability
+      visit <a href="https://mcmw.abilitynet.org.uk/">AbilityNet</a>.
+    </p>
+    <p>
+      You can also find advice on GOV.UK at <a href="https://www.gov.uk/help/accessibility">Accessibility</a>.
+    </p>
+    <h2 class="govuk-heading-m">Service accessibility</h2>
+    <p>
+      We are not aware of any parts of our service which are not accessible.
+    </p>
+    <h2 class="govuk-heading-m">What to do if you cannot access parts of this service</h2>
+    <p>
+      <a aria-label="Get into teaching support email address" href="mailto:getintoteaching.helpdesk@education.gov.uk">Email us</a> if you need information on this service in any of the following formats:
+      <ul>
+        <li>accessible PDF</li>
+        <li>audio recording</li>
+        <li>braille, easy read or large print format email</li>
+      </ul>
+    </p>
+    <p>
+      We'll consider your request and get back to you within 5 working days.
+    </p>
+    <h2 class="govuk-heading-m">Reporting accessibility problems with this service</h2>
+    <p>
+      We're always looking to improve the accessibility of this service.
+    </p>
+    <p>
+      If you find any problems that are not listed on this page or think we're
+      not meeting accessibility requirements email
+      <a href="mailto:getintoteaching.helpdesk@education.gov.uk">getintoteaching.helpdesk@education.gov.uk</a>
+    </p>
+    <h2 class="govuk-heading-m">Enforcement procedure</h2>
+    <p>
+      The <a href="https://www.equalityhumanrights.com/en">Equality and Human Rights Commission (EHRC)</a>
+      is responsible for
+      enforcing the 'accessibility regulations' - officially known as the
+      <a href="http://www.legislation.gov.uk/uksi/2018/852/contents/made">Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</a>
+    </p>
+    <p>
+      If you're not happy with how we respond to your complaint, contact the
+      <a href="https://www.equalityadvisoryservice.com/">Equality Advisory and Support Service (EASS)</a>.
+    </p>
+    <h2 class="govuk-heading-m">Technical information about this service's accessibility</h2>
+    <p>
+      DfE is committed to making its service accessible, in accordance with the
+      Public Sector Bodies (Websites and Mobile Applications) (No. 2)
+      Accessibility Regulations 2018.
+    </p>
+    <p>
+      This service is fully compliant with the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1</a> AA standard.
+    </p>
+    <h3 class="govuk-heading-s">
+      Navigation and accessing information
+    </h3>
+    <p>
+      We have not identified any problems relating to interactive tools and
+      transactions.
+    </p>
+    <h2 class="govuk-heading-m">How we tested this service</h2>
+    <p>
+      This service was last tested on 01 September 2020. The test was carried out by
+      the <a href="https://digitalaccessibilitycentre.org/">Digital Accessibility Centre (DAC)</a>.
+    </p>
+    <p>
+      We tested our whole service platform.
+    </p>
+    <p>
+      You can read the full <a href="/assets/documents/dac_git_report.pdf">Digital Accessibility Centre Report</a>.
+    </p>
+    <p class="govuk-hint">
+      This statement was prepared on 01 September 2020.
+    </p>
+  </div>
+</div>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,225 +1,223 @@
 <% @page_title = "Cookies" %>
 
-<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
-    <div class="govuk-width-container">
-        <div class="content__left">
-            <%= link_to 'Back', 'javascript:history.go(-1);', class: "govuk-back-link hidden", id: "backlink" %>
-            <h1>Cookies</h1>
-            <p>
-                We want to make our services easy, useful and reliable. When services are delivered on the internet, this sometimes involves placing small amounts of information on your computer, tablet, or mobile phone – whichever device you use to access our site. these include small files known as cookies.
-            </p>
-            <p>
-                The information below shows the cookies that are set by <a href="https://www.gov.uk/government/organisations/department-for-education" target="_blank" rel="noopener noreferrer">education.gov.uk<span class="govuk-visually-hidden">(Link opens in new
-            window)</span> <i class="fas fa-external-link-alt"></i></a> and the third-party services we use. At the header and footer of this page, you can change your preferences at any time for marketing cookies.
-            </p>
+<div class="govuk-width-container">
+  <div class="content__left">
+    <%= link_to 'Back', 'javascript:history.go(-1);', class: "govuk-back-link hidden", id: "backlink" %>
+    <h1>Cookies</h1>
+    <p>
+      We want to make our services easy, useful and reliable. When services are delivered on the internet, this sometimes involves placing small amounts of information on your computer, tablet, or mobile phone – whichever device you use to access our site. these include small files known as cookies.
+    </p>
+    <p>
+      The information below shows the cookies that are set by <a href="https://www.gov.uk/government/organisations/department-for-education" target="_blank" rel="noopener noreferrer">education.gov.uk<span class="govuk-visually-hidden">(Link opens in new
+    window)</span> <i class="fas fa-external-link-alt"></i></a> and the third-party services we use. At the header and footer of this page, you can change your preferences at any time for marketing cookies.
+    </p>
 
-            <h3>1. Functional cookies</h3>
-            <p>
-                These functional cookies are strictly necessary cookies, which help to make your experience on the site as smooth as possible and do not gather information about you.
-            </p>
-            <p>Some examples of these cookies include:</p>
-            <ul>
-                <li>enabling a service to recognise your device so you don’t have to give the same information several times during one task</li>
-                <li>recognising that you may already have given a username and password so that you don’t need to do so for every webpage requested</li>
-                <li>measuring how many people are using our services so that we can make them easier to use and ensure that there is enough capacity to make sure they are fast</li>
-            </ul>
+    <h3>1. Functional cookies</h3>
+    <p>
+      These functional cookies are strictly necessary cookies, which help to make your experience on the site as smooth as possible and do not gather information about you.
+    </p>
+    <p>Some examples of these cookies include:</p>
+    <ul>
+      <li>enabling a service to recognise your device so you don’t have to give the same information several times during one task</li>
+      <li>recognising that you may already have given a username and password so that you don’t need to do so for every webpage requested</li>
+      <li>measuring how many people are using our services so that we can make them easier to use and ensure that there is enough capacity to make sure they are fast</li>
+    </ul>
 
-            <p>
-                <table class="govuk-table">
-                    <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                            <th>Name</th>
-                            <th>Purpose</th>
-                            <th>Expires</th>
-                        </tr>
-                    </thead>
-                    <tbody class="govuk-table__body">
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">_dfe_session</th>
-                            <td class="govuk-table__cell">temporary session data</th>
-                            <td class="govuk-table__cell">End of browser session</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">gta-cookie-preferences-v1</th>
-                            <td class="govuk-table__cell">Record acceptance of beta site cookie policy</th>
-                            <td class="govuk-table__cell">90 days</th>
-                        </tr>
-                    </tbody>
-                </table>
-            </p>
+    <p>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th>Name</th>
+            <th>Purpose</th>
+            <th>Expires</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_dfe_session</th>
+            <td class="govuk-table__cell">temporary session data</th>
+            <td class="govuk-table__cell">End of browser session</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">gta-cookie-preferences-v1</th>
+            <td class="govuk-table__cell">Record acceptance of beta site cookie policy</th>
+            <td class="govuk-table__cell">90 days</th>
+          </tr>
+        </tbody>
+      </table>
+    </p>
 
-            <h3>2. Non-functional cookies</h3>
-            <p>These cookies allow us to provide a more enhanced service and help us to learn what content our users like or don’t like, so we can make the service even better. they also help us to provide you with personalised content and teaching-related advertisements to help you with your consideration of Initial Teacher Training and returning to teaching. Whilst these cookies don’t collect your name or address, they do collect a unique user identifier code, which is linked to your device.</p>
-            <p>The types of non-functional cookies we set are:</p>
+    <h3>2. Non-functional cookies</h3>
+    <p>These cookies allow us to provide a more enhanced service and help us to learn what content our users like or don’t like, so we can make the service even better. they also help us to provide you with personalised content and teaching-related advertisements to help you with your consideration of Initial Teacher Training and returning to teaching. Whilst these cookies don’t collect your name or address, they do collect a unique user identifier code, which is linked to your device.</p>
+    <p>The types of non-functional cookies we set are:</p>
 
-            <h3>Website usage</h3>
-            <p>We measure website usage so that we can gain a better understanding of how people use our site. this enables us to improve the information that we provide. It also ensures that the service is available when you want it, and that it delivers information quickly. We use Google Analytics to gather this data.</p>
-            <p>
-                <table class="govuk-table">
-                    <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                            <th>Name</th>
-                            <th>Purpose</th>
-                            <th>Expires</th>
-                        </tr>
-                    </thead>
-                    <tbody class="govuk-table__body">
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">_ga</th>
-                            <td class="govuk-table__cell">Used by Google Analytics, this helps count how many people visit this site by tracking if you’ve visited before</th>
-                            <td class="govuk-table__cell">2 years</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">UA-179982899-1</th>
-                            <td class="govuk-table__cell">Used by Google Analytics, this registers a unique ID to generate statistics about how you use the website</th>
-                            <td class="govuk-table__cell">1 minute</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">_gid</th>
-                            <td class="govuk-table__cell">Used by Google Analytics, this helps count how many people visit this site by tracking if you’ve visited before</th>
-                            <td class="govuk-table__cell">24 hours</th>
-                        </tr>
-                    </tbody>
-                </table>
-            </p>
+    <h3>Website usage</h3>
+    <p>We measure website usage so that we can gain a better understanding of how people use our site. this enables us to improve the information that we provide. It also ensures that the service is available when you want it, and that it delivers information quickly. We use Google Analytics to gather this data.</p>
+    <p>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th>Name</th>
+            <th>Purpose</th>
+            <th>Expires</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_ga</th>
+            <td class="govuk-table__cell">Used by Google Analytics, this helps count how many people visit this site by tracking if you’ve visited before</th>
+            <td class="govuk-table__cell">2 years</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">UA-179982899-1</th>
+            <td class="govuk-table__cell">Used by Google Analytics, this registers a unique ID to generate statistics about how you use the website</th>
+            <td class="govuk-table__cell">1 minute</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_gid</th>
+            <td class="govuk-table__cell">Used by Google Analytics, this helps count how many people visit this site by tracking if you’ve visited before</th>
+            <td class="govuk-table__cell">24 hours</th>
+          </tr>
+        </tbody>
+      </table>
+    </p>
 
-            <h3>Marketing</h3>
-            <p>We use cookies to make our marketing more engaging and relevant to users. We use cookie information to focus our marketing on what’s relevant to specific users, to improve performance reporting, and to avoid showing ads that the user has already seen.</p>
-            <p>For example, we use cookies to remember your most recent searches, your previous interactions with our ads or search results, and your visits to our website.</p>
-            <p>We may also use data from conversion cookies to determine how many people who click on our ads go on to sign up for services on our website. Conversion cookies are not used by Google for interest-based ad targeting and persist for a limited time only.</p>
-            <p>We place marketing tags on our pages to simply track the success of our content per channel. Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. these sites are sometimes called 'third party' services. this tells us how many people are seeing the content and whether it's useful.</p>
-            <p>In addition, if you share a link to one of our pages, the service you share it on (for example, Facebook) may set a cookie. We have no control over cookies set on other websites - you can turn them off, but not through us.</p>
-            <p>
-                <table class="govuk-table">
-                    <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                            <th>Name</th>
-                            <th>Purpose</th>
-                            <th>Expires</th>
-                        </tr>
-                    </thead>
-                    <tbody class="govuk-table__body">
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">_pin_unauth</th>
-                            <td class="govuk-table__cell">We work with Pinterest to make our Pinterest ads more effective by being able to retarget those that have already visited our website and create lookalike audiences.</th>
-                            <td class="govuk-table__cell">1 year later</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">_scid</th>
-                            <td class="govuk-table__cell">Snapchat uses this cookie to deliver advertisements, to make them more relevant and meaningful to consumers, and to track the efficiency of advertising campaigns.</th>
-                            <td class="govuk-table__cell">13 months later</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">_derived_epik</th>
-                            <td class="govuk-table__cell">gets set by Pinterest</th>
-                            <td class="govuk-table__cell">1 year later</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">fr</th>
-                            <td class="govuk-table__cell">These help to deliver our advertising when you visit Facebook or a digital platform powered by Facebook Advertising</th>
-                            <td class="govuk-table__cell">90 days later</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">ATN</th>
-                            <td class="govuk-table__cell">athmt.com </th>
-                            <td class="govuk-table__cell">2 years later</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">X-AB</th>
-                            <td class="govuk-table__cell">sc-static.net</th>
-                            <td class="govuk-table__cell">24 hours later</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">_pineterest_ct_ua</th>
-                            <td class="govuk-table__cell">Pinterest marketing.</th>
-                            <td class="govuk-table__cell">1 year later</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">GPS</th>
-                            <td class="govuk-table__cell">YouTube may set this cookie on your computer once you click on the YouTube video player</th>
-                            <td class="govuk-table__cell">30 minutes later</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">PREF</th>
-                            <td class="govuk-table__cell">YouTube may set this cookie on your computer once you click on the YouTube video player</th>
-                            <td class="govuk-table__cell">2 years later</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">VISITOR_INFO1_LIVE</th>
-                            <td class="govuk-table__cell">YouTube may set this cookie on your computer once you click on the YouTube video player</th>
-                            <td class="govuk-table__cell">180 days later</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">YSC</th>
-                            <td class="govuk-table__cell">YouTube may set this cookie on your computer once you click on the YouTube video player</th>
-                            <td class="govuk-table__cell">End of browser session</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">IDE</th>
-                            <td class="govuk-table__cell">Double-click advertising</th>
-                            <td class="govuk-table__cell">390 days later</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">sc_at</th>
-                            <td class="govuk-table__cell">Snapchat uses this cookie to deliver advertisements, to make them more relevant and meaningful to consumers, and to track the efficiency of advertising campaigns.</th>
-                            <td class="govuk-table__cell">390 days later</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">personalization_id</th>
-                            <td class="govuk-table__cell">Twitter uses this cookie to deliver advertisements, to make them more relevant and meaningful to consumers, and to track the efficiency of advertising campaigns.</th>
-                            <td class="govuk-table__cell">2 years later</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">bam-session</th>
-                            <td class="govuk-table__cell">BAM use this cookie to attribute mailing list sign ups back to the agent at a teaching event that presented a QR code to the candidate.</th>
-                            <td class="govuk-table__cell">30 days</th>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">dax_listenerid</th>
-                            <td class="govuk-table__cell">DAX use this cookie for campaign effectiveness measurement for digital audio activity.</th>
-                            <td class="govuk-table__cell">3 months</th>
-                        </tr>
-                    </tbody>
-                </table>
-            </p>
+    <h3>Marketing</h3>
+    <p>We use cookies to make our marketing more engaging and relevant to users. We use cookie information to focus our marketing on what’s relevant to specific users, to improve performance reporting, and to avoid showing ads that the user has already seen.</p>
+    <p>For example, we use cookies to remember your most recent searches, your previous interactions with our ads or search results, and your visits to our website.</p>
+    <p>We may also use data from conversion cookies to determine how many people who click on our ads go on to sign up for services on our website. Conversion cookies are not used by Google for interest-based ad targeting and persist for a limited time only.</p>
+    <p>We place marketing tags on our pages to simply track the success of our content per channel. Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. these sites are sometimes called 'third party' services. this tells us how many people are seeing the content and whether it's useful.</p>
+    <p>In addition, if you share a link to one of our pages, the service you share it on (for example, Facebook) may set a cookie. We have no control over cookies set on other websites - you can turn them off, but not through us.</p>
+    <p>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th>Name</th>
+            <th>Purpose</th>
+            <th>Expires</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_pin_unauth</th>
+            <td class="govuk-table__cell">We work with Pinterest to make our Pinterest ads more effective by being able to retarget those that have already visited our website and create lookalike audiences.</th>
+            <td class="govuk-table__cell">1 year later</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_scid</th>
+            <td class="govuk-table__cell">Snapchat uses this cookie to deliver advertisements, to make them more relevant and meaningful to consumers, and to track the efficiency of advertising campaigns.</th>
+            <td class="govuk-table__cell">13 months later</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_derived_epik</th>
+            <td class="govuk-table__cell">gets set by Pinterest</th>
+            <td class="govuk-table__cell">1 year later</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">fr</th>
+            <td class="govuk-table__cell">These help to deliver our advertising when you visit Facebook or a digital platform powered by Facebook Advertising</th>
+            <td class="govuk-table__cell">90 days later</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">ATN</th>
+            <td class="govuk-table__cell">athmt.com </th>
+            <td class="govuk-table__cell">2 years later</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">X-AB</th>
+            <td class="govuk-table__cell">sc-static.net</th>
+            <td class="govuk-table__cell">24 hours later</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_pineterest_ct_ua</th>
+            <td class="govuk-table__cell">Pinterest marketing.</th>
+            <td class="govuk-table__cell">1 year later</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">GPS</th>
+            <td class="govuk-table__cell">YouTube may set this cookie on your computer once you click on the YouTube video player</th>
+            <td class="govuk-table__cell">30 minutes later</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">PREF</th>
+            <td class="govuk-table__cell">YouTube may set this cookie on your computer once you click on the YouTube video player</th>
+            <td class="govuk-table__cell">2 years later</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">VISITOR_INFO1_LIVE</th>
+            <td class="govuk-table__cell">YouTube may set this cookie on your computer once you click on the YouTube video player</th>
+            <td class="govuk-table__cell">180 days later</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">YSC</th>
+            <td class="govuk-table__cell">YouTube may set this cookie on your computer once you click on the YouTube video player</th>
+            <td class="govuk-table__cell">End of browser session</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">IDE</th>
+            <td class="govuk-table__cell">Double-click advertising</th>
+            <td class="govuk-table__cell">390 days later</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">sc_at</th>
+            <td class="govuk-table__cell">Snapchat uses this cookie to deliver advertisements, to make them more relevant and meaningful to consumers, and to track the efficiency of advertising campaigns.</th>
+            <td class="govuk-table__cell">390 days later</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">personalization_id</th>
+            <td class="govuk-table__cell">Twitter uses this cookie to deliver advertisements, to make them more relevant and meaningful to consumers, and to track the efficiency of advertising campaigns.</th>
+            <td class="govuk-table__cell">2 years later</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">bam-session</th>
+            <td class="govuk-table__cell">BAM use this cookie to attribute mailing list sign ups back to the agent at a teaching event that presented a QR code to the candidate.</th>
+            <td class="govuk-table__cell">30 days</th>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">dax_listenerid</th>
+            <td class="govuk-table__cell">DAX use this cookie for campaign effectiveness measurement for digital audio activity.</th>
+            <td class="govuk-table__cell">3 months</th>
+          </tr>
+        </tbody>
+      </table>
+    </p>
 
-            <h3>How to control your cookies</h3>
-            <p>You can delete or manage all cookies from your browser. the links below take you to the ‘Help' sections for each of the major browsers, so that you can find out more about how to manage your cookies.</p>
-            <p>
-                <ul>
-                    <li>
-                        <a href="https://support.google.com/chrome/answer/95647?hl=en-GB&p=cpn_cookies" target="_blank" rel="noopener noreferrer">
-                        Google Chrome <span class="govuk-visually-hidden">(Link opens in new
-            window)</span> <i class="fas fa-external-link-alt"></i>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://support.microsoft.com/en-us/help/17442/windows-internet-explorer-delete-manage-cookies#ie=ie-11" target="_blank" rel="noopener noreferrer">
-                        Internet Explorer <span class="govuk-visually-hidden">(Link opens in new
-            window)</span> <i class="fas fa-external-link-alt"></i>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://support.microsoft.com/en-us/help/4468242/microsoft-edge-browsing-data-and-privacy" target="_blank" rel="noopener noreferrer">
-                        Microsoft Edge <span class="govuk-visually-hidden">(Link opens in new
-            window)</span> <i class="fas fa-external-link-alt"></i>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://support.apple.com/kb/ph21411?locale=en_GB" target="_blank" rel="noopener noreferrer">
-                        Safari for Mac and mobile devices <span class="govuk-visually-hidden">(Link opens in new
-            window)</span> <i class="fas fa-external-link-alt"></i>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://support.mozilla.org/en-US/kb/cookies-information-websites-store-on-your-computer?redirectlocale=en-US&redirectslug=Cookies" target="_blank" rel="noopener noreferrer">
-                        Mozilla Firefox. <span class="govuk-visually-hidden">(Link opens in new
-            window)</span> <i class="fas fa-external-link-alt"></i>
-                        </a>
-                    </li>
-                </ul>
-            </p>
-            <p>Find out how we use your personal data when you sign up for our services.</p>
-        </div>
-    </div>
-</main>
+    <h3>How to control your cookies</h3>
+    <p>You can delete or manage all cookies from your browser. the links below take you to the ‘Help' sections for each of the major browsers, so that you can find out more about how to manage your cookies.</p>
+    <p>
+      <ul>
+        <li>
+          <a href="https://support.google.com/chrome/answer/95647?hl=en-GB&p=cpn_cookies" target="_blank" rel="noopener noreferrer">
+          Google Chrome <span class="govuk-visually-hidden">(Link opens in new
+    window)</span> <i class="fas fa-external-link-alt"></i>
+          </a>
+        </li>
+        <li>
+          <a href="https://support.microsoft.com/en-us/help/17442/windows-internet-explorer-delete-manage-cookies#ie=ie-11" target="_blank" rel="noopener noreferrer">
+          Internet Explorer <span class="govuk-visually-hidden">(Link opens in new
+    window)</span> <i class="fas fa-external-link-alt"></i>
+          </a>
+        </li>
+        <li>
+          <a href="https://support.microsoft.com/en-us/help/4468242/microsoft-edge-browsing-data-and-privacy" target="_blank" rel="noopener noreferrer">
+          Microsoft Edge <span class="govuk-visually-hidden">(Link opens in new
+    window)</span> <i class="fas fa-external-link-alt"></i>
+          </a>
+        </li>
+        <li>
+          <a href="https://support.apple.com/kb/ph21411?locale=en_GB" target="_blank" rel="noopener noreferrer">
+          Safari for Mac and mobile devices <span class="govuk-visually-hidden">(Link opens in new
+    window)</span> <i class="fas fa-external-link-alt"></i>
+          </a>
+        </li>
+        <li>
+          <a href="https://support.mozilla.org/en-US/kb/cookies-information-websites-store-on-your-computer?redirectlocale=en-US&redirectslug=Cookies" target="_blank" rel="noopener noreferrer">
+          Mozilla Firefox. <span class="govuk-visually-hidden">(Link opens in new
+    window)</span> <i class="fas fa-external-link-alt"></i>
+          </a>
+        </li>
+      </ul>
+    </p>
+    <p>Find out how we use your personal data when you sign up for our services.</p>
+  </div>
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,47 +1,45 @@
-<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <div class="govuk-main-wrapper">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">Get an adviser</h1>
+<div class="govuk-width-container">
+  <div class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Get an adviser</h1>
 
-          <p>If you want to become a teacher or return to teaching in England, a teacher training adviser can guide you through the process with free one-to-one support.</p>
-          <p>Your adviser will help you with:</p>
-          <ul>
-            <li>getting school experience</li>
-            <li>funding your course</li>
-            <li>choosing the right training</li>
-            <li>writing your personal statement</li>
-            <li>interview tips</li>
-          </ul>
-          <h2 class="govuk-heading-m">Who can get an adviser?</h2>
+        <p>If you want to become a teacher or return to teaching in England, a teacher training adviser can guide you through the process with free one-to-one support.</p>
+        <p>Your adviser will help you with:</p>
+        <ul>
+          <li>getting school experience</li>
+          <li>funding your course</li>
+          <li>choosing the right training</li>
+          <li>writing your personal statement</li>
+          <li>interview tips</li>
+        </ul>
+        <h2 class="govuk-heading-m">Who can get an adviser?</h2>
 
-          <p>You can get an adviser if you:</p>
+        <p>You can get an adviser if you:</p>
 
-          <ul>
-            <li>have a bachelor's degree, class 2:2 (honours) or higher</li>
-            <li>are studying for a degree and are predicted to get a class 2:2 (honours) or higher</li>
-            <li>already have qualified teacher status (QTS) and are returning to teach chemistry, computing, maths, modern foreign languages or physics</li>
-          </ul>
+        <ul>
+          <li>have a bachelor's degree, class 2:2 (honours) or higher</li>
+          <li>are studying for a degree and are predicted to get a class 2:2 (honours) or higher</li>
+          <li>already have qualified teacher status (QTS) and are returning to teach chemistry, computing, maths, modern foreign languages or physics</li>
+        </ul>
 
-          <p>If you are a non-UK citizen, you also need to have or be studying for a bachelor's degree (or equivalent qualification).</p>
+        <p>If you are a non-UK citizen, you also need to have or be studying for a bachelor's degree (or equivalent qualification).</p>
 
-          <p>Before you use this service as a non-UK citizen, you can check your qualifications by calling <%= link_to("0800 389 2500", "tel://08003892500") %>.</p>
+        <p>Before you use this service as a non-UK citizen, you can check your qualifications by calling <%= link_to("0800 389 2500", "tel://08003892500") %>.</p>
 
-          <a href="<%= teacher_training_adviser_step_path(:identity, params.to_unsafe_h.slice(:channel, :sub_channel)) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
-          Start now
-          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-          </svg>
-        </a>
-          <p>Find teacher training options if you live in:</p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li><a href="https://teachinscotland.scot">Scotland</a></li>
-            <li><a href="https://educators.wales/">Wales</a></li>
-            <li><a href="https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland">Northern Ireland</a></li>
-          </ul>
-        </div>
+        <a href="<%= teacher_training_adviser_step_path(:identity, params.to_unsafe_h.slice(:channel, :sub_channel)) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
+        Start now
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+          <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+        </svg>
+      </a>
+        <p>Find teacher training options if you live in:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li><a href="https://teachinscotland.scot">Scotland</a></li>
+          <li><a href="https://educators.wales/">Wales</a></li>
+          <li><a href="https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland">Northern Ireland</a></li>
+        </ul>
       </div>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,11 +1,9 @@
 <% @page_title = "Privacy Policy" %>
 
-<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <div class="content__left">
-      <%= link_to 'Back', 'javascript:history.go(-1);', class: "govuk-back-link hidden", id: "backlink" %>
-      <h2>Privacy Policy</h2>
-      <%= safe_html_format @privacy_policy.text %>
-    </div>
+<div class="govuk-width-container">
+  <div class="content__left">
+    <%= link_to 'Back', 'javascript:history.go(-1);', class: "govuk-back-link hidden", id: "backlink" %>
+    <h2>Privacy Policy</h2>
+    <%= safe_html_format @privacy_policy.text %>
   </div>
-</main>
+</div>

--- a/app/views/pages/session_expired.html.erb
+++ b/app/views/pages/session_expired.html.erb
@@ -1,17 +1,15 @@
 <% @page_title = "Session Expired" %>
 
-<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-heading-l">
-          Session expired
-        </div>
-        <p>
-          Your session has expired.
-        </p>
-        <%= link_to 'Restart your application', root_path %>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-heading-l">
+        Session expired
       </div>
+      <p>
+        Your session has expired.
+      </p>
+      <%= link_to 'Restart your application', root_path %>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/teacher_training_adviser/feedbacks/index.html.erb
+++ b/app/views/teacher_training_adviser/feedbacks/index.html.erb
@@ -1,16 +1,14 @@
 <% @page_title = "Service feedback" %>
 
-<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <div class="govuk-main-wrapper">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-          <h1 class="govuk-heading-l">Service feedback</h1>
-          <%= render "teacher_training_adviser/feedbacks/export_form" %>
-          <hr class="govuk-section-break govuk-section-break--l" />
-          <%= render "teacher_training_adviser/feedbacks/recent", recent_feedback: @recent_feedback %>
-        </div>
+<div class="govuk-width-container">
+  <div class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-l">Service feedback</h1>
+        <%= render "teacher_training_adviser/feedbacks/export_form" %>
+        <hr class="govuk-section-break govuk-section-break--l" />
+        <%= render "teacher_training_adviser/feedbacks/recent", recent_feedback: @recent_feedback %>
       </div>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/teacher_training_adviser/feedbacks/new.html.erb
+++ b/app/views/teacher_training_adviser/feedbacks/new.html.erb
@@ -1,39 +1,37 @@
 <% @page_title = "Give feedback on this service" %>
 
-<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <div class="govuk-main-wrapper">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">Give feedback on this service</h1>
-            <%= govuk_form_for @feedback do |f| %>
-              <%= f.govuk_error_summary %>
+<div class="govuk-width-container">
+  <div class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Give feedback on this service</h1>
+          <%= govuk_form_for @feedback do |f| %>
+            <%= f.govuk_error_summary %>
 
-              <p>
-                Help us improve the get an adviser service.
-              </p>
+            <p>
+              Help us improve the get an adviser service.
+            </p>
 
-              <%= f.govuk_radio_buttons_fieldset :successful_visit do %>
-                <%= f.govuk_radio_button :successful_visit, true, label: { text: "Yes" }, link_errors: true %>
-                <%= f.govuk_radio_button :successful_visit, false, label: { text: "No" }, link_errors: true do %>
-                  <%= f.govuk_text_area :unsuccessful_visit_explanation %>
-                <% end %>
+            <%= f.govuk_radio_buttons_fieldset :successful_visit do %>
+              <%= f.govuk_radio_button :successful_visit, true, label: { text: "Yes" }, link_errors: true %>
+              <%= f.govuk_radio_button :successful_visit, false, label: { text: "No" }, link_errors: true do %>
+                <%= f.govuk_text_area :unsuccessful_visit_explanation %>
               <% end %>
-
-              <%= f.govuk_collection_radio_buttons :rating, f.object.class.ratings, :first, nil %>
-
-              <%= f.govuk_text_area :improvements, rows: 5, label: { class: 'govuk-heading-m' } do %>
-                <p>
-                 Do not include any information that could identify you personally - such as your name.
-                </p>
-              <% end %>
-
-              <%= invisible_captcha %>
-
-              <%= f.govuk_submit "Submit feedback" %>
             <% end %>
-        </div>
+
+            <%= f.govuk_collection_radio_buttons :rating, f.object.class.ratings, :first, nil %>
+
+            <%= f.govuk_text_area :improvements, rows: 5, label: { class: 'govuk-heading-m' } do %>
+              <p>
+                Do not include any information that could identify you personally - such as your name.
+              </p>
+            <% end %>
+
+            <%= invisible_captcha %>
+
+            <%= f.govuk_submit "Submit feedback" %>
+          <% end %>
       </div>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/teacher_training_adviser/feedbacks/thank_you.erb
+++ b/app/views/teacher_training_adviser/feedbacks/thank_you.erb
@@ -1,26 +1,24 @@
 <% @page_title = "Thank you for your feedback" %>
 
-<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <div class="govuk-main-wrapper">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <div class="govuk-panel govuk-panel--confirmation">
-            <h1 class="govuk-panel__title">
-              Thank you for your feedback.
-            </h1>
-          </div>
-          <h2 class="govuk-heading-m">
-            Still have questions about teaching?
-          </h2>
-          <p>
-            <%= link_to_git_events("Get your questions answered at an event") %> or consider getting <%= link_to("school experience", "https://schoolexperience.education.gov.uk/") %>.
-          </p>
-          <p>
-            There's lots of <%= link_to_git_site("ways into teaching", "/train-to-be-a-teacher") %>, including training on the job with a salary or going to university to do a postgraduate course.
-          </p>
+<div class="govuk-width-container">
+  <div class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-panel govuk-panel--confirmation">
+          <h1 class="govuk-panel__title">
+            Thank you for your feedback.
+          </h1>
         </div>
+        <h2 class="govuk-heading-m">
+          Still have questions about teaching?
+        </h2>
+        <p>
+          <%= link_to_git_events("Get your questions answered at an event") %> or consider getting <%= link_to("school experience", "https://schoolexperience.education.gov.uk/") %>.
+        </p>
+        <p>
+          There's lots of <%= link_to_git_site("ways into teaching", "/train-to-be-a-teacher") %>, including training on the job with a salary or going to university to do a postgraduate course.
+        </p>
       </div>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/teacher_training_adviser/steps/_form.html.erb
+++ b/app/views/teacher_training_adviser/steps/_form.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:above_main_content) do %>
 <div role="navigation">
   <div class="govuk-width-container">
     <p>
@@ -5,21 +6,20 @@
     </p>
   </div>
 </div>
+<% end %>
 
-<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <%= govuk_form_for current_step, url: step_path do |f| %>
-      <%= f.govuk_error_summary %>
+<div class="govuk-width-container">
+  <%= govuk_form_for current_step, url: step_path do |f| %>
+    <%= f.govuk_error_summary %>
 
-      <%= render current_step.key, current_step: current_step, f: f %>
+    <%= render current_step.key, current_step: current_step, f: f %>
 
-      <% if wizard.step_can_proceed? %>
-        <%= f.govuk_submit(wizard.last_step? ? "Complete" : "Continue") %>
-      <% end %>
-
-      <% if content_for?(:form_help) %>
-        <div class="form-help"><%= yield(:form_help) %></div>
-      <% end %>
+    <% if wizard.step_can_proceed? %>
+      <%= f.govuk_submit(wizard.last_step? ? "Complete" : "Continue") %>
     <% end %>
-  </div>
-</main>
+
+    <% if content_for?(:form_help) %>
+      <div class="form-help"><%= yield(:form_help) %></div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/teacher_training_adviser/steps/_subject_not_found.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_not_found.html.erb
@@ -1,21 +1,19 @@
 <% @page_title = "We're sorry, but you are not eligible for this service" %>
 
-<main class="govuk-main-wrapper no-margin" id="main-content" role="main">
-  <div class="govuk-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">We're sorry, but you are not eligible for this service.</h1>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">We're sorry, but you are not eligible for this service.</h1>
 
-        <p>To be eligible, you must be planning to teach chemistry, computing, maths, modern foreign languages or physics.</p>
-        <p>You can find out more about getting back into teaching on the Get Into Teaching website.</p>
+      <p>To be eligible, you must be planning to teach chemistry, computing, maths, modern foreign languages or physics.</p>
+      <p>You can find out more about getting back into teaching on the Get Into Teaching website.</p>
 
-        <ul>
-          <li><%= link_to_git_site("returning to teaching", "returning-to-teaching", target: "_blank") %></li>
-          <li><%= link_to_git_site("coming to England to teach if you're from outside the UK", "come-to-england-to-teach-if-you-are-a-teacher-from-outside-the-uk", target: "_blank") %></li>
-          <li><%= link_to_git_site("return to teaching from overseas", "international-returners", target: "_blank") %></li>
-        </ul>
+      <ul>
+        <li><%= link_to_git_site("returning to teaching", "returning-to-teaching", target: "_blank") %></li>
+        <li><%= link_to_git_site("coming to England to teach if you're from outside the UK", "come-to-england-to-teach-if-you-are-a-teacher-from-outside-the-uk", target: "_blank") %></li>
+        <li><%= link_to_git_site("return to teaching from overseas", "international-returners", target: "_blank") %></li>
+      </ul>
 
-        <p>You can also search for teaching jobs in England at <%= link_to("Teaching Vacancies", "https://teaching-vacancies.service.gov.uk/", target: "_blank") %>.</p>
-    </div>
+      <p>You can also search for teaching jobs in England at <%= link_to("Teaching Vacancies", "https://teaching-vacancies.service.gov.uk/", target: "_blank") %>.</p>
   </div>
 </div>


### PR DESCRIPTION
### Trello card

[Trello-3257](https://trello.com/c/twvsWl1m/3257-dac-audit-no-main-landmark)

### Context

The completed page did not contain a main landmark and so the skip to main content link was not working.

Update application layout to include the main landmark and add a new `yield` so that we can insert back links above it on the form steps.

### Changes proposed in this pull request

- Ensure all pages have a main landmark
- Patch freetype vulnerability

### Guidance to review

