### PR TITLE
Update wizard to use new repo/gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem "invisible_captcha"
 
 gem "iso_country_codes"
 
-gem "dfe_wizard", github: "DFE-Digital/dfe_wizard"
+gem "git_wizard", github: "DFE-Digital/get-into-teaching-wizard"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/DFE-Digital/dfe_wizard.git
-  revision: 08a2dda2de41b67ea28dfa3513f59245ea6dcc6a
-  specs:
-    dfe_wizard (1.0.1)
-      activemodel (>= 6.0.3.4)
-      activesupport (>= 6.0.3.4)
-
-GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
   revision: cf858eb830316acbb9a7cb1f2991a7eb89f17f36
   specs:
@@ -20,6 +12,14 @@ GIT
       faraday_middleware
       faraday_middleware-circuit_breaker
       get_into_teaching_api_client
+
+GIT
+  remote: https://github.com/DFE-Digital/get-into-teaching-wizard.git
+  revision: 3d35745683526ee015f1a1de06cade6ab76119bb
+  specs:
+    git_wizard (2.0.0)
+      activemodel (>= 6.0.3.4)
+      activesupport (>= 6.0.3.4)
 
 GIT
   remote: https://github.com/mitsuru/validates_timeliness.git
@@ -419,11 +419,11 @@ DEPENDENCIES
   byebug
   canonical-rails
   capybara (~> 3.37)
-  dfe_wizard!
   dotenv-rails
   factory_bot_rails
   foreman
   get_into_teaching_api_client_faraday!
+  git_wizard!
   govuk_design_system_formbuilder
   invisible_captcha
   iso_country_codes

--- a/app/controllers/teacher_training_adviser/steps_controller.rb
+++ b/app/controllers/teacher_training_adviser/steps_controller.rb
@@ -1,7 +1,7 @@
 module TeacherTrainingAdviser
   class StepsController < ApplicationController
     include CircuitBreaker
-    include DFEWizard::Controller
+    include GITWizard::Controller
     self.wizard_class = TeacherTrainingAdviser::Wizard
 
     around_action :set_time_zone, only: %i[show update] # rubocop:disable Rails/LexicallyScopedActionFilter
@@ -35,7 +35,7 @@ module TeacherTrainingAdviser
     helper_method :step_path
 
     def wizard_store
-      ::DFEWizard::Store.new app_store, crm_store
+      ::GITWizard::Store.new app_store, crm_store
     end
 
     def app_store

--- a/app/models/teacher_training_adviser/steps/accept_privacy_policy.rb
+++ b/app/models/teacher_training_adviser/steps/accept_privacy_policy.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class AcceptPrivacyPolicy < DFEWizard::Step
+  class AcceptPrivacyPolicy < GITWizard::Step
     attribute :accepted_policy_id, :string
 
     validates :accepted_policy_id, policy: true

--- a/app/models/teacher_training_adviser/steps/already_signed_up.rb
+++ b/app/models/teacher_training_adviser/steps/already_signed_up.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class AlreadySignedUp < DFEWizard::Step
+  class AlreadySignedUp < GITWizard::Step
     def skipped?
       can_subscribe = @store["can_subscribe_to_teacher_training_adviser"]
       can_subscribe.nil? || can_subscribe

--- a/app/models/teacher_training_adviser/steps/date_of_birth.rb
+++ b/app/models/teacher_training_adviser/steps/date_of_birth.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class DateOfBirth < DFEWizard::Step
+  class DateOfBirth < GITWizard::Step
     # multi parameter date fields aren't yet support by ActiveModel so we
     # need to include the support for them from ActiveRecord
     require "active_record/attribute_assignment"

--- a/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class GcseMathsEnglish < DFEWizard::Step
+  class GcseMathsEnglish < GITWizard::Step
     attribute :has_gcse_maths_and_english_id, :integer
 
     validates :has_gcse_maths_and_english_id, pick_list_items: { method: :get_candidate_retake_gcse_status }

--- a/app/models/teacher_training_adviser/steps/gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_science.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class GcseScience < DFEWizard::Step
+  class GcseScience < GITWizard::Step
     attribute :has_gcse_science_id, :integer
 
     validates :has_gcse_science_id, pick_list_items: { method: :get_candidate_retake_gcse_status }

