### PR TITLE
Run Snyk nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,14 +85,6 @@ jobs:
           build-args: |
             APP_SHA=${{ env.GIT_SHORT_SHA }}
 
-      - name: Run Snyk to check Docker image for vulnerabilities
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ steps.keyvault-yaml-secret.outputs.SNYK-TOKEN }}
-        with:
-          image: ${{ env.DOCKER_IMAGE }}
-          args: --severity-threshold=high --file=Dockerfile
-
       - name: Push image to registry
         if: ${{ success() }}
         run: docker image push --all-tags ${{ env.DOCKER_REPOSITORY }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,48 @@
+name: Nightly Snyk Security Scan
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 5 * * *'  # 5:30am daily
+
+jobs:
+  security_tests:
+    name: Snyk Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: DfE-Digital/keyvault-yaml-secret@v1
+        id:  keyvault-yaml-secret
+        with:
+          keyvault: ${{ secrets.KEY_VAULT}}
+          secret: INFRA-KEYS
+          key: SLACK-WEBHOOK, SNYK-TOKEN
+
+      - name: Run Snyk to check Docker image for vulnerabilities
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ steps.keyvault-yaml-secret.outputs.SNYK-TOKEN }}
+        with:
+          image:  ${{ env.DOCKER_REPOSITORY }}:master
+          args: --severity-threshold=high --file=Dockerfile
+
+      - name: Run Brakeman static security scanner
+        run: |-
+          docker run -t --rm -e RAILS_ENV=test ${{ env.DOCKER_REPOSITORY }}:master brakeman --no-pager
+
+      - name: Slack Notification
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_COLOR: ${{env.SLACK_ERROR}}
+          SLACK_TITLE: Failure with Nightly Anchore Security Scan
+          SLACK_MESSAGE: Failure Nightly Anchore Security Scan for ${{env.APPLICATION}}
+          SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK-WEBHOOK }}


### PR DESCRIPTION
[Trello-4152](https://trello.com/c/Xfa7qQ6L/4152-update-snyk-to-run-nightly)

We currently run Snyk on every build, which isn't necessary and blocks the pipeline when we have a vulnerability; going forward we will run it on a nightly schedule as we do in the GiT app.