### PR TITLE
Changing subject interested in teaching copy

### DIFF
--- a/app/views/teacher_training_adviser/steps/_subject_interested_teaching.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_interested_teaching.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = "Which subject would you like to teach?" %>
+<% @page_title = "What would you like like to teach?" %>
 
 <%= f.govuk_collection_select :preferred_teaching_subject_id,
   f.object.class.options,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,7 +150,7 @@ en:
       teacher_training_adviser_steps_what_subject_degree:
         degree_subject: "If your subject is not listed choose the option that is nearest to your degree."
       teacher_training_adviser_steps_subject_interested_teaching:
-        preferred_teaching_subject_id: "Select 'primary' or the secondary subject you're interested in teaching, even if you're not sure yet. We try and match you with an adviser based on your subject."
+        preferred_teaching_subject_id: "Choose a subject, even if you're not sure yet. We try and match you with an adviser based on your subject."
       teacher_training_adviser_steps_uk_telephone:
         address_telephone: |-
           Your adviser can talk to you by text and WhatsApp, as well as by

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,7 +150,7 @@ en:
       teacher_training_adviser_steps_what_subject_degree:
         degree_subject: "If your subject is not listed choose the option that is nearest to your degree."
       teacher_training_adviser_steps_subject_interested_teaching:
-        preferred_teaching_subject_id: "If you're interested in teaching secondary, select the subject you'd like to teach. If you're interested in teaching primary, select 'primary'. Select an option even if you're not sure yet — you can change your preferences later."
+        preferred_teaching_subject_id: "You can either select 'primary' or the secondary subject you'd like to teach. Select an option even if you're not sure yet — you can change your preferences later."
       teacher_training_adviser_steps_uk_telephone:
         address_telephone: |-
           Your adviser can talk to you by text and WhatsApp, as well as by

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,7 +150,7 @@ en:
       teacher_training_adviser_steps_what_subject_degree:
         degree_subject: "If your subject is not listed choose the option that is nearest to your degree."
       teacher_training_adviser_steps_subject_interested_teaching:
-        preferred_teaching_subject_id: "You can either select 'primary' or the secondary subject you'd like to teach. Select an option even if you're not sure yet — you can change your preferences later."
+        preferred_teaching_subject_id: "Select 'primary' or the secondary subject you're interested in teaching, even if you're not sure yet. We try and match you with an adviser based on your subject."
       teacher_training_adviser_steps_uk_telephone:
         address_telephone: |-
           Your adviser can talk to you by text and WhatsApp, as well as by

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,7 +98,7 @@ en:
       teacher_training_adviser_steps_subject_taught:
         subject_taught_id: "Which main subject did you previously teach?"
       teacher_training_adviser_steps_subject_interested_teaching:
-        preferred_teaching_subject_id: "Which subject would you like to teach?"
+        preferred_teaching_subject_id: "What would you like to teach?"
       teacher_training_adviser_steps_start_teacher_training:
         initial_teacher_training_year_id: "When do you want to start your teacher training?"
       teacher_training_adviser_steps_uk_telephone:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,6 +149,8 @@ en:
           resent: We've sent you another email
       teacher_training_adviser_steps_what_subject_degree:
         degree_subject: "If your subject is not listed choose the option that is nearest to your degree."
+      teacher_training_adviser_steps_subject_interested_teaching:
+        preferred_teaching_subject_id: "If you're interested in teaching secondary, select the subject you'd like to teach. If you're interested in teaching primary, select 'primary'. Select an option even if you're not sure yet — you can change your preferences later."
       teacher_training_adviser_steps_uk_telephone:
         address_telephone: |-
           Your adviser can talk to you by text and WhatsApp, as well as by

--- a/docs/journey.md
+++ b/docs/journey.md
@@ -29,7 +29,7 @@ graph TD;
   what_stage --> gcses[Do you have English and maths GCSEs?]
 
   gcses -- No --> retake_gcses[Are you planning on retaking English and maths GCSEs?]
-  gcses -- Yes --> subject[Which subject would you like to]
+  gcses -- Yes --> subject[What would you like to]
 
   retake_gcses -- Yes --> subject
   retake_gcses -- No --> get_gcses[Get the right GCSEs]

--- a/spec/contracts/sign_up_spec.rb
+++ b/spec/contracts/sign_up_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe "Sign up", type: :feature, vcr: false do
         click_on_continue
 
         expect_current_step(:subject_interested_teaching)
-        expect(page).to have_select("Which subject would you like to teach?", selected: "Physics")
+        expect(page).to have_select("What would you like to teach?", selected: "Physics")
         click_on_continue
 
         expect_current_step(:start_teacher_training)

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -262,7 +262,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       choose "Secondary"
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Which subject would you like to teach?"
+      expect(page).to have_css "h1", text: "What would you like to teach?"
       select "Physics"
       click_on "Continue"
 
@@ -332,7 +332,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       choose "Secondary"
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Which subject would you like to teach?"
+      expect(page).to have_css "h1", text: "What would you like to teach?"
       select "Physics"
       click_on "Continue"
 
@@ -400,7 +400,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
         choose "Secondary"
         click_on "Continue"
 
-        expect(page).to have_css "h1", text: "Which subject would you like to teach?"
+        expect(page).to have_css "h1", text: "What would you like to teach?"
         select "Physics"
         click_on "Continue"
 
@@ -463,7 +463,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
         choose "Secondary"
         click_on "Continue"
 
-        expect(page).to have_css "h1", text: "Which subject would you like to teach?"
+        expect(page).to have_css "h1", text: "What would you like to teach?"
         select "Physics"
         click_on "Continue"
 
@@ -531,7 +531,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       select "Maths"
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Which subject would you like to teach?"
+      expect(page).to have_css "h1", text: "What would you like to teach?"
       select "Physics"
       click_on "Continue"
 
@@ -970,7 +970,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       expect(find_field("Secondary")).to be_checked
       click_on "Continue"
 
-      expect(page).to have_css "h1", text: "Which subject would you like to teach?"
+      expect(page).to have_css "h1", text: "What would you like to teach?"
       select "Physics"
       click_on "Continue"
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/8kSTY8rg/4253-review-teaching-subject-question-for-eta-candidates-in-adviser-funnel

### Context

The current 'What subject would you like to teach?' question doesn't really work for those interested in teaching primary, now that we've taken the 'What stage do you want to teach?' question out for ETAs.

We should tweak the question and add hint text to make the question work for ETAs.

### Changes proposed in this pull request

### Guidance to review

