### PR TITLE
Patch openssl vulerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENTRYPOINT ["bundle", "exec"]
 CMD ["rails db:migrate && rails server"]
 
 # patches
-RUN apk add --no-cache postgresql14=14.5-r0 libtasn1=4.18.0-r1 
+RUN apk add --no-cache libtasn1=4.18.0-r1 openssl=1.1.1t-r0 
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache build-base tzdata shared-mime-info git nodejs yarn postgresql-libs postgresql-dev chromium chromium-chromedriver


### PR DESCRIPTION
[Trello-4260](https://trello.com/c/5ygbyXqA/4260-fix-snyk-vulnerabilities)

The version of openssl in the alpine docker image has vulnerabilities, see:

https://security.snyk.io/vuln/SNYK-ALPINE316-OPENSSL-3314624 
https://security.snyk.io/vuln/SNYK-ALPINE316-OPENSSL-3314641 
https://security.snyk.io/vuln/SNYK-ALPINE316-OPENSSL-3314643
