### PR TITLE
updating funding link

### DIFF
--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -36,7 +36,7 @@
 
         <ul>
           <li>discover the different <%= link_to_git_site "ways to train", "train-to-be-a-teacher" %> to become a teacher</li>
-          <li>find out about <%= link_to_git_site "funding", "funding-your-training" %></li>
+          <li>find out about <%= link_to_git_site "funding", "funding-and-support" %></li>
           <li><%= link_to_git_site "search for events", "events" %> that might interest you</li>
           <% if @returner %>
             <li>read further information on our dedicated <%= link_to_git_site "return to teaching page", "returning-to-teaching" %></li>


### PR DESCRIPTION
### Trello card

https://trello.com/c/l5Zy697r/3466-update-backlink-to-funding-page-in-adviser-funnel

### Context

Adviser funnel still currently has a link to the old funding page. This needs changing to the new funding and support section.

### Changes proposed in this pull request

### Guidance to review

