### PR TITLE
Added warning of slower response during holidays

### DIFF
--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -15,6 +15,8 @@
         <p>
           A return to teaching adviser will email you to outline your next steps.
         </p>
+        <p> It may take us longer to respond to you until after the holidays in January. We’ll be in touch as soon as we can, thank you for your patience. 
+        </p>
         <% elsif @equivalent_degree %>
         <p>
           We've booked a call. We will be in contact with you at the time you selected.
@@ -26,7 +28,10 @@
 
         <p>An adviser will email you within 3 working days.</p>
 
-        <p>You need to reply to the email to be assigned an adviser.</p>
+       <p>You need to reply to the email to be assigned an adviser.</p>
+
+       <p> It may take us longer to respond to you until after the holidays in January. We’ll be in touch as soon as we can, thank you for your patience. 
+        </p>
 
         <% end %>
 

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -15,7 +15,7 @@
         <p>
           A return to teaching adviser will email you to outline your next steps.
         </p>
-        <p> It may take us longer to respond to you until after the holidays in January. We’ll be in touch as soon as we can, thank you for your patience. 
+        <p> It may take us longer to respond to you during the holiday period until early January. We’ll be in touch as soon as we can, thank you for your patience. 
         </p>
         <% elsif @equivalent_degree %>
         <p>
@@ -30,7 +30,7 @@
 
        <p>You need to reply to the email to be assigned an adviser.</p>
 
-       <p> It may take us longer to respond to you until after the holidays in January. We’ll be in touch as soon as we can, thank you for your patience. 
+       <p> It may take us longer to respond to you during the holiday period until early January. We’ll be in touch as soon as we can, thank you for your patience. 
         </p>
 
         <% end %>


### PR DESCRIPTION
### Trello card

https://trello.com/c/C8nLNnH0

### Context

As someone interested in teaching who has signed up for an adviser
I need to understand that there may be a delayed response over Christmas
So that my expectations are set correctly

### Changes proposed in this pull request

Added a message to the completion page to explain there may be a delay in response times until January. 

### Guidance to review