--- a/app/models/teacher_training_adviser/steps/has_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/has_teacher_id.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class HasTeacherId < DFEWizard::Step
+  class HasTeacherId < GITWizard::Step
     attribute :has_id, :boolean
 
     validates :has_id, inclusion: { in: [true, false] }

--- a/app/models/teacher_training_adviser/steps/have_a_degree.rb
+++ b/app/models/teacher_training_adviser/steps/have_a_degree.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class HaveADegree < DFEWizard::Step
+  class HaveADegree < GITWizard::Step
     attribute :degree_options, :string
     attribute :degree_status_id, :integer
     attribute :degree_type_id, :integer

--- a/app/models/teacher_training_adviser/steps/identity.rb
+++ b/app/models/teacher_training_adviser/steps/identity.rb
@@ -1,6 +1,6 @@
 module TeacherTrainingAdviser::Steps
-  class Identity < DFEWizard::Step
-    include ::DFEWizard::IssueVerificationCode
+  class Identity < GITWizard::Step
+    include ::GITWizard::IssueVerificationCode
 
     attribute :first_name, :string
     attribute :last_name, :string

--- a/app/models/teacher_training_adviser/steps/no_degree.rb
+++ b/app/models/teacher_training_adviser/steps/no_degree.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class NoDegree < DFEWizard::Step
+  class NoDegree < GITWizard::Step
     def can_proceed?
       false
     end

--- a/app/models/teacher_training_adviser/steps/overseas_callback.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_callback.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class OverseasCallback < DFEWizard::Step
+  class OverseasCallback < GITWizard::Step
     extend CallbackBookingQuotas
 
     attribute :phone_call_scheduled_at, :datetime

--- a/app/models/teacher_training_adviser/steps/overseas_country.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_country.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class OverseasCountry < DFEWizard::Step
+  class OverseasCountry < GITWizard::Step
     extend ApiOptions
     # overwrites UK default
     attribute :country_id, :string

--- a/app/models/teacher_training_adviser/steps/overseas_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_telephone.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class OverseasTelephone < DFEWizard::Step
+  class OverseasTelephone < GITWizard::Step
     attribute :address_telephone, :string
 
     validates :address_telephone, telephone: { international: true }, allow_blank: true

--- a/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class OverseasTimeZone < DFEWizard::Step
+  class OverseasTimeZone < GITWizard::Step
     attribute :address_telephone, :string
     attribute :time_zone, :string
 

--- a/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class PreviousTeacherId < DFEWizard::Step
+  class PreviousTeacherId < GITWizard::Step
     attribute :teacher_id, :string
 
     def optional?

--- a/app/models/teacher_training_adviser/steps/primary_returner.rb
+++ b/app/models/teacher_training_adviser/steps/primary_returner.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class PrimaryReturner < DFEWizard::Step
+  class PrimaryReturner < GITWizard::Step
     def can_proceed?
       false
     end

--- a/app/models/teacher_training_adviser/steps/qualification_required.rb
+++ b/app/models/teacher_training_adviser/steps/qualification_required.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class QualificationRequired < DFEWizard::Step
+  class QualificationRequired < GITWizard::Step
     def can_proceed?
       false
     end

--- a/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class RetakeGcseMathsEnglish < DFEWizard::Step
+  class RetakeGcseMathsEnglish < GITWizard::Step
     attribute :planning_to_retake_gcse_maths_and_english_id, :integer
 
     validates :planning_to_retake_gcse_maths_and_english_id, pick_list_items: { method: :get_candidate_retake_gcse_status }

--- a/app/models/teacher_training_adviser/steps/retake_gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_science.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class RetakeGcseScience < DFEWizard::Step
+  class RetakeGcseScience < GITWizard::Step
     attribute :planning_to_retake_gcse_science_id, :integer
 
     validates :planning_to_retake_gcse_science_id, pick_list_items: { method: :get_candidate_retake_gcse_status }

--- a/app/models/teacher_training_adviser/steps/returning_teacher.rb
+++ b/app/models/teacher_training_adviser/steps/returning_teacher.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class ReturningTeacher < DFEWizard::Step
+  class ReturningTeacher < GITWizard::Step
     OPTIONS = { returning_to_teaching: 222_750_001, interested_in_teaching: 222_750_000 }.freeze
 
     attribute :type_id, :integer

