### PR TITLE
Bump up various dependency library versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ group :development, :test do
   gem "pry-byebug"
 
   # Testing framework
-  gem "rspec-rails", "~> 6.0.1"
+  gem "rspec-rails", "~> 6.0.3"
   gem "rspec-sonarqube-formatter", "~> 1.5"
   gem "simplecov", "~> 0.22.0"
   # Adds support for Capybara system testing and selenium driver

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,11 +9,11 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: a7a90dcad3504755cde124a7e180cdc9e6211c2d
+  revision: 6619b0f9e00db68618deb05ef493930d2dff3b5d
   specs:
-    get_into_teaching_api_client (3.2.0)
+    get_into_teaching_api_client (3.3.0)
       faraday (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (3.2.0)
+    get_into_teaching_api_client_faraday (3.3.0)
       activesupport
       faraday
       faraday-encoding
@@ -24,7 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-wizard.git
-  revision: 1cfc90fe09ba661c761d29a5a653a014e23ea386
+  revision: 590da16f18d63d4008b60f640aa81676b3db57dc
   specs:
     git_wizard (2.1.0)
       activemodel (>= 6.0.3.4)
@@ -269,7 +269,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
-    pg (1.4.4)
+    pg (1.5.3)
     prometheus-client (4.1.0)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -337,30 +337,30 @@ GEM
       concurrent-ruby (~> 1.0)
     retriable (3.1.2)
     rexml (3.2.5)
-    rspec (3.11.0)
-      rspec-core (~> 3.11.0)
-      rspec-expectations (~> 3.11.0)
-      rspec-mocks (~> 3.11.0)
-    rspec-core (3.11.0)
-      rspec-support (~> 3.11.0)
-    rspec-expectations (3.11.1)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.11.0)
-    rspec-mocks (3.11.2)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.11.0)
-    rspec-rails (6.0.1)
+      rspec-support (~> 3.12.0)
+    rspec-rails (6.0.3)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       railties (>= 6.1)
-      rspec-core (~> 3.11)
-      rspec-expectations (~> 3.11)
-      rspec-mocks (~> 3.11)
-      rspec-support (~> 3.11)
+      rspec-core (~> 3.12)
+      rspec-expectations (~> 3.12)
+      rspec-mocks (~> 3.12)
+      rspec-support (~> 3.12)
     rspec-sonarqube-formatter (1.5.0)
       htmlentities (~> 4.3.3)
       rspec (~> 3.0)
-    rspec-support (3.11.1)
+    rspec-support (3.12.0)
     rubocop (1.39.0)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -407,10 +407,10 @@ GEM
     semantic_logger (4.13.0)
       concurrent-ruby (~> 1.0)
     semantic_range (3.0.0)
