### PR TITLE
Updated phone number link text and bank holidays

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -5,7 +5,7 @@
                 <h2 class="govuk-heading-m">Get help</h2>
 
                 <p class="govuk-body-s govuk-!-margin-bottom-1">
-                <%= link_to("Call 0800 389 2500", "tel://08003892500", class: "govuk-footer__link") %> or <%= link_to_git_site("chat online", "#talk-to-us", class: "govuk-footer__link") %>
+                <%= link_to("Call the Get Into Teaching team on 0800 389 2500", "tel://08003892500", class: "govuk-footer__link") %> or <%= link_to_git_site("chat online", "#talk-to-us", class: "govuk-footer__link") %>
                 </p>
                 <p class="govuk-body-s govuk-!-margin-bottom-1">
                   Monday to Friday, 8:30am to 5:30pm (except bank holidays)

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -5,10 +5,10 @@
                 <h2 class="govuk-heading-m">Get help</h2>
 
                 <p class="govuk-body-s govuk-!-margin-bottom-1">
-                  Call <%= link_to("0800 389 2500", "tel://08003892500", class: "govuk-footer__link") %> or <%= link_to_git_site("chat online", "#talk-to-us", class: "govuk-footer__link") %>
+                <%= link_to("Call 0800 389 2500", "tel://08003892500", class: "govuk-footer__link") %> or <%= link_to_git_site("chat online", "#talk-to-us", class: "govuk-footer__link") %>
                 </p>
                 <p class="govuk-body-s govuk-!-margin-bottom-1">
-                  Monday to Friday, 8:30am to 5:30pm (except public holidays)
+                  Monday to Friday, 8:30am to 5:30pm (except bank holidays)
                 </p>
                 <p class="govuk-body-s">Free of charge</p>
 

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -5,7 +5,7 @@
                 <h2 class="govuk-heading-m">Get help</h2>
 
                 <p class="govuk-body-s govuk-!-margin-bottom-1">
-                <%= link_to("Call the Get Into Teaching team on 0800 389 2500", "tel://08003892500", class: "govuk-footer__link") %> or <%= link_to_git_site("chat online", "#talk-to-us", class: "govuk-footer__link") %>
+                <%= link_to("Call us on 0800 389 2500", "tel://08003892500", class: "govuk-footer__link") %> or <%= link_to_git_site("chat online", "#talk-to-us", class: "govuk-footer__link") %>
                 </p>
                 <p class="govuk-body-s govuk-!-margin-bottom-1">
                   Monday to Friday, 8:30am to 5:30pm (except bank holidays)


### PR DESCRIPTION
### Trello card

https://trello.com/c/eUf7bdzY

### Context

Updated the phone number link text to improve the experience for screen readers and changed the opening hours to refer to bank holidays as we do elsewhere on the GiT website.

### Changes proposed in this pull request

Added call to the link text for the phone number
Changed public holidays to bank holidays

### Guidance to review

