### PR TITLE
Fix flakey sign up specs

### DIFF
--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -28,6 +28,12 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       receive(:get_callback_booking_quotas) { [quota] }
   end
 
+  around do |example|
+    travel_to(Date.new(2022, 6, 1)) do
+      example.run
+    end
+  end
+
   context "when a new candidate" do
     before do
       # Emulate an unsuccessful matchback response from the API.


### PR DESCRIPTION
As we are now after 7th September the 2022 ITT year is excluded from the list of available years. Freezing the date to be earlier fixes it.