### PR TITLE
Add redirect from the home page to GiT

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--exclude-pattern "./spec/**/*_spec.rb"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     end
   end
 
-  get "/", to: redirect(host: "getintoteaching.education.gov.uk", path: "/teacher-training-adviser/sign_up/identity?adviser-redirect")
+  get "/", to: redirect(host: "getintoteaching.education.gov.uk", path: "/teacher-training-adviser/sign_up/identity?utm_source=adviser-getintoteaching.education.gov.uk&utm_medium=referral&utm_campaign=adviser_redirect")
 
   get "/teacher_training_adviser/not_available", to: "teacher_training_adviser/steps#not_available"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     end
   end
 
-  root "pages#home"
+  get "/", to: redirect(host: "getintoteaching.education.gov.uk", path: "/teacher-training-adviser/sign_up/identity?adviser-redirect")
 
   get "/teacher_training_adviser/not_available", to: "teacher_training_adviser/steps#not_available"
 


### PR DESCRIPTION
### Trello card

[Trello-4793](https://trello.com/c/pTz3BYQN/4793-coordinate-top-level-redirect-from-get-an-adviser-site-to-git-adviser-funnel)

### Context

Add top level redirect FROM `https://adviser-getintoteaching.education.gov.uk/` TO `https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity`

### Changes proposed in this pull request

### Guidance to review

