### PR TITLE
Upgrade Terraform to version 1.2.8

### DIFF
--- a/.github/workflows/actions/deploy/action.yml
+++ b/.github/workflows/actions/deploy/action.yml
@@ -100,9 +100,9 @@ runs:
            secret: INFRA-KEYS
            key: LOGIT-API
 
-       - uses: hashicorp/setup-terraform@v1.3.2
+       - uses: hashicorp/setup-terraform@v2.0.0
          with:
-              terraform_version: 0.14.9
+              terraform_version: 1.2.8
 
        - name: Terraform ( ${{inputs.environment}} )
          shell: bash

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 0.14.9
+          terraform_version: 1.2.8
 
       - name: Terraform Destroy
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-terraform 0.14.9
+terraform 1.2.8

--- a/terraform/paas/.gitignore
+++ b/terraform/paas/.gitignore
@@ -1,1 +1,0 @@
-.terraform.lock.hcl

--- a/terraform/paas/.terraform.lock.hcl
+++ b/terraform/paas/.terraform.lock.hcl
@@ -1,0 +1,68 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudfoundry-community/cloudfoundry" {
+  version     = "0.15.5"
+  constraints = "0.15.5"
+  hashes = [
+    "h1:wPpBEOFquPx5pPQ30oOg4WybgwZSpsECewJPsvyCv7s=",
+    "zh:0f4384d5aedd17cd8ec8827db4075890bdebe151d5f2300669c28d5021ef67cf",
+    "zh:164f74e6297b398f7d695c38bffc696fbb25377bc815a5f0a25d41da1085e771",
+    "zh:337332a1bfcda419d6a0bf758a131631eb977eb830525e759213ed7d1d84aa10",
+    "zh:488820c337cd5032335d0dede08aee717b5c089c7ac6c30f0b75fba9cf36bb53",
+    "zh:4e5003af86bf3ec19ad3d8b659ba1e357ab52092ea3b606c2f20e232768a71fa",
+    "zh:5ec1186931bc2b42313b2d2589df5c084909a7cecafc1c0bb112e326fad877c1",
+    "zh:613942f7da3fb818f884fd464a7da6bcb6ecffb9e83f2eb3ec26f67d052419c3",
+    "zh:6764f9d2a88e39230384cb742a46063257602c19827d1570020a93ef190ca380",
+    "zh:770b0bb30b1b9301b197aa8907f1e46a4f82869febb6c03eb64fc8efaca4961d",
+    "zh:77cf66c586f3dec13e43580ba854d0c5cdde71d4ffa10f9ca4609bdf1d3f300b",
+    "zh:7914f451b19285132e93804b88fefbeff9a75b22d8321fafde048cbed87f1169",
+    "zh:8b8c919b13210fe6f8ade33e00c6ddfe1277ae9414fdacd7b955703570120526",
+    "zh:db06d1f2aa10be7600769e8d2d90acf2fc72de5424cd7fda8718acaf00922616",
+    "zh:f9c897cfa4cb952eac54208b2ee0bce00234323d77aabb664170f1a953698d2a",
+    "zh:fb50ad7f4de74761af8c4af5a99a5f3abce6a39feb330d36272e9d8238583a0c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.20.0"
+  constraints = "3.20.0"
+  hashes = [
+    "h1:heH/4bYgajEFQ+fwSV9Zduvpyb7eTCQUv+gl201EFg8=",
+    "zh:0d534bb2fed67b5b58d3adb2b0be7a9986f62b34f40eae450dafc9454fb54db8",
+    "zh:19f6d5f196a35500e0f1ae9d9baee44f49b90858524338a7b8aaec06d3e3a047",
+    "zh:1d042648d2eaffde8858a8006b944374599c5e8c2f834ae74b97adedd1468142",
+    "zh:278ebac38cf3c1e6df4bc5de00e931bfc04298607f428aa84a932bbf26dee421",
+    "zh:48f29b802e2de7e6dd2452a012c633686fce5d7ad3eadb490a7b8c0967a9ebfa",
+    "zh:731bf2e97c4a519723682beb2e85e065bf0bf53b2f50e2ff7b15b39ea74e37ff",
+    "zh:7c8187ebca19ca8f6ef82d3d79a418ccfa6574bb99e63cc930fa46ff938a7921",
+    "zh:82fdb2052601f6fa925195e77506fb609ce8bb4a6f6e94cf6a5058252ef570d4",
+    "zh:995ca23bb3765a16c6b3138b468d920acff5742b22492324c836579e3344ea40",
+    "zh:a970131232ad41203382f6fa3f0014a22767cbfe28cd7562346184ea6e678d63",
+    "zh:bf5036675a7f0b8691fe393e2782a76c7943ba17eec7255e16a31c7547436a48",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/statuscakedev/statuscake" {
+  version     = "2.0.3"
+  constraints = "2.0.3"
+  hashes = [
+    "h1:p59YX5ngLYcxPP3TcPGeB9upck9GHWwr2rCDrW4t3xg=",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:23c8c0aba2079500e762f4222a52faa015d256315298677f02ed9669c28671ed",
+    "zh:401de1618e1deedd22e77a0a2473a12d2ea5e818fd1e3406012b1c87d8459dc7",
+    "zh:439c34178b9e23dbe6853631eac5adab95498f45b6adbcfb4246ecb160365cd2",
+    "zh:47abf79a5a890a25123ebca80c313a8c5c2161e5e7cd33d06614fa3ad0383aad",
+    "zh:47be434f8587ce1573734c44560da08c718e5dcd5278e227aa9b0211afd387fb",
+    "zh:4a4aa5ea94d18cc4de2099134d6d486f6e41f39e6f1888ceac85137ba9aadcd7",
+    "zh:74fde1491dc16d375b3b2c47fb94045b32d8db3fdb22afe67c873bcfd1551dbe",
+    "zh:9c1e2845201206f0c5f9c4aba6fd7ed04e81c2e8b38ad2adfcedc6cbf4b65691",
+    "zh:a1f1854e1d2ab7987fd90d31b35a22ffb82ac1d25ceca80cbfd3bdc23e8b004d",
+    "zh:b0c72443d93289de234f5831234c1dcfa53718cb976f6635f0e52103915c6abb",
+    "zh:bae9b4a0052362ea315b76243c4caee65e5512951d77a90eb8fc2130b8d70d01",
+    "zh:c0a4543bf17478ffcf78102cb4281757ebc8d98eb1919faad83ea30ea103b0ec",
+    "zh:e3660bec86147264afdf29df714d3aa8468a7e3c4d1ab6e4e032d1002d3f5f75",
+    "zh:f8e414cf2e8d27748557c64899f257cebe4f95a41f54e272f6820cd2273bbcff",
+  ]
+}

--- a/terraform/paas/provider.tf
+++ b/terraform/paas/provider.tf
@@ -22,7 +22,7 @@ provider "azurerm" {
 }
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 1.2.8"
 
   required_providers {
     azurerm = {


### PR DESCRIPTION
### Context
Ensure the Terraform version contains the latest fixes and supports Apple processors

### Changes proposed in this pull request
- Update Terraform version to 1.2.8

### Guidance to review
- Successfully deployed to review app with 0.14.9 then once upgraded to 1.2.8
