### PR TITLE
Updated delayed responses messages

### DIFF
--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -15,7 +15,7 @@
         <p>
           A return to teaching adviser will email you to outline your next steps.
         </p>
-        <p> We’re getting a lot of requests at the moment so you may not get a response from us until early January.
+        <p> We’re getting a lot of requests for advisers at the moment so it might take us longer to respond. We'll be in touch as soon as we can. Thank you for your patience.
         </p>
         <% elsif @callback_booked %>
         <p>
@@ -31,7 +31,7 @@
 
         <p>You need to reply to the email to be assigned an adviser.</p>
 
-        <p>It may take us longer to respond to you during the holiday period until early January. We’ll be in touch as soon as we can, thank you for your patience.</p>
+        <p>It may take us longer to respond to you because we're getting a lot of requests for advisers. We’ll be in touch as soon as we can. Thank you for your patience.</p>
         <% end %>
 
         <h2 class="govuk-heading-m">Understanding your options</h2>


### PR DESCRIPTION
### Trello card

https://trello.com/c/1Ueb7JVi

### Context

We added a message to the adviser completion page to warn of slower response times over Christmas. We now need to update this to reflect the continued high demand. 

### Changes proposed in this pull request

Updated delay message on the completion page

### Guidance to review



