### PR TITLE
Update various dependencies

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,6 @@
 VCAP_APPLICATION="{\"application_name\": \"app-name\",\"space_name\": \"space-name\",\"organization_name\": \"org-name\"}"
 GTM_ID=123-ABC
 CF_INSTANCE_INDEX=app-instance
+# Prevent the dfe-analytics gem eager-loading Rails (which
+# causes our validators to fire network requests).
+SUPPRESS_DFE_ANALYTICS_INIT=true

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "validates_timeliness", github: "mitsuru/validates_timeliness", branch: "rai
 
 gem "dotenv-rails"
 
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.3.2"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.5.3"
 
 gem "rack-attack"
 

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,8 @@ gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.3.2"
 gem "rack-attack"
 
 # redis for session store
-gem "redis"
+gem "connection_pool"
+gem "redis", "~> 4.8.0"
 
 gem "prometheus-client"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
     childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    connection_pool (2.3.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -321,7 +322,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.7.1)
+    redis (4.8.0)
     regexp_parser (2.5.0)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -468,6 +469,7 @@ DEPENDENCIES
   byebug
   canonical-rails
   capybara (~> 3.37)
+  connection_pool
   dfe-analytics!
   dotenv-rails
   factory_bot_rails
@@ -488,7 +490,7 @@ DEPENDENCIES
   rack-attack
   rails (~> 7.0.3)
   rails_semantic_logger (>= 4.10.0)
-  redis
+  redis (~> 4.8.0)
   rspec-rails (~> 6.0.0)
   rspec-sonarqube-formatter (~> 1.5)
   rubocop-govuk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 6dc16420e0b5c6b2b722887589b0bc2212798802
-  tag: v1.3.2
+  revision: bfa569a60b4fca7545ca7b72764c526b65d913b9
+  tag: v1.5.3
   specs:
-    dfe-analytics (1.3.2)
+    dfe-analytics (1.5.3)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 
@@ -187,9 +187,9 @@ GEM
     foreman (0.87.2)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    google-apis-bigquery_v2 (0.39.0)