--- a/app/models/teacher_training_adviser/steps/review_answers.rb
+++ b/app/models/teacher_training_adviser/steps/review_answers.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class ReviewAnswers < DFEWizard::Step
+  class ReviewAnswers < GITWizard::Step
     def personal_detail_answers_by_step
       answers_by_step.select { |k| k.contains_personal_details? } # rubocop:disable Style/SymbolProc
     end

--- a/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class StageInterestedTeaching < DFEWizard::Step
+  class StageInterestedTeaching < GITWizard::Step
     extend ApiOptions
 
     attribute :preferred_education_phase_id, :integer

--- a/app/models/teacher_training_adviser/steps/stage_of_degree.rb
+++ b/app/models/teacher_training_adviser/steps/stage_of_degree.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class StageOfDegree < DFEWizard::Step
+  class StageOfDegree < GITWizard::Step
     extend ApiOptions
 
     # overwrites session[:sign_up]["degree_status_id"]

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class StartTeacherTraining < DFEWizard::Step
+  class StartTeacherTraining < GITWizard::Step
     attribute :initial_teacher_training_year_id, :integer
 
     validates :initial_teacher_training_year_id, inclusion: { in: :year_ids }

--- a/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class SubjectInterestedTeaching < DFEWizard::Step
+  class SubjectInterestedTeaching < GITWizard::Step
     extend ApiOptions
 
     attribute :preferred_teaching_subject_id, :string

