### PR TITLE
Patch openssl vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENTRYPOINT ["bundle", "exec"]
 CMD ["rails db:migrate && rails server"]
 
 # patches
-RUN apk add --no-cache libtasn1=4.18.0-r1 openssl=1.1.1t-r0 
+RUN apk add --no-cache libtasn1=4.18.0-r1 openssl=1.1.1t-r1
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache build-base tzdata shared-mime-info git nodejs yarn postgresql-libs postgresql-dev chromium chromium-chromedriver


### PR DESCRIPTION
[Trello-4422](https://trello.com/c/piAJ5icQ/4422-fix-vulnerability-on-gse)

https://security.snyk.io/vuln/SNYK-ALPINE316-OPENSSL-3368756
