### PR TITLE
Add noindex to page template

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
     <%= tag :meta, property: 'og:image', content: asset_pack_path('static/govuk-frontend/govuk/assets/images/govuk-opengraph-image.png') %>
     <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
+    <%= tag :meta, name: 'robots', content: 'noindex' %>
     <%= favicon_link_tag asset_pack_path('static/govuk-frontend/govuk/assets/images/favicon.ico') %>
     <%= favicon_link_tag asset_pack_path('static/govuk-frontend/govuk/assets/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
     <%= favicon_link_tag asset_pack_path('static/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>


### PR DESCRIPTION
### Trello card

[Trello-4793](https://trello.com/c/pTz3BYQN/4793-coordinate-top-level-redirect-from-get-an-adviser-site-to-git-adviser-funnel)

### Context

Add noindex to the page template

### Changes proposed in this pull request

### Guidance to review