--- a/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
+++ b/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class SubjectLikeToTeach < DFEWizard::Step
+  class SubjectLikeToTeach < GITWizard::Step
     extend ApiOptions
 
     OMIT_SUBJECT_IDS = [

--- a/app/models/teacher_training_adviser/steps/subject_taught.rb
+++ b/app/models/teacher_training_adviser/steps/subject_taught.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class SubjectTaught < DFEWizard::Step
+  class SubjectTaught < GITWizard::Step
     extend ApiOptions
 
     OMIT_SUBJECT_IDS = [

--- a/app/models/teacher_training_adviser/steps/uk_address.rb
+++ b/app/models/teacher_training_adviser/steps/uk_address.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class UkAddress < DFEWizard::Step
+  class UkAddress < GITWizard::Step
     attribute :address_line1, :string
     attribute :address_line2, :string
     attribute :address_city, :string

--- a/app/models/teacher_training_adviser/steps/uk_callback.rb
+++ b/app/models/teacher_training_adviser/steps/uk_callback.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class UkCallback < DFEWizard::Step
+  class UkCallback < GITWizard::Step
     extend CallbackBookingQuotas
 
     attribute :address_telephone, :string

--- a/app/models/teacher_training_adviser/steps/uk_or_overseas.rb
+++ b/app/models/teacher_training_adviser/steps/uk_or_overseas.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class UkOrOverseas < DFEWizard::Step
+  class UkOrOverseas < GITWizard::Step
     attribute :uk_or_overseas, :string
 
     OPTIONS = { uk: "UK", overseas: "Overseas" }.freeze

--- a/app/models/teacher_training_adviser/steps/uk_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/uk_telephone.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class UkTelephone < DFEWizard::Step
+  class UkTelephone < GITWizard::Step
     attribute :address_telephone, :string
 
     validates :address_telephone, telephone: true, allow_blank: true

--- a/app/models/teacher_training_adviser/steps/what_degree_class.rb
+++ b/app/models/teacher_training_adviser/steps/what_degree_class.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class WhatDegreeClass < DFEWizard::Step
+  class WhatDegreeClass < GITWizard::Step
     extend ApiOptions
 
     OMIT_GRADE_IDS = [

--- a/app/models/teacher_training_adviser/steps/what_subject_degree.rb
+++ b/app/models/teacher_training_adviser/steps/what_subject_degree.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class WhatSubjectDegree < DFEWizard::Step
+  class WhatSubjectDegree < GITWizard::Step
     extend ApiOptions
 
     OMIT_SUBJECT_IDS = [

--- a/app/models/teacher_training_adviser/wizard.rb
+++ b/app/models/teacher_training_adviser/wizard.rb
@@ -1,10 +1,10 @@
 module TeacherTrainingAdviser
-  class Wizard < ::DFEWizard::Base
+  class Wizard < ::GITWizard::Base
     UK_COUNTRY_ID = "72f5c2e6-74f9-e811-a97a-000d3a2760f2".freeze
 
     self.steps = [
       Steps::Identity,
-      DFEWizard::Steps::Authenticate,
+      GITWizard::Steps::Authenticate,
       Steps::AlreadySignedUp,
       Steps::ReturningTeacher,
       Steps::HaveADegree,

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -718,11 +718,11 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Send another code to verify my details."
 
       expect(page).to have_text "We've sent you another email"
-      fill_in "dfe-wizard-steps-authenticate-timed-one-time-password-field", with: invalid_code
+      fill_in "git-wizard-steps-authenticate-timed-one-time-password-field", with: invalid_code
       click_on "Continue"
 
       expect(page).to have_text "Please enter the latest verification code sent to your email address"
-      fill_in "dfe-wizard-steps-authenticate-timed-one-time-password-field-error", with: valid_code
+      fill_in "git-wizard-steps-authenticate-timed-one-time-password-field-error", with: valid_code
       click_on "Continue"
 
       expect(page).to have_css "h1", text: "Are you qualified to teach?"
@@ -807,7 +807,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Continue"
 
       expect(page).to have_css "h1", text: "You're already registered with us"
-      fill_in "dfe-wizard-steps-authenticate-timed-one-time-password-field", with: valid_code
+      fill_in "git-wizard-steps-authenticate-timed-one-time-password-field", with: valid_code
       click_on "Continue"
 
       expect(page).to have_css "h1", text: "Are you qualified to teach?"

--- a/spec/models/teacher_training_adviser/steps/identity_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/identity_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::Identity do
   it_behaves_like "a wizard step"
   include_context "sanitize fields", %i[first_name last_name email]
 
-  it { expect(described_class).to include(::DFEWizard::IssueVerificationCode) }
+  it { expect(described_class).to include(::GITWizard::IssueVerificationCode) }
 
   it { is_expected.to be_contains_personal_details }
 

--- a/spec/models/teacher_training_adviser/wizard_spec.rb
+++ b/spec/models/teacher_training_adviser/wizard_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
     it do
       expect(subject).to eql [
         TeacherTrainingAdviser::Steps::Identity,
-        DFEWizard::Steps::Authenticate,
+        GITWizard::Steps::Authenticate,
         TeacherTrainingAdviser::Steps::AlreadySignedUp,
         TeacherTrainingAdviser::Steps::ReturningTeacher,
         TeacherTrainingAdviser::Steps::HaveADegree,
@@ -55,7 +55,7 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
         "degree_options" => "equivalent",
       }
     end
-    let(:wizardstore) { DFEWizard::Store.new store, {} }
+    let(:wizardstore) { GITWizard::Store.new store, {} }
 
     describe "#time_zone" do
       it "defaults to London" do

--- a/spec/support/shared_examples/wizard_support.rb
+++ b/spec/support/shared_examples/wizard_support.rb
@@ -1,7 +1,7 @@
 RSpec.shared_context "with a wizard store" do
   let(:backingstore) { { "name" => "Joe", "age" => 35 } }
   let(:crm_backingstore) { {} }
-  let(:wizardstore) { DFEWizard::Store.new backingstore, crm_backingstore }
+  let(:wizardstore) { GITWizard::Store.new backingstore, crm_backingstore }
 end
 
 RSpec.shared_context "with a wizard step" do
@@ -108,24 +108,24 @@ RSpec.shared_examples "with a wizard step that exposes API lookup items as optio
   end
 end
 
-class TestWizard < DFEWizard::Base
-  class Name < DFEWizard::Step
+class TestWizard < GITWizard::Base
+  class Name < GITWizard::Step
     attribute :name
     validates :name, presence: true
   end
 
   # To simulate two steps writing to the same attribute.
-  class OtherAge < DFEWizard::Step
+  class OtherAge < GITWizard::Step
     attribute :age, :integer
     validates :age, presence: false
   end
 
-  class Age < DFEWizard::Step
+  class Age < GITWizard::Step
     attribute :age, :integer
     validates :age, presence: true
   end
 
-  class Postcode < DFEWizard::Step
+  class Postcode < GITWizard::Step
     attribute :postcode
     validates :postcode, presence: true
   end


### PR DESCRIPTION
We have renamed the repository of the `dfe_wizard` to something more git-specific and updated the gem name.

Update the Gemfile to use the new repository/name and update module references.

The functionality of the gem has not changed.