### PR TITLE
Update copy on teacher training years options

### DIFF
--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -36,7 +36,9 @@ module TeacherTrainingAdviser::Steps
 
       year = item.value.to_i
 
-      if year == current_year
+      if [first_year, current_year + 1].all?(year)
+        "#{year} - start your training next September"
+      elsif year == first_year
         "#{year} - start your training this September"
       else
         year.to_s
@@ -69,7 +71,11 @@ module TeacherTrainingAdviser::Steps
     end
 
     def current_year
-      Time.zone.today.year
+      current_date.year
+    end
+
+    def current_date
+      Time.zone.today
     end
   end
 end

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -23,13 +23,10 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
     before do
       years = [
         GetIntoTeachingApiClient::PickListItem.new(id: 12_917, value: "Not sure"),
-        GetIntoTeachingApiClient::PickListItem.new(id: 12_918, value: 2020),
-        GetIntoTeachingApiClient::PickListItem.new(id: 12_919, value: 2021),
         GetIntoTeachingApiClient::PickListItem.new(id: 12_920, value: 2022),
         GetIntoTeachingApiClient::PickListItem.new(id: 12_921, value: 2023),
         GetIntoTeachingApiClient::PickListItem.new(id: 12_921, value: 2024),
         GetIntoTeachingApiClient::PickListItem.new(id: 12_922, value: 2025),
-        GetIntoTeachingApiClient::PickListItem.new(id: 12_922, value: 2026),
       ]
 
       allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
@@ -38,7 +35,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
 
     let(:years) { subject.years }
 
-    context "when its before 24th June of the current year" do
+    context "when its before 24th June of the current year (2022)" do
       around do |example|
         travel_to(Date.new(2022, 6, 23)) { example.run }
       end
@@ -53,7 +50,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
       end
     end
 
-    context "when its 24th June of the current year" do
+    context "when its 24th June of the current year (2022)" do
       around do |example|
         travel_to(Date.new(2022, 6, 24)) { example.run }
       end
@@ -69,7 +66,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
       end
     end
 
-    context "when its between 24th June and 6th September of the current year" do
+    context "when its between 24th June and 6th September of the current year (2022)" do
       around do |example|
         travel_to(Date.new(2022, 9, 6)) { example.run }
       end
@@ -85,7 +82,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
       end
     end
 
-    context "when its after 6th September of the current year" do
+    context "when its after 6th September of the current year (2022)" do
       around do |example|
         travel_to(Date.new(2022, 9, 7)) { example.run }
       end
@@ -93,7 +90,22 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
       it "returns 'Not sure', and the next 3 years" do
         expect(years.map(&:value)).to contain_exactly(
           "Not sure",
-          "2023",
+          "2023 - start your training next September",
+          "2024",
+          "2025",
+        )
+      end
+    end
+
+    context "when its 1st January of the current year (2023)" do
+      around do |example|
+        travel_to(Date.new(2023, 1, 1)) { example.run }
+      end
+
+      it "returns 'Not sure', and the next 3 years" do
+        expect(years.map(&:value)).to contain_exactly(
+          "Not sure",
+          "2023 - start your training this September",
           "2024",
           "2025",
         )


### PR DESCRIPTION
### Trello card

[Trello-3531](https://trello.com/c/SRns0nx7/3531-confirm-when-tta-funnel-should-be-updated-to-remove-2022)

### Context

We want to update the copy around the first available year in the set of options depending on what the current date is. This is in an effort to clear up the reference to "this September" when the date is after the cutoff (7th September) and "this September" is actually "next September" until January 1st when it becomes "this September" again!

The logic is as follows.

**Current year is 2022**

1st January 2022 to 23rd June 2022:

```
Not sure
2022 - start your training this September
2023
2024
```

Between 24th June 2022 and 6th September 2022:

```
Not sure
2022 - start your training this September
2023
2024
2025
```

Between 7th September 2022 and 31st December 2022:

```
Not sure
2023 - start your training next September
2024
2025
```

**Current year becomes 2023**

Between 1st January 2023 and 23rd June 2023:

```
Not sure
2023 - start your training this September
2024
2025
```

... etc ...

### Changes proposed in this pull request

- Update copy on teacher training years options

### Guidance to review

