### PR TITLE
[656] Do not skip "Destroy review instance" for dependabot

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   destroy:
     name: Destroy
-    if: startsWith(github.head_ref, 'dependabot/') == false
     environment:
        name: Review
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Trello card
https://trello.com/c/uFEpw9o2

### Context
Dependabot review apps are not deleted

Example: https://github.com/DFE-Digital/get-teacher-training-adviser-service/actions/runs/2823915112

### Changes proposed in this pull request
We now create a review app for PRs raised by dependabot. The previous condition must be removed as it skipped it for dependabot.

### Guidance to review
Compare with GiT: https://github.com/DFE-Digital/get-into-teaching-app/blob/master/.github/workflows/destroy.yml

