### PR TITLE
Add additional ITT year on 24th June

### DIFF
--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -4,7 +4,6 @@ module TeacherTrainingAdviser::Steps
 
     validates :initial_teacher_training_year_id, inclusion: { in: :year_ids }
 
-    NUMBER_OF_YEARS = 3
     NOT_SURE_ID = 12_917
 
     def reviewable_answers
@@ -47,14 +46,26 @@ module TeacherTrainingAdviser::Steps
     def filter_items(items)
       items.select do |item|
         item.id == NOT_SURE_ID ||
-          item.value.to_i.between?(first_year, first_year + (NUMBER_OF_YEARS - 1))
+          item.value.to_i.between?(first_year, first_year + number_of_years)
       end
     end
 
     def first_year
       # After 6th September you can no longer start teacher training for that year.
-      include_current_year = Time.zone.today < Date.new(current_year, 9, 7)
+      include_current_year = Time.zone.today < date_to_drop_current_year
       include_current_year ? current_year : current_year + 1
+    end
+
+    def number_of_years
+      Time.zone.today.between?(date_to_add_additional_year, date_to_drop_current_year - 1.day) ? 3 : 2
+    end
+
+    def date_to_add_additional_year
+      Date.new(current_year, 6, 24)
+    end
+
+    def date_to_drop_current_year
+      Date.new(current_year, 9, 7)
     end
 
     def current_year

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
         GetIntoTeachingApiClient::PickListItem.new(id: 12_920, value: 2022),
         GetIntoTeachingApiClient::PickListItem.new(id: 12_921, value: 2023),
         GetIntoTeachingApiClient::PickListItem.new(id: 12_921, value: 2024),
+        GetIntoTeachingApiClient::PickListItem.new(id: 12_922, value: 2025),
+        GetIntoTeachingApiClient::PickListItem.new(id: 12_922, value: 2026),
       ]
 
       allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
@@ -36,32 +38,64 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
 
     let(:years) { subject.years }
 
-    context "when its on or before 6th September of the current year" do
+    context "when its before 24th June of the current year" do
       around do |example|
-        travel_to(Date.new(2020, 9, 6)) { example.run }
+        travel_to(Date.new(2022, 6, 23)) { example.run }
       end
 
       it "returns 'Not sure', and the current year plus next 2 years" do
         expect(years.map(&:value)).to contain_exactly(
           "Not sure",
-          "2020 - start your training this September",
-          "2021",
-          "2022",
+          "2022 - start your training this September",
+          "2023",
+          "2024",
+        )
+      end
+    end
+
+    context "when its 24th June of the current year" do
+      around do |example|
+        travel_to(Date.new(2022, 6, 24)) { example.run }
+      end
+
+      it "returns 'Not sure', and the current year plus next 3 years" do
+        expect(years.map(&:value)).to contain_exactly(
+          "Not sure",
+          "2022 - start your training this September",
+          "2023",
+          "2024",
+          "2025",
+        )
+      end
+    end
+
+    context "when its between 24th June and 6th September of the current year" do
+      around do |example|
+        travel_to(Date.new(2022, 9, 6)) { example.run }
+      end
+
+      it "returns 'Not sure', and the current year plus next 2 years" do
+        expect(years.map(&:value)).to contain_exactly(
+          "Not sure",
+          "2022 - start your training this September",
+          "2023",
+          "2024",
+          "2025",
         )
       end
     end
 
     context "when its after 6th September of the current year" do
       around do |example|
-        travel_to(Date.new(2020, 9, 7)) { example.run }
+        travel_to(Date.new(2022, 9, 7)) { example.run }
       end
 
       it "returns 'Not sure', and the next 3 years" do
         expect(years.map(&:value)).to contain_exactly(
           "Not sure",
-          "2021",
-          "2022",
           "2023",
+          "2024",
+          "2025",
         )
       end
     end


### PR DESCRIPTION
### Trello card

[Trello-3413](https://trello.com/c/4NbyCaGY/3413-update-training-years-in-the-tta-funnel?filter=member:rossoliver15)

### Context

We want to display an additional Initial Teacher Training (ITT) year on the 24th June (for 2022 this will be 2025). When we drop the current year on September 7th we _don't_ then want to show 2026, so the behaviour is as follows:

**Before 24th June:**

```
Not sure
Current year - start your training this September
Current year + 1
Current year + 2
```

**Between 24th June and 6th September:**

```
Not sure
Current year - start your training this September
Current year + 1
Current year + 2
Current year + 3
```

**After 6th September:**

```
Not sure
Next year
Next year + 1
Next year + 2
```

### Changes proposed in this pull request

- Add additional ITT year on 24th June

### Guidance to review

This assumes the behaviour is going to be consistent year-on-year (in that we will add a new year on the 24th June and remove the current year on 7th September).