-    sentry-rails (5.8.0)
+    sentry-rails (5.9.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.8.0)
-    sentry-ruby (5.8.0)
+      sentry-ruby (~> 5.9.0)
+    sentry-ruby (5.9.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shakapacker (6.6.0)
       activesupport (>= 5.2)
@@ -497,7 +497,7 @@ DEPENDENCIES
   rails (~> 7.0.3)
   rails_semantic_logger (>= 4.10.0)
   redis (~> 4.8.1)
-  rspec-rails (~> 6.0.1)
+  rspec-rails (~> 6.0.3)
   rspec-sonarqube-formatter (~> 1.5)
   rubocop-govuk
   scss_lint-govuk

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "@rails/ujs": "^7.0.4",
     "babel-loader": "9",
     "babel-plugin-macros": "^3.1.0",
-    "compression-webpack-plugin": "9",
+    "compression-webpack-plugin": "10.0.0",
     "css-loader": "^6.7.2",
-    "govuk-frontend": "^4.5.0",
+    "govuk-frontend": "^4.6.0",
     "js-cookie": "^3.0.1",
-    "mini-css-extract-plugin": "^2.7.5",
+    "mini-css-extract-plugin": "^2.7.6",
     "sass": "^1.62.1",
-    "sass-loader": "^13.2.2",
+    "sass-loader": "^13.3.1",
     "serialize-javascript": "^6.0.1",
     "set-value": "^4.0.1",
     "shakapacker": "6.6.0",
@@ -24,7 +24,7 @@
     "webpack-assets-manifest": "5",
     "webpack-cli": "5",
     "webpack-dev-server": "^4.11.1",
-    "webpack-merge": "5"
+    "webpack-merge": "5.9.0"
   },
   "devDependencies": {
     "@stimulus/test": "^2.0.0",

--- a/spec/requests/big_query_analytics_spec.rb
+++ b/spec/requests/big_query_analytics_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "BigQuery Analytics", type: :request do
 
   it "sends DFE Analytics entity events" do
     params = { teacher_training_adviser_feedback: attributes_for(:feedback) }
-    post teacher_training_adviser_feedbacks_path, params: params
+    post(teacher_training_adviser_feedbacks_path, params:)
     expect(:create_entity).to have_been_enqueued_as_analytics_events
   end
 end

--- a/spec/requests/invalid_authenticity_token_spec.rb
+++ b/spec/requests/invalid_authenticity_token_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Invalid Authenticity Token", type: :request do
     it "redirects to the session_expired page" do
       identity_params = { email: "email@address.com", first_name: "first", last_name: "last" }
       params = { "authenticity_token" => "expired", identity: identity_params }
-      put teacher_training_adviser_step_path(:identity), params: params
+      put(teacher_training_adviser_step_path(:identity), params:)
       expect(response).to redirect_to session_expired_path
       expect(Sentry).to have_received(:capture_exception)
     end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2213,10 +2213,10 @@ compressible@~2.0.16:
   dependencies:
     mime-db ">= 1.43.0 < 2"
 
-compression-webpack-plugin@9:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-9.2.0.tgz#57fd539d17c5907eebdeb4e83dcfe2d7eceb9ef6"
-  integrity sha512-R/Oi+2+UHotGfu72fJiRoVpuRifZT0tTC6UqFD/DUo+mv8dbOow9rVOuTvDv5nPPm3GZhHL/fKkwxwIHnJ8Nyw==
+compression-webpack-plugin@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-10.0.0.tgz#3496af1b0dc792e13efc474498838dbff915c823"
+  integrity sha512-wLXLIBwpul/ALcm7Aj+69X0pYT3BYt6DdPn3qrgBIh9YejV9Bju9ShhlAsjujLyWMo6SAweFIWaUoFmXZNuNrg==
   dependencies:
     schema-utils "^4.0.0"
     serialize-javascript "^6.0.0"
@@ -2831,10 +2831,10 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-govuk-frontend@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.5.0.tgz#64759e39efbaa81f9cb7a35cc6cff6fd9fa619ef"
-  integrity sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw==
+govuk-frontend@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.6.0.tgz#662b41f7c468bb5468441218c720f0b31c948cbd"
+  integrity sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw==
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"
@@ -3705,11 +3705,6 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-klona@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.6.tgz#85bffbf819c03b2f53270412420a4555ef882e22"
-  integrity sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==
-
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -3847,10 +3842,10 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mini-css-extract-plugin@^2.7.5:
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.5.tgz#afbb344977659ec0f1f6e050c7aea456b121cfc5"
-  integrity sha512-9HaR++0mlgom81s95vvNjxkg52n2b5s//3ZTI1EtzFb98awsLSivs2LMsVqnQ3ay0PVhqWcGNyDaTE961FOcjQ==
+mini-css-extract-plugin@^2.7.6:
+  version "2.7.6"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz#282a3d38863fddcd2e0c220aaed5b90bc156564d"
+  integrity sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==
   dependencies:
     schema-utils "^4.0.0"
 
@@ -4418,12 +4413,11 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass-loader@^13.2.2:
-  version "13.2.2"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-13.2.2.tgz#f97e803993b24012c10d7ba9676548bf7a6b18b9"
-  integrity sha512-nrIdVAAte3B9icfBiGWvmMhT/D+eCDwnk+yA7VE/76dp/WkHX+i44Q/pfo71NYbwj0Ap+PGsn0ekOuU1WFJ2AA==
+sass-loader@^13.3.1:
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-13.3.2.tgz#460022de27aec772480f03de17f5ba88fa7e18c6"
+  integrity sha512-CQbKl57kdEv+KDLquhC+gE3pXt74LEAzm+tzywcA0/aHZuub8wTErbjAoNI57rPUWRYRNC5WUnNl8eGJNbDdwg==
   dependencies:
-    klona "^2.0.6"
     neo-async "^2.6.2"
 
 sass@^1.62.1:
@@ -5082,7 +5076,15 @@ webpack-dev-server@^4.11.1:
     webpack-dev-middleware "^5.3.1"
     ws "^8.4.2"
 
-webpack-merge@5, webpack-merge@^5.7.3:
+webpack-merge@5.9.0:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.9.0.tgz#dc160a1c4cf512ceca515cc231669e9ddb133826"
+  integrity sha512-6NbRQw4+Sy50vYNTw7EyOn41OZItPiXB8GNv3INSoe3PSFaHJEz3SHTrYVaRm2LilNGnFUzh0FAwqPEmU/CwDg==
+  dependencies:
+    clone-deep "^4.0.1"
+    wildcard "^2.0.0"
+
+webpack-merge@^5.7.3:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.8.0.tgz#2b39dbf22af87776ad744c390223731d30a68f61"
   integrity sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==


### PR DESCRIPTION
Various dependency updates

Bump git_wizard from 1cfc90f to 590da16
Bump get_into_teaching_api_client_faraday from a7a90dc to d96278f 
Bump pg from 1.4.4 to 1.5.3
Bump govuk-frontend from 4.5.0 to 4.6.0
Bump rspec-rails from 6.0.1 to 6.0.3
Bump webpack-merge from 5.8.0 to 5.9.0
Bump sass-loader from 13.2.2 to 13.3.1
Bump sentry-rails from 5.8.0 to 5.9.0
Bump compression-webpack-plugin from 9.2.0 to 10.0.0
Bump mini-css-extract-plugin from 2.7.5 to 2.7.6


Closes #1331, #1330, #1329, #1328, #1327, #1326, #1325, #1324, #1323, #1322

