### PR TITLE
Add get help section to footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,6 +2,16 @@
     <div class="govuk-width-container">
         <div class="govuk-footer__meta">
             <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+                <h2 class="govuk-heading-m">Get help</h2>
+
+                <p class="govuk-body-s govuk-!-margin-bottom-1">
+                  Call <%= link_to("0800 389 2500", "tel://08003892500", class: "govuk-footer__link") %> or <%= link_to_git_site("chat online", "#talk-to-us", class: "govuk-footer__link") %>
+                </p>
+                <p class="govuk-body-s govuk-!-margin-bottom-1">
+                  Monday to Friday, 8:30am to 5:30pm (except public holidays)
+                </p>
+                <p class="govuk-body-s">Free of charge</p>
+
                 <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
                     <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
                     />

--- a/spec/requests/gtm_spec.rb
+++ b/spec/requests/gtm_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Google Tag Manager", type: :request do
 
   context "when the GTM_ID is not set" do
     before do
+      allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("GTM_ID").and_return(nil)
     end
 


### PR DESCRIPTION
### Trello card

[Trello-3680](https://trello.com/c/ZIH9FAhh/3680-add-contact-details-to-footer-of-tta-funnel)

### Context

We don't have an obvious/easy way for candidates to get in touch if they are having difficulties with the adviser service; we should display clear contact details on every page.

### Changes proposed in this pull request

- Add get help section to footer

Add a new section to the footer with contact details.

### Guidance to review

