### PR TITLE
Update cookie hide link text

### DIFF
--- a/app/views/shared/_cookie_banner.html.erb
+++ b/app/views/shared/_cookie_banner.html.erb
@@ -36,7 +36,7 @@
       </div>
 
       <div class="govuk-grid-column-one-third">
-        <%= link_to "Hide", "#", data: { action: 'cookie-acceptance#hideCookieBanner' } %>
+        <%= link_to "Hide cookie message", "#", data: { action: 'cookie-acceptance#hideCookieBanner' } %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Trello card

[Trello-3847](https://trello.com/c/2CgyrH26/3847-dac-audit-non-descriptive-links-tta-cookies)

### Context

Our cookie acceptance message has a link with the text `hide` which is not very accessible for screen readers. Use `hide cookie message` instead.

### Changes proposed in this pull request

- Update cookie hide link text

### Guidance to review

