### PR TITLE
Fix missing translation for time zone on check answers page

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,20 +17,20 @@ Rails.application.configure do
   # Enable server timing
   config.server_timing = true
 
+  # Use in-memory cache
+  config.cache_store = :memory_store
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}",
     }
   else
     config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
   end
 
   # Don't care if the mailer can't send.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,9 +214,6 @@ en:
       callback_time:
         title: "Callback time"
         change: "callback time"
-      time_zone:
-        title: "Time zone"
-        change: "callback time zone"
     overseas_country:
       country_id:
         title: "Which country do you live in?"
@@ -226,6 +223,9 @@ en:
         title: "Telephone"
         change: "your telephone"
     overseas_time_zone:
+      time_zone:
+        title: "Time zone"
+        change: "callback time zone"
       address_telephone:
         title: "Telephone"
         change: "your telephone"


### PR DESCRIPTION
### Trello card

[Trello-3416](https://trello.com/c/kx8angpq/3416-fix-time-zone-label-error-on-tta-funnel-check-answers-page)

### Context

There is a missing translation for the 'time zone' row on the check answers page, causing it to render as 'Title'.

### Changes proposed in this pull request

- Add missing translation for overseas time zone

The translation was missing for the overseas time zone field, causing it to display 'Title' on the check answers page instead of 'Time zone'. It looks like it was placed under the wrong key in the translations file.

- Use in-memory store in development

If the Rails cache is disabled we were defaulting to a `null_store` for the cache; we later set the `session_store` to use the `cache_store`, however, so it was causing the session to immediately expire. Instead, we should use a `memory_store` in development (caching is disabled by setting `perform_caching` to false).

I'm not sure how this ever worked 😕 

### Guidance to review