-      google-apis-core (>= 0.7, < 2.a)
-    google-apis-core (0.7.0)
+    google-apis-bigquery_v2 (0.42.0)
+      google-apis-core (>= 0.9.0, < 2.a)
+    google-apis-core (0.9.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -209,8 +209,8 @@ GEM
       google-cloud-errors (~> 1.0)
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
-    google-cloud-errors (1.2.0)
-    googleauth (1.2.0)
+    google-cloud-errors (1.3.0)
+    googleauth (1.3.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -233,7 +233,7 @@ GEM
       rails (>= 5.0)
     iso_country_codes (0.7.8)
     json (2.6.2)
-    jwt (2.4.1)
+    jwt (2.5.0)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)

--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -15,8 +15,8 @@ class Healthcheck
   def test_redis
     return nil unless ENV["REDIS_URL"]
 
-    Redis.current.ping == "PONG"
-  rescue RuntimeError
+    REDIS.ping == "PONG"
+  rescue Redis::BaseError
     false
   end
 

--- a/app/webpacker/controllers/cookie-acceptance_controller.js
+++ b/app/webpacker/controllers/cookie-acceptance_controller.js
@@ -1,5 +1,5 @@
 import CookiePreferences from "../javascript/cookie_preferences"
-import { Controller } from "stimulus"
+import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["banner", "accept"];

--- a/app/webpacker/controllers/cookie_preferences_controller.js
+++ b/app/webpacker/controllers/cookie_preferences_controller.js
@@ -1,5 +1,5 @@
 import CookiePreferences from '../javascript/cookie_preferences';
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static targets = ['category'];

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -5,6 +5,16 @@ if ENV["REDIS_URL"].blank? && Rails.application.config.x.vcap_services.present?
   ENV["REDIS_URL"] = redis_url if redis_url.present?
 end
 
-if ENV["REDIS_URL"].present? && Redis.current.ping != "PONG"
-  raise "Cannot connect to Redis"
+if ENV["REDIS_URL"]
+  REDIS = ConnectionPool::Wrapper.new(size: 5, timeout: 3) do
+    Redis.new(
+      db: (Rails.env.test? ? ENV["TEST_ENV_NUMBER"].presence : nil),
+      connect_timeout: 20, # Default is 5s but logic is we're better being slower booting than failing to boot
+      reconnect_attempts: 1, # Allow for connection failure since Azure networking to Redis is showing some unreliability
+    )
+  end
+
+  unless REDIS.ping == "PONG"
+    raise "Could not connect to Redis"
+  end
 end

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "js-cookie": "^3.0.1",
     "serialize-javascript": "^6.0.0",
     "set-value": "^4.0.1",
-    "stimulus": "^2.0.0",
+    "stimulus": "^3.1",
     "turbolinks": "^5.2.0"
   },
   "devDependencies": {

--- a/spec/javascript/controllers/cookie-acceptance_controller_spec.js
+++ b/spec/javascript/controllers/cookie-acceptance_controller_spec.js
@@ -1,6 +1,6 @@
 const Cookies = require('js-cookie') ;
 import CookiePreferences from "cookie_preferences" ;
-import { Application } from 'stimulus' ;
+import { Application } from '@hotwired/stimulus' ;
 import CookieAcceptanceController from 'cookie-acceptance_controller.js' ;
 
 describe('CookieAcceptanceController', () => {

--- a/spec/javascript/controllers/cookie_preferences_controller_spec.js
+++ b/spec/javascript/controllers/cookie_preferences_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus' ;
 import CookiePreferencesController from 'cookie_preferences_controller.js';
 import Cookies from 'js-cookie';
 import CookiePreferences from 'cookie_preferences';

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -57,6 +57,8 @@ RSpec.describe Healthcheck do
     subject { described_class.new.test_redis }
 
     before do
+      stub_const("REDIS", Redis.new)
+
       allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("REDIS_URL").and_return \
         "redis://localhost:6379/1"
@@ -64,7 +66,7 @@ RSpec.describe Healthcheck do
 
     context "with working connection" do
       before do
-        allow(Redis).to receive(:current).and_return instance_double(Redis, ping: "PONG")
+        allow(REDIS).to receive(:ping).and_return("PONG")
       end
 
       it { is_expected.to be true }
@@ -72,7 +74,7 @@ RSpec.describe Healthcheck do
 
     context "with broken connection" do
       before do
-        allow(Redis).to receive(:current).and_raise Redis::CannotConnectError
+        allow(REDIS).to receive(:ping).and_raise(Redis::CannotConnectError)
       end
 
       it { is_expected.to be false }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1132,6 +1132,16 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
+"@hotwired/stimulus-webpack-helpers@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus-webpack-helpers/-/stimulus-webpack-helpers-1.0.1.tgz#4cd74487adeca576c9865ac2b9fe5cb20cef16dd"
+  integrity sha512-wa/zupVG0eWxRYJjC1IiPBdt3Lruv0RqGN+/DTMmUWUyMAEB27KXmVY6a8YpUVTM7QwVuaLNGW4EqDgrS2upXQ==
+
+"@hotwired/stimulus@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.1.0.tgz#20215251e5afe6e0a3787285181ba1bfc9097df0"
+  integrity sha512-iDMHUhiEJ1xFeicyHcZQQgBzhtk5mPR0QZO3L6wtqzMsJEk2TKECuCQTGKjm+KJTHVY0dKq1dOOAWvODjpd2Mg==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1472,34 +1482,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@stimulus/core@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/core/-/core-2.0.0.tgz#140c85318d6a8a8210c0faf182223b8459348877"
-  integrity sha512-ff70GafKtzc8zQ1/cG+UvL06GcifPWovf2wBEdjLMh9xO2GOYURO3y2RYgzIGYUIBefQwyfX2CLfJdZFJrEPTw==
-  dependencies:
-    "@stimulus/mutation-observers" "^2.0.0"
-
-"@stimulus/multimap@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/multimap/-/multimap-2.0.0.tgz#420cfa096ed6538df4a91dbd2b2842c1779952b2"
-  integrity sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w==
-
-"@stimulus/mutation-observers@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz#3dbe37453bda47a6c795a90204ee8d77a799fb87"
-  integrity sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==
-  dependencies:
-    "@stimulus/multimap" "^2.0.0"
-
 "@stimulus/test@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@stimulus/test/-/test-2.0.0.tgz#eed53eb04710ce8c3773c9bb8e4a1e2f5e740393"
   integrity sha512-n8X6H5l6FAznX8Gziyeyp7RCiCR7Sxo2zErebFwuWrBz4ZCq7AYQfhZ6gLgq9878XhJZx58d63AmXvuYRkRGAw==
-
-"@stimulus/webpack-helpers@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/webpack-helpers/-/webpack-helpers-2.0.0.tgz#54296d2a2dffd4f962d2e802d99a3fdd84b8845f"
-  integrity sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA==
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -7965,13 +7951,13 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stimulus@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-2.0.0.tgz#713c8b91a72ef90914b90955f0e705f004403047"
-  integrity sha512-xipy7BS5TVpg4fX6S8LhrYZp7cmHGjmk09WSAiVx1gF5S5g43IWsuetfUhIk8HfHUG+4MQ9nY0FQz4dRFLs/8w==
+stimulus@^3.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-3.1.0.tgz#225298f1936f96b0eafa883b8b304266427912c3"
+  integrity sha512-ln+BtLkhemwJozr5N3I5q0kGlSv6fmcPi3JtDjBo7gnnz2tAYhK2WBhyY/EN/4+CWIwqp3qPm3Pc+i9CjIXrtg==
   dependencies:
-    "@stimulus/core" "^2.0.0"
-    "@stimulus/webpack-helpers" "^2.0.0"
+    "@hotwired/stimulus" "^3.1.0"
+    "@hotwired/stimulus-webpack-helpers" "^1.0.0"
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
### Trello card

[Trello-3808](https://trello.com/c/xYgwOwq5/3808-fix-csp-errors-on-tta-service)

### Context

The TTA service has various dependencies with major version bumps that we need to update and require a bit of refactoring for compatibility. 

### Changes proposed in this pull request

- Upgrade to Stimulus v3

Upgrade to the latest version of Stimulus.

- Upgrade Redis to v5

Using a single connection to Redis is now discouraged because it can lead to blocking. The recommended fix is to enable connection pooling.

Wrap the existing connection using the connection_pool gem.

- Update dfe-analytics gem

Update to the latest version of `dfe-analytics`. There is an issue whereby the latest gem calls `eager_load!` which causes Rails to evaluate the `inclusion` validation block in `WhatDegreeClass` and make an external request (which fails due to being unauthorized in the test environment). It probably shouldn't do this if the gem is disabled in that environment.

### Guidance to review

I'll create a separate ticket to clean up the CSP directives as we should make them consistent with the GiT website for ease.