### PR TITLE
Support CORS preflight requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem "foreman"
 # Canonical meta tag
 gem "canonical-rails"
 
+gem "rack-cors"
+
 gem "govuk_design_system_formbuilder"
 
 gem "secure_headers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,6 +284,8 @@ GEM
     rack (2.2.6.2)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
+    rack-cors (2.0.0)
+      rack (>= 2.0.0)
     rack-proxy (0.7.6)
       rack
     rack-test (2.0.2)
@@ -491,6 +493,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 6.0)
   rack-attack
+  rack-cors
   rails (~> 7.0.3)
   rails_semantic_logger (>= 4.10.0)
   redis (~> 4.8.0)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,3 @@
+# We don't allow CORS but use the Rack::Cors middleware to correctly
+#  serve the preflight OPTIONS requests from browsers.
+Rails.application.config.middleware.insert_before 0, Rack::Cors


### PR DESCRIPTION
### Trello card

[Trello-4264](https://trello.com/c/IBdTsDhA/4264-investigate-404-landing-pages-for-adviser-service)

### Context

A CORS preflight request is a CORS request that checks to see if the CORS protocol is understood and a server is aware using specific methods and headers.

It is an OPTIONS request, using three HTTP request headers: Access-Control-Request-Method, Access-Control-Request-Headers, and the Origin header.

We currently respond to all OPTIONS requests with a 404; instead, we can include the `rack-cors` gem to correctly service these requests.

### Changes proposed in this pull request

- Support CORS preflight requests

### Guidance to review

