### PR TITLE
Fix ncurse vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,10 @@ ENTRYPOINT ["bundle", "exec"]
 CMD ["rails db:migrate && rails server"]
 
 # patches
-RUN apk add --no-cache libtasn1=4.18.0-r1 openssl=1.1.1t-r2 tiff=4.4.0-r1 ncurses=6.3_p20220521-r1
+RUN apk add --no-cache libtasn1=4.18.0-r1 \
+"ncurses-libs>=6.3_p20211120-r1" \
+"openssl>=1.1.1t-r2" \
+"tiff>=4.4.0"
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache build-base tzdata shared-mime-info git nodejs yarn postgresql-libs postgresql-dev chromium chromium-chromedriver


### PR DESCRIPTION
See [https://security.snyk.io/vuln/SNYK-ALPINE316-NCURSES-5606597](https://security.snyk.io/vuln/SNYK-ALPINE316-NCURSES-5606597)

And Snyk Security Scan was failing in nightly builds:

<img width="1301" alt="Screenshot 2023-06-05 at 14 44 39" src="https://github.com/DFE-Digital/get-teacher-training-adviser-service/assets/77098906/89aea4f3-a71b-4993-ae08-c994a628c4cf">
