### PR TITLE
Gracefully handle when there are no available callback slots

### DIFF
--- a/app/controllers/teacher_training_adviser/steps_controller.rb
+++ b/app/controllers/teacher_training_adviser/steps_controller.rb
@@ -10,7 +10,8 @@ module TeacherTrainingAdviser
       super
 
       @returner = wizard_store[:type_id].to_i == Steps::ReturningTeacher::OPTIONS[:returning_to_teaching]
-      @equivalent_degree = wizard_store[:degree_options] == Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      @equivalent = wizard_store[:degree_options] == Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
+      @callback_booked = wizard_store[:callback_offered] && @equivalent
     end
 
   protected

--- a/app/models/teacher_training_adviser/steps/overseas_callback.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_callback.rb
@@ -14,12 +14,13 @@ module TeacherTrainingAdviser::Steps
     end
 
     def skipped?
+      callback_not_offered = !other_step(:overseas_time_zone).callback_offered
       overseas_country_skipped = other_step(:overseas_country).skipped?
       have_a_degree_step = other_step(:have_a_degree)
       have_a_degree_skipped = have_a_degree_step.skipped?
       equivalent_degree = have_a_degree_step.degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]
 
-      overseas_country_skipped || have_a_degree_skipped || !equivalent_degree
+      callback_not_offered || overseas_country_skipped || have_a_degree_skipped || !equivalent_degree
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
@@ -1,10 +1,13 @@
 module TeacherTrainingAdviser::Steps
   class OverseasTimeZone < GITWizard::Step
+    extend CallbackBookingQuotas
+
     attribute :address_telephone, :string
     attribute :time_zone, :string
+    attribute :callback_offered, :boolean
 
-    validates :address_telephone, telephone: { international: true }, presence: true
-    validates :time_zone, presence: true
+    validates :address_telephone, telephone: { international: true }, presence: true, if: :callback_offered
+    validates :time_zone, presence: true, if: :callback_offered
 
     before_validation if: :address_telephone do
       self.address_telephone = address_telephone.to_s.strip.presence
@@ -19,9 +22,15 @@ module TeacherTrainingAdviser::Steps
     end
 
     def reviewable_answers
+      return {} unless callback_offered
+
       { "address_telephone" => address_telephone }.tap do |answers|
         answers["time_zone"] = time_zone if time_zone.present?
       end
+    end
+
+    def export
+      super.except("callback_offered")
     end
 
     def address_telephone_value

--- a/app/models/teacher_training_adviser/steps/uk_callback.rb
+++ b/app/models/teacher_training_adviser/steps/uk_callback.rb
@@ -4,9 +4,10 @@ module TeacherTrainingAdviser::Steps
 
     attribute :address_telephone, :string
     attribute :phone_call_scheduled_at, :datetime
+    attribute :callback_offered, :boolean
 
-    validates :address_telephone, telephone: true, presence: true
-    validates :phone_call_scheduled_at, presence: true
+    validates :address_telephone, telephone: true, presence: true, if: :callback_offered
+    validates :phone_call_scheduled_at, presence: true, if: :callback_offered
 
     before_validation if: :address_telephone do
       self.address_telephone = address_telephone.to_s.strip.presence
@@ -17,11 +18,17 @@ module TeacherTrainingAdviser::Steps
     end
 
     def reviewable_answers
+      return {} unless callback_offered
+
       {
         "address_telephone" => address_telephone,
         "callback_date" => phone_call_scheduled_at&.to_date,
         "callback_time" => phone_call_scheduled_at&.to_time,
       }
+    end
+
+    def export
+      super.except("callback_offered")
     end
 
     def skipped?

--- a/app/models/teacher_training_adviser/wizard.rb
+++ b/app/models/teacher_training_adviser/wizard.rb
@@ -50,7 +50,7 @@ module TeacherTrainingAdviser
 
       sign_up_candidate
 
-      @store.prune!(leave: %w[type_id degree_options sub_channel_id])
+      @store.prune!(leave: %w[type_id degree_options sub_channel_id callback_offered])
     end
 
     def exchange_access_token(timed_one_time_password, request)

--- a/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
@@ -2,19 +2,27 @@
 
 <%= f.govuk_fieldset legend: { text: 'You told us you have an equivalent degree and live overseas' } do %>
 
-<p>We need to call you to check your degree. When we call, our adviser will ask for more details about the qualification you have.</p>
+<% if f.object.class.callback_booking_quotas.any? %>
+  <p>We need to call you to check your degree. When we call, our adviser will ask for more details about the qualification you have.</p>
 
-<p>We will call you between 8.30am and 5.30pm (UK time).</p>
+  <p>We will call you between 8.30am and 5.30pm (UK time).</p>
 
-<p>Or, you can call us on 0800 389 2500.<p>
+  <p>Or, you can call us on 0800 389 2500.<p>
 
-<%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+", value: f.object.address_telephone_value %>
+  <%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+", value: f.object.address_telephone_value %>
 
