### PR TITLE
Update CSP to whitelist domains

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -10,21 +10,27 @@ SecureHeaders::Configuration.default do |config|
   google_analytics = %w[*.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com s.ytimg.com https://www.googleadservices.com *.google.co.uk https://www.google.com https://googleads.g.doubleclick.net https://pagead2.googlesyndication.com]
   lid_pixels = %w[pixelg.adswizz.com tracking.audio.thisisdax.com]
   bam_pixels = %w[linkbam.uk]
+  gtm_server = %w[get-into-teaching-staging-gtm.nw.r.appspot.com analytics.getintoteaching.education.gov.uk]
+
+  google_adservice = %w[adservice.google.com adservice.google.co.uk]
+
+  hotjar = %w[*.hotjar.com vc.hotjar.io wss://*.hotjar.com]
+  reddit = %w[www.redditstatic.com alb.reddit.com]
 
   config.csp = {
     default_src: %w['none'],
     base_uri: %w['self'],
     block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
-    child_src: %w['self' *.youtube.com ct.pinterest.com tr.snapchat.com],
-    connect_src: %W['self' ct.pinterest.com www.facebook.com stats.g.doubleclick.net tr.snapchat.com] + google_analytics,
+    child_src: %w['self' *.youtube.com ct.pinterest.com tr.snapchat.com] + hotjar,
+    connect_src: %W['self' ct.pinterest.com www.facebook.com stats.g.doubleclick.net tr.snapchat.com] + google_analytics + gtm_server + hotjar + google_adservice,
     font_src: %w['self' *.gov.uk fonts.gstatic.com],
     form_action: %w['self' tr.snapchat.com www.facebook.com],
-    frame_ancestors: %w['self'],
+    frame_ancestors: %w['self'] + hotjar,
     frame_src: %w['self' tr.snapchat.com www.facebook.com www.youtube.com *.doubleclick.net *.pinterest.com *.pinterest.co.uk],
-    img_src: %W['self' *.gov.uk data: *.googleapis.com ade.googlesyndication.com analytics.twitter.com www.facebook.com ct.pinterest.com t.co www.facebook.com cx.atdmt.com ad.doubleclick.net *.fls.doubleclick.net i.ytimg.com adservice.google.com adservice.google.co.uk] + google_analytics + lid_pixels + bam_pixels,
+    img_src: %W['self' *.gov.uk data: *.googleapis.com ade.googlesyndication.com analytics.twitter.com www.facebook.com ct.pinterest.com t.co www.facebook.com cx.atdmt.com ad.doubleclick.net *.fls.doubleclick.net i.ytimg.com adservice.google.com adservice.google.co.uk] + google_analytics + lid_pixels + bam_pixels + gtm_server + reddit,
     manifest_src: %w['self'],
     media_src: %w['self'],
-    script_src: %W['self' 'unsafe-inline' 'unsafe-eval' *.googleapis.com *.gov.uk code.jquery.com *.youtube.com *.facebook.net *.pinimg.com sc-static.net static.ads-twitter.com analytics.twitter.com ad.doubleclick.com] + google_analytics,
+    script_src: %W['self' 'unsafe-inline' 'unsafe-eval' *.googleapis.com *.gov.uk code.jquery.com *.youtube.com *.facebook.net *.pinimg.com sc-static.net static.ads-twitter.com analytics.twitter.com ad.doubleclick.com] + google_analytics + hotjar + reddit,
     style_src: %w['self' 'unsafe-inline' *.gov.uk *.googleapis.com] + google_analytics,
     worker_src: %w['self'],
     upgrade_insecure_requests: !Rails.env.development?, # see https://www.w3.org/TR/upgrade-insecure-requests/


### PR DESCRIPTION
I'm not sure why these have started suddenly flagging as violations (the pixels have been enabled for months!).

Whitelist google ad services, reddit, hotjar and our GTM server-side container.

I plan on doing a clean up of the CSP directives in the future to get them more inline with those in the app and just generally tidied, but this fixes the immediate issues.