### PR TITLE
Handle invalid IP address gracefully

### DIFF
--- a/lib/cloud_front_ip_filter.rb
+++ b/lib/cloud_front_ip_filter.rb
@@ -17,6 +17,8 @@ private
     cloudfront_proxies.any? do |range|
       range.include? ip
     end
+  rescue IPAddr::InvalidAddressError
+    false
   end
 
   def cloudfront_proxies

--- a/spec/lib/cloud_front_ip_filter_spec.rb
+++ b/spec/lib/cloud_front_ip_filter_spec.rb
@@ -36,5 +36,9 @@ RSpec.describe CloudFrontIpFilter do
       it { expect(subject.call("15.207.13.1")).to be false }
       it { expect(subject.call("15.207.13.127")).to be false }
     end
+
+    context "with an invalid ip" do
+      it { expect(subject.call("a.b.c.d")).to be false }
+    end
   end
 end


### PR DESCRIPTION
If an invalid IP address makes it into the CloudFrontIpFilter it raises an IPAddr::InvalidAddressError to Sentry. These appear to originate from bots/non-user traffic but cause noise in Sentry, so handling it gracefully to silence the errors.