-<%= f.govuk_collection_select :time_zone,
-  f.object.filtered_time_zones,
-  :name,
-  ->(option) { option.to_s },
-  options: { prompt: "Please select" }
-%>
+  <%= f.govuk_collection_select :time_zone,
+    f.object.filtered_time_zones,
+    :name,
+    ->(option) { option.to_s },
+    options: { prompt: "Please select" }
+  %>
 
+  <%= f.hidden_field :callback_offered, value: true %>
+<% else %>
+  <p>We need to speak to you to check your degree.</p>
+  <p>Call us on <%= link_to("0800 389 2500", "tel://08003892500") %> between 8.30am and 5.30pm (UK time).</p>
+  <p>When you call, our adviser will ask for more details about the qualification you have.</p>
+  <%= f.hidden_field :callback_offered, value: false %>
+<% end %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
@@ -2,11 +2,20 @@
 
 <%= f.govuk_fieldset legend: { text: 'You told us you have an equivalent degree and live in the United Kingdom' } do %>
 
-<p>You need to book a callback with us to check your degree. We will contact you once your call is booked.</p>
-<p>You must have the details of your overseas qualifications when we contact you.</p>
 
-<%= f.govuk_phone_field :address_telephone, width: 20 %>
+<% if f.object.class.callback_booking_quotas.any? %>
+  <p>You need to book a callback with us to check your degree. We will contact you once your call is booked.</p>
+  <p>You must have the details of your overseas qualifications when we contact you.</p>
 
-<%= f.govuk_select :phone_call_scheduled_at, callback_options(f.object.class.callback_booking_quotas) %>
+  <%= f.govuk_phone_field :address_telephone, width: 20 %>
 
+  <%= f.govuk_select :phone_call_scheduled_at, callback_options(f.object.class.callback_booking_quotas) %>
+
+  <%= f.hidden_field :callback_offered, value: true %>
+<% else %>
+  <p>We need to check your degree.</p>
+  <p>Call us on <%= link_to("0800 389 2500", "tel://08003892500") %> between 8.30am and 5.30pm (UK time).</p>
+  <p>Please have the details of your overseas qualifications to hand when you call.</p>
+  <%= f.hidden_field :callback_offered, value: false %>
+<% end %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -17,22 +17,21 @@
         </p>
         <p> We’re getting a lot of requests at the moment so you may not get a response from us until early January.
         </p>
-        <% elsif @equivalent_degree %>
+        <% elsif @callback_booked %>
         <p>
           We've booked a call. We will be in contact with you at the time you selected.
         </p>
         <p>
           If we are unable to contact you at this time, we will try to contact you a further 2 times. If we are still unable to contact you, you will have to sign up again.
         </p>
+        <% elsif @equivalent %>
+        <p>Please give us a call so that we can check your degree.</p>
         <% else %>
-
         <p>An adviser will email you within 3 working days.</p>
 
-       <p>You need to reply to the email to be assigned an adviser.</p>
+        <p>You need to reply to the email to be assigned an adviser.</p>
 
-       <p> It may take us longer to respond to you during the holiday period until early January. We’ll be in touch as soon as we can, thank you for your patience. 
-        </p>
-
+        <p>It may take us longer to respond to you during the holiday period until early January. We’ll be in touch as soon as we can, thank you for your patience.</p>
         <% end %>
 
         <h2 class="govuk-heading-m">Understanding your options</h2>

--- a/spec/models/teacher_training_adviser/steps/overseas_callback_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_callback_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasCallback do
   end
 
   describe "#skipped?" do
-    it "returns false if OverseasCountry/HaveADegree steps were shown and degree_options is equivalent" do
+    it "returns false if callback_offered was true, OverseasCountry/HaveADegree steps were shown and degree_options is equivalent" do
       allow(Rails).to receive(:env) { "preprod".inquiry }
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::OverseasTimeZone).to receive(:callback_offered).and_return(true)
       expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?).and_return(false)
       expect_any_instance_of(TeacherTrainingAdviser::Steps::OverseasCountry).to receive(:skipped?).and_return(false)
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
@@ -31,6 +32,15 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasCallback do
       expect_any_instance_of(TeacherTrainingAdviser::Steps::OverseasCountry).to receive(:skipped?).and_return(false)
       expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?).and_return(false)
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
+      expect(subject).to be_skipped
+    end
+
+    it "returns true if callback_offered is false" do
+      allow(Rails).to receive(:env) { "preprod".inquiry }
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::OverseasTimeZone).to receive(:callback_offered).and_return(false)
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?).and_return(false)
+      expect_any_instance_of(TeacherTrainingAdviser::Steps::OverseasCountry).to receive(:skipped?).and_return(false)
+      wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
       expect(subject).to be_skipped
     end
   end

--- a/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/overseas_time_zone_spec.rb
@@ -11,17 +11,35 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTimeZone do
   describe "attributes" do
     it { is_expected.to respond_to :time_zone }
     it { is_expected.to respond_to :address_telephone }
+    it { is_expected.to respond_to :callback_offered }
   end
 
   describe "address_telephone" do
