### PR TITLE
Update git_wizard

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,9 +24,9 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-wizard.git
-  revision: 1cfc90fe09ba661c761d29a5a653a014e23ea386
+  revision: d2f364735f51715696f63fa0bc220cfd17b32ef8
   specs:
-    git_wizard (2.1.0)
+    git_wizard (2.2.0)
       activemodel (>= 6.0.3.4)
       activesupport (>= 6.0.3.4)
 


### PR DESCRIPTION
[Trello-4372](https://trello.com/c/iDqBrbp4/4372-clean-up-existingcandidaterequest-model)

The update removes first/last name from the matchback requests; the API no longer uses these fields and instead matches back only on email.
