### PR TITLE
Fix dfe-analytics deprecation warning

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,3 @@
 class ApplicationRecord < ActiveRecord::Base
-  include DfE::Analytics::Entities
-
   self.abstract_class = true
 end

--- a/spec/requests/big_query_analytics_spec.rb
+++ b/spec/requests/big_query_analytics_spec.rb
@@ -1,7 +1,17 @@
 require "rails_helper"
 
 RSpec.describe "BigQuery Analytics", type: :request do
+  # Auto-initialization is disabled in our test environment.
+  # See .env.test for details.
+  before { DfE::Analytics.initialize! }
+
   it "sends a DFE Analytics web request event" do
     expect { get root_path }.to have_sent_analytics_event_types(:web_request)
+  end
+
+  it "sends DFE Analytics entity events" do
+    params = { teacher_training_adviser_feedback: attributes_for(:feedback) }
+    post teacher_training_adviser_feedbacks_path, params: params
+    expect(:create_entity).to have_been_enqueued_as_analytics_events
   end
 end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -30,11 +30,6 @@ RSpec.describe "Feedback" do
       expect(response.body).to include("Thank you for your feedback.")
     end
 
-    it "sends DFE Analytics request and entity events" do
-      post teacher_training_adviser_feedbacks_path, params: params
-      expect(:create_entity).to have_been_enqueued_as_analytics_events
-    end
-
     context "when there are errors" do
       let(:params) { { teacher_training_adviser_feedback: { rating: nil } } }
 


### PR DESCRIPTION
### Trello card

[Trello-4028](https://trello.com/c/oDECMFWN/4028-fix-deprecation-warnings-in-git-website-tta-service)

### Context

We no longer need to include `DfE::Analytics::Entities` explicitly; as of v1.4 it is included automatically.

### Changes proposed in this pull request

- Fix dfe-analytics deprecation warning

### Guidance to review