+    before { instance.callback_offered = true }
+
     it { is_expected.not_to allow_values(nil, "abc12345", "12", "1" * 21, "000000000").for :address_telephone }
     it { is_expected.to allow_values("123456789").for :address_telephone }
+    it { is_expected.to validate_presence_of :address_telephone }
+
+    context "when callback_offered is false" do
+      before { instance.callback_offered = false }
+
+      it { is_expected.not_to validate_presence_of :time_zone }
+    end
   end
 
   describe "#time_zone" do
+    before { instance.callback_offered = true }
+
     it { is_expected.not_to allow_values("", nil).for :time_zone }
     it { is_expected.to allow_values(ActiveSupport::TimeZone.all).for :time_zone }
     it { is_expected.to validate_presence_of :time_zone }
+
+    context "when callback_offered is false" do
+      before { instance.callback_offered = false }
+
+      it { is_expected.not_to validate_presence_of :time_zone }
+    end
   end
 
   describe "#filtered_time_zones" do
@@ -50,12 +68,19 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTimeZone do
     end
   end
 
+  describe "#export" do
+    subject { instance.export.keys }
+
+    it { is_expected.to contain_exactly("address_telephone", "time_zone") }
+  end
+
   describe "#reviewable_answers" do
     subject { instance.reviewable_answers }
 
     before do
       instance.address_telephone = "1234567"
       instance.time_zone = "London"
+      instance.callback_offered = true
     end
 
     it {
@@ -69,6 +94,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::OverseasTimeZone do
       before { instance.time_zone = nil }
 
       it { is_expected.to eq({ "address_telephone" => "1234567" }) }
+    end
+
+    context "when callback_offered is false" do
+      before { instance.callback_offered = false }
+
+      it { is_expected.to be_empty }
     end
   end
 end

--- a/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_callback_spec.rb
@@ -11,16 +11,33 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
   describe "attributes" do
     it { is_expected.to respond_to :phone_call_scheduled_at }
     it { is_expected.to respond_to :address_telephone }
+    it { is_expected.to respond_to :callback_offered }
   end
 
   describe "#phone_call_scheduled_at" do
+    before { instance.callback_offered = true }
+
     it { is_expected.not_to allow_values("", nil, "invalid_date").for :phone_call_scheduled_at }
     it { is_expected.to allow_value(Time.zone.now).for :phone_call_scheduled_at }
+
+    context "when callback_offered is false" do
+      before { instance.callback_offered = false }
+
+      it { is_expected.not_to validate_presence_of :phone_call_scheduled_at }
+    end
   end
 
   describe "#address_telephone" do
+    before { instance.callback_offered = true }
+
     it { is_expected.not_to allow_values(nil, "", "abc12345", "12", "1" * 21).for :address_telephone }
     it { is_expected.to allow_values("123456789").for :address_telephone }
+
+    context "when callback_offered is false" do
+      before { instance.callback_offered = false }
+
+      it { is_expected.not_to validate_presence_of :address_telephone }
+    end
   end
 
   describe "#skipped?" do
@@ -55,6 +72,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
     before do
       instance.phone_call_scheduled_at = date_time
       instance.address_telephone = address_telephone
+      instance.callback_offered = true
     end
 
     it {
@@ -70,6 +88,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::UkCallback do
       let(:address_telephone) { nil }
 
       it { is_expected.to eq({ "callback_date" => nil, "callback_time" => nil, "address_telephone" => nil }) }
+    end
+
+    context "when callback_offered is false" do
+      before { instance.callback_offered = false }
+
+      it { is_expected.to be_empty }
     end
   end
 end

--- a/spec/models/teacher_training_adviser/wizard_spec.rb
+++ b/spec/models/teacher_training_adviser/wizard_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
         "last_name" => "Joseph",
         "type_id" => 123,
         "degree_options" => "equivalent",
+        "callback_offered" => true,
       }
     end
     let(:wizardstore) { GITWizard::Store.new store, {} }
@@ -105,7 +106,7 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
       it { is_expected.to have_received(:can_proceed?) }
 
       it "prunes the store leaving data required to render the completion page" do
-        expect(store).to eql({ "type_id" => 123, "degree_options" => "equivalent" })
+        expect(store).to eql({ "type_id" => 123, "degree_options" => "equivalent", "callback_offered" => true })
       end
     end
 


### PR DESCRIPTION
### Trello card

[Trello-4062](https://trello.com/c/n5iRbaIL/4062-review-callback-quota-fallback-functionality-in-light-of-increased-demand)

### Context

Currently the API will provide a fallback list of available callback slots in the event the CRM returns none. Going forward the API will also return 0 if the CRM has none available.

We need to account for this in the front-end by asking the candidates to contact us instead of providing a mechanism for them to book a callback.

### Changes proposed in this pull request

- Gracefully handle when there are no available callback slots

Update copy on steps that ask for a callback; on the overseas journey its actually two steps as we ask for their phone number/time zone before showing a list of callback slots (in their selected time zone). If the candidate is unable to book a callback we will not ask for their telephone number/time zone.

### Guidance to review

There's currently no way to easily test this, but it should just present the same behaviour as master/production until I make the API change to allow 0 callback slots to be returned.
