### PR TITLE
Remove cache read metric

### DIFF
--- a/config/initializers/instrumentation.rb
+++ b/config/initializers/instrumentation.rb
@@ -49,18 +49,6 @@ ActiveSupport::Notifications.subscribe "render_partial.action_view" do |*args|
   metric.observe(event.duration, labels:)
 end
 
-ActiveSupport::Notifications.subscribe "cache_read.active_support" do |*args|
-  event = ActiveSupport::Notifications::Event.new(*args)
-
-  prometheus = Prometheus::Client.registry
-
-  labels = { key: nil, hit: nil }
-  labels.merge!(event.payload.symbolize_keys.slice(*labels.keys))
-
-  metric = prometheus.get(:tta_cache_read_total)
-  metric.increment(labels:)
-end
-
 ActiveSupport::Notifications.subscribe "tta.csp_violation" do |*args|
   event = ActiveSupport::Notifications::Event.new(*args)
   report = event.payload.transform_keys(&:underscore).symbolize_keys

--- a/lib/prometheus/metrics.rb
+++ b/lib/prometheus/metrics.rb
@@ -47,13 +47,6 @@ module Prometheus
     )
 
     prometheus.counter(
-      :tta_cache_read_total,
-      docstring: "A counter of cache reads",
-      labels: %i[key hit] + preset_labels.keys,
-      preset_labels:,
-    )
-
-    prometheus.counter(
       :tta_csp_violations_total,
       docstring: "A counter of CSP violations",
       labels: %i[blocked_uri document_uri violated_directive] + preset_labels.keys,

--- a/spec/lib/prometheus/metrics_spec.rb
+++ b/spec/lib/prometheus/metrics_spec.rb
@@ -56,15 +56,6 @@ RSpec.describe Prometheus::Metrics do
     it { expect { subject.get(labels: %i[identifier]) }.not_to raise_error }
   end
 
-  describe "tta_cache_read_total" do
-    subject { registry.get(:tta_cache_read_total) }
-
-    it { is_expected.not_to be_nil }
-    it { is_expected.to have_attributes(docstring: "A counter of cache reads") }
-    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
-    it { expect { subject.get(labels: %i[key hit]) }.not_to raise_error }
-  end
-
   describe "tta_csp_violations_total" do
     subject { registry.get(:tta_csp_violations_total) }
 

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -45,18 +45,6 @@ RSpec.describe "Instrumentation" do
     end
   end
 
-  describe "cache_read.active_support" do
-    after { Rails.cache.read("test") }
-
-    it "observes the :tta_cache_read_total metric" do
-      metric = registry.get(:tta_cache_read_total)
-      expect(metric).to receive(:increment).with(labels: {
-        key: instance_of(String),
-        hit: false,
-      }).once
-    end
-  end
-
   describe "tta.csp_violation" do
     let(:params) do
       {


### PR DESCRIPTION
### Trello card

[Trello-4256](https://trello.com/c/JE8s3iFB/4256-look-to-see-if-we-can-remove-metrics-to-alleviate-the-load-on-prometheus)

### Context

We are overloading our InfluxDB instance due to the amount of metrics we are processing. We don't tend to look at the cache read metric and its likely one of the busier ones so removing it to alleviate some of the load.

### Changes proposed in this pull request

- Remove cache read metric

### Guidance to review

