### PR TITLE
Stronger message QTS message for Non-UK teachers 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENTRYPOINT ["bundle", "exec"]
 CMD ["rails db:migrate && rails server"]
 
 # patches
-RUN apk add --no-cache postgresql14=14.5-r0
+RUN apk add --no-cache postgresql14=14.5-r0 libtasn1=4.18.0-r1 
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache build-base tzdata shared-mime-info git nodejs yarn postgresql-libs postgresql-dev chromium chromium-chromedriver

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -5,7 +5,7 @@
         <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
   <div class="govuk-notification-banner__header">
     <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-      Non-UK Teachers
+      Non-UK teachers
     </h2>
   </div>
   <div class="govuk-notification-banner__content">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -10,7 +10,7 @@
   </div>
   <div class="govuk-notification-banner__content">
     <p class="govuk-notification-banner__heading">
-      If you qualified outside of the UK, you must have <a href="https://www.gov.uk/guidance/qualified-teacher-status-qts">English qualified teacher status (QTS)</a>to use this service. If you do not have QTS,
+      If you qualified outside the UK, you must have <a href="https://www.gov.uk/guidance/qualified-teacher-status-qts">English qualified teacher status (QTS)</a>to use this service. If you do not have QTS,
       <a class="govuk-notification-banner__link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas">learn more about other options to teach in England, and how to apply for QTS</a>.
     </p>
   </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -2,6 +2,19 @@
   <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Non-UK Teachers
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      If you qualified outside of the UK, you must have <a href="https://www.gov.uk/guidance/qualified-teacher-status-qts">English qualified teacher status (QTS)</a>to use this service. If you do not have QTS,
+      <a class="govuk-notification-banner__link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas">learn more about other options to teach in England, and how to apply for QTS</a>.
+    </p>
+  </div>
+</div>
         <h1 class="govuk-heading-l">Get an adviser</h1>
 
         <p>If you’re thinking about teaching in England, an adviser can provide free, one-to-one support through phone, text or email. You can talk to them as little or as much as needed.</p>
@@ -21,13 +34,20 @@
         
         <p>If you’re thinking about returning to teaching, you'll need to have qualified teacher status (QTS) and want to teach a secondary subject in England to get an adviser.</p>
 
-        <h2 class="govuk-heading-m">Non-UK trainees and teachers</h2>
+        <h2 class="govuk-heading-m">Non-UK trainees</h2>
 
         <p>To get an adviser, you'll need to have or be studying for an overseas qualification of the same standard as a UK bachelor’s degree, class 2:2 (honours) or higher.</p>
         
         <p>You can check the UK equivalents of your degree qualifications by calling us on +44 800 389 2500.</p>
+        
+        <h2 class="govuk-heading-m">Non-UK teachers</h2>
 
-        <p>If you're already qualified as a teacher outside the UK, you'll need to have <a href="https://www.gov.uk/guidance/qualified-teacher-status-qts">English qualified teacher status (QTS)</a> and want to teach a secondary subject (teaching children aged 11 to 16) to get an adviser.</p>
+        <p>To get an adviser you must:</p>
+          <ul>
+            <li>already be qualified as a teacher outside the UK</li> 
+            <li>have <a href="https://www.gov.uk/guidance/qualified-teacher-status-qts">English qualified teacher status (QTS)</a></li>
+            <li>want to teach a secondary subject (teaching children aged 11 to 16)</li>
+        </ul>
 
         <a href="<%= teacher_training_adviser_step_path(:identity, params.to_unsafe_h.slice(:channel, :sub_channel)) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
         Start now

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -10,7 +10,7 @@
   </div>
   <div class="govuk-notification-banner__content">
     <p class="govuk-notification-banner__heading">
-      If you qualified outside the UK, you must have <a href="https://www.gov.uk/guidance/qualified-teacher-status-qts">English qualified teacher status (QTS)</a>to use this service. If you do not have QTS,
+      If you qualified outside the UK, you must have <a href="https://www.gov.uk/guidance/qualified-teacher-status-qts">English qualified teacher status (QTS)</a> to use this service. If you do not have QTS,
       <a class="govuk-notification-banner__link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas">learn more about other options to teach in England, and how to apply for QTS</a>.
     </p>
   </div>

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -15,7 +15,7 @@
         <p>
           A return to teaching adviser will email you to outline your next steps.
         </p>
-        <p> It may take us longer to respond to you during the holiday period until early January. We’ll be in touch as soon as we can, thank you for your patience. 
+        <p> We’re getting a lot of requests at the moment so you may not get a response from us until early January.
         </p>
         <% elsif @equivalent_degree %>
         <p>


### PR DESCRIPTION
### Trello card

https://trello.com/c/8tF71dr1

### Context

As an overseas qualified teacher
I need to understand whether I am eligible for an adviser
So that I can decide whether to complete the sign-up form

### Changes proposed in this pull request

Added a notification banner for Non-UK teachers and strengthened the wording on the page

### Guidance to review

