### PR TITLE
Prevent caching of JS/CSS assets in development

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -8,4 +8,15 @@ const options = {
   }
 }
 
+// add hashing of generated JS and CSS files to fix caching
+// issue in development see: https://github.com/shakacode/shakapacker/issues/88
+baseWebpackConfig.output.filename = 'js/[name]-[contenthash].js'
+baseWebpackConfig.output.chunkFilename = 'js/[name]-[contenthash].chunk.js'
+
+baseWebpackConfig.plugins.forEach(plugin => {
+  if (plugin.options && plugin.options.filename === 'css/[name].css') {
+    plugin.options.filename = 'css/[name]-[contenthash].css'
+  }
+})
+
 module.exports = merge({}, baseWebpackConfig, options)

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -69,7 +69,10 @@ development:
     # live_reload: true
     client:
       # Should we show a full-screen overlay in the browser when there are compiler errors or warnings?
-      overlay: true
+      overlay: {
+        warnings: false,
+        errors: true
+      }
       # May also be a string
       # webSocketURL:
       #  hostname: '0.0.0.0'

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@stimulus/test": "^2.0.0",
+    "@webpack-cli/serve": "^2.0.1",
     "jest": "^29.4.2",
     "jest-environment-jsdom": "^29.4.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,6 +1643,11 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.7.0.tgz#e1993689ac42d2b16e9194376cfb6753f6254db1"
   integrity sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==
 
+"@webpack-cli/serve@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.1.tgz#34bdc31727a1889198855913db2f270ace6d7bf8"
+  integrity sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
### Trello card

[Trello-4299](https://trello.com/c/rzc4Pc09/4299-fix-shakapacker-not-reflecting-updated-css-js-in-development)

### Context

By default Shakapacker generates applicaton.js/css without any digest. This causes the browser to serve the cached version of the asset even after the
contents have changed.

### Changes proposed in this pull request

- Prevent caching of JS/CSS assets in development

Change webpack to always generate JS/CSS asset filenames with a digest.

Also update webpack overlay to only show errors as we have deprecation warnings in dependencies we can't do anything about.

### Guidance to review

