### PR TITLE
Fix Privacy Policy formatting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENTRYPOINT ["bundle", "exec"]
 CMD ["rails db:migrate && rails server"]
 
 # patches
-RUN apk add --no-cache pcre2=10.40-r0 postgresql14=14.5-r0
+RUN apk add --no-cache pcre2=10.40-r0 postgresql14=14.5-r0 expat=2.5.0-r0
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache build-base tzdata shared-mime-info git nodejs yarn postgresql-libs postgresql-dev chromium chromium-chromedriver

--- a/app/helpers/text_format_helper.rb
+++ b/app/helpers/text_format_helper.rb
@@ -7,6 +7,6 @@ module TextFormatHelper
   end
 
   def safe_html_format(html)
-    sanitize html, tags: %w[strong a ul li p b span br], attributes: %w[href class]
+    sanitize html, tags: %w[link strong a ul li p b br div span h1 h2 h3 h4 h5 br], attributes: %w[href target rel id class]
   end
 end

--- a/spec/helpers/text_format_helper_spec.rb
+++ b/spec/helpers/text_format_helper_spec.rb
@@ -36,7 +36,26 @@ RSpec.describe TextFormatHelper, type: :helper do
     subject { safe_html_format html }
 
     context "with allowed HTML" do
-      let(:html) { "<p><strong>hello</strong><br><a href=\"http://test.com\">world</a></p><ul><li>test</li></ul>" }
+      let(:html) do
+        <<~HTML
+          <div>test</div>
+          <p id="paragraph">
+            <strong>hello</strong>
+            <a href="http://test.com">world</a>
+          </p>
+          <ul>
+            <li>test</li>
+          </ul>
+          <span class="test">test</span>
+          <h1>heading1</h1>
+          <h2>heading1</h2>
+          <h3>heading1</h3>
+          <h4>heading1</h4>
+          <h5>heading1</h5>
+          <br>
+          <link href="/test" rel="canonical">
+        HTML
+      end
 
       it { is_expected.to eql html }
     end
@@ -51,6 +70,18 @@ RSpec.describe TextFormatHelper, type: :helper do
       let(:html) { "<a href=\"http://test.com\" onclick=\"somethingNasty();\">boom</a>" }
 
       it { is_expected.to eql "<a href=\"http://test.com\">boom</a>" }
+    end
+
+    context "with anchor tags" do
+      let(:html) { "<a href=\"http://test.com\" target=\"blank\">open</a>" }
+
+      it { is_expected.to eql html }
+    end
+
+    context "with href containing disallowed protocol" do
+      let(:html) { "<a href=\"file://test.com\" target=\"blank\">open</a>" }
+
+      it { is_expected.to eql "<a target=\"blank\">open</a>" }
     end
   end
 end


### PR DESCRIPTION
Our HTML whitelisting was too strict and stripping out headings/jump links. I'm updating it to match the same method on the Get into Teaching website so that its consistent.
