### PR TITLE
Change dependabot to monthly interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
   - package-ecosystem: bundler
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: docker
     directory: /
@@ -21,7 +21,7 @@ updates:
     directory: /
     schedule:
       interval: daily
-      
+
   - package-ecosystem: terraform
     directory:  /terraform/paas/
     schedule:


### PR DESCRIPTION
We're finding the weekly interval too frequent and the number of PRs dependabot raises is a pain to keep on top of - monthly should work out better for us.